### PR TITLE
Ignore IDE0003 as it conflict with SA1101

### DIFF
--- a/src/PInvoke.ruleset
+++ b/src/PInvoke.ruleset
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Microsoft Managed Recommended Rules" Description="These rules focus on the most critical problems in your code, including potential security holes, application crashes, and other important logic and design errors. It is recommended to include this rule set in any custom rule set you create for your projects." ToolsVersion="10.0">
+<RuleSet Name="Microsoft Managed Recommended Rules" Description="These rules focus on the most critical problems in your code, including potential security holes, application crashes, and other important logic and design errors. It is recommended to include this rule set in any custom rule set you create for your projects." ToolsVersion="14.0">
   <Localization ResourceAssembly="Microsoft.VisualStudio.CodeAnalysis.RuleSets.Strings.dll" ResourceBaseName="Microsoft.VisualStudio.CodeAnalysis.RuleSets.Strings.Localized">
     <Name Resource="MinimumRecommendedRules_Name" />
     <Description Resource="MinimumRecommendedRules_Description" />
@@ -68,11 +68,14 @@
     <Rule Id="CA2241" Action="Warning" />
     <Rule Id="CA2242" Action="Warning" />
   </Rules>
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
+    <Rule Id="IDE0003" Action="None" />
+  </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
-    <Rule Id="SA1600" Action="Hidden" />
-    <Rule Id="SA1310" Action="None" />
-    <Rule Id="SA1602" Action="Hidden" />
     <Rule Id="SA1307" Action="None" />
+    <Rule Id="SA1310" Action="None" />
     <Rule Id="SA1313" Action="None" />
+    <Rule Id="SA1600" Action="Hidden" />
+    <Rule Id="SA1602" Action="Hidden" />
   </Rules>
 </RuleSet>


### PR DESCRIPTION
Essentially the same thing as : https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/532 the two rules clashes

_StyleCop disagreeing with the default VS IDE rules is pretty funny you would bet that it's not 2 products of the same company :stuck_out_tongue_closed_eyes:_

**Note**: Visual Studio reordered the rules in `StyleCop.Analyzers` but nothing changed in that block.
