### PR TITLE
Remove xunit dependency in Desktop project template

### DIFF
--- a/templates/LIBNAME.Desktop/project.json
+++ b/templates/LIBNAME.Desktop/project.json
@@ -1,8 +1,6 @@
 ﻿{
   "supports": { },
   "dependencies": {
-    "xunit": "2.1.0",
-    "xunit.runner.visualstudio": "2.1.0"
   },
   "frameworks": {
     ".NETFramework,Version=v4.0": { }


### PR DESCRIPTION
The default project template for Desktop dlls depends on xunit and fail to build due to that.
