### PR TITLE
[To be tested] Add the "win" runtime in all Desktop & Test project.json

### DIFF
--- a/src/BCrypt.Tests/project.json
+++ b/src/BCrypt.Tests/project.json
@@ -8,6 +8,7 @@
     ".NETFramework,Version=v4.6": { }
   },
   "runtimes": {
-    "win-anycpu": { }
+    "win-anycpu": { },
+    "win": { }
   }
 }

--- a/src/Gdi32.Desktop/project.json
+++ b/src/Gdi32.Desktop/project.json
@@ -3,6 +3,9 @@
   "dependencies": {
   },
   "frameworks": {
-    ".NETFramework,Version=v4.0": {}
+    ".NETFramework,Version=v4.0": { }
+  },
+  "runtimes": {
+    "win": { }
   }
 }

--- a/src/Hid.Desktop/project.json
+++ b/src/Hid.Desktop/project.json
@@ -6,6 +6,7 @@
     ".NETFramework,Version=v4.0": { }
   },
   "runtimes": {
-    "win-anycpu": { }
+    "win-anycpu": { },
+    "win": { }
   }
 }

--- a/src/Hid.Tests/project.json
+++ b/src/Hid.Tests/project.json
@@ -8,6 +8,7 @@
     ".NETFramework,Version=v4.6": { }
   },
   "runtimes": {
-    "win-anycpu": { }
+    "win-anycpu": { },
+    "win": { }
   }
 }

--- a/src/Kernel32.Desktop/project.json
+++ b/src/Kernel32.Desktop/project.json
@@ -6,6 +6,7 @@
     ".NETFramework,Version=v4.0": { }
   },
   "runtimes": {
-    "win-anycpu": { }
+    "win-anycpu": { },
+    "win": { }
   }
 }

--- a/src/Kernel32.Tests.Portable/project.json
+++ b/src/Kernel32.Tests.Portable/project.json
@@ -8,6 +8,7 @@
     ".NETPortable,Version=v4.5,Profile=Profile111": { }
   },
   "runtimes": {
-    "win-anycpu": { }
+    "win-anycpu": { },
+    "win": { }
   }
 }

--- a/src/Kernel32.Tests/project.json
+++ b/src/Kernel32.Tests/project.json
@@ -8,6 +8,7 @@
     ".NETFramework,Version=v4.6": { }
   },
   "runtimes": {
-    "win-anycpu": { }
+    "win-anycpu": { },
+    "win": { }
   }
 }

--- a/src/SetupApi.Desktop/project.json
+++ b/src/SetupApi.Desktop/project.json
@@ -6,6 +6,7 @@
     ".NETFramework,Version=v4.0": { }
   },
   "runtimes": {
-    "win-anycpu": { }
+    "win-anycpu": { },
+    "win": { }
   }
 }

--- a/src/SetupApi.Tests/project.json
+++ b/src/SetupApi.Tests/project.json
@@ -8,6 +8,7 @@
     ".NETFramework,Version=v4.6": { }
   },
   "runtimes": {
-    "win-anycpu": { }
+    "win-anycpu": { },
+    "win": { }
   }
 }

--- a/src/User32.Desktop/project.json
+++ b/src/User32.Desktop/project.json
@@ -3,6 +3,9 @@
   "dependencies": {
   },
   "frameworks": {
-    ".NETFramework,Version=v4.0": {}
+    ".NETFramework,Version=v4.0": { }
+  },
+  "runtimes": {
+    "win": { }
   }
 }

--- a/src/Windows.Core.Tests/project.json
+++ b/src/Windows.Core.Tests/project.json
@@ -8,6 +8,7 @@
     ".NETFramework,Version=v4.6": { }
   },
   "runtimes": {
-    "win-anycpu": { }
+    "win-anycpu": { },
+    "win": { }
   }
 }

--- a/templates/LIBNAME.Desktop/project.json
+++ b/templates/LIBNAME.Desktop/project.json
@@ -6,6 +6,7 @@
     ".NETFramework,Version=v4.0": { }
   },
   "runtimes": {
-    "win-anycpu": { }
+    "win-anycpu": { },
+    "win": { }
   }
 }

--- a/templates/LIBNAME.Tests/project.json
+++ b/templates/LIBNAME.Tests/project.json
@@ -8,6 +8,7 @@
     ".NETFramework,Version=v4.6": { }
   },
   "runtimes": {
-    "win-anycpu": { }
+    "win-anycpu": { },
+    "win": { }
   }
 }


### PR DESCRIPTION
It solve the build for me on VS 2015 Update 1 RC

I let the "win-anycpu" runtime everywhere it was already present, but I don't know if it build under Non-Update1 VS.

@AArnott if you can you test on non-Update1 ? Otherwise i'll do it tomorrow from work (Still didn't update). This PR is also there to see how appveyor behave with such a configuration.
