### PR TITLE
More win32exception

### DIFF
--- a/src/AdvApi32.Desktop/AdvApi32.cs
+++ b/src/AdvApi32.Desktop/AdvApi32.cs
@@ -276,7 +276,7 @@ namespace PInvoke
         /// </param>
         /// <returns>
         /// If the function succeeds, the return value is a handle to the specified service control manager database.
-        /// If the function fails, the return value is NULL.To get extended error information, call GetLastError.
+        /// If the function fails, the return value is NULL.To get extended error information, call <see cref="Kernel32.GetLastError"/>.
         /// </returns>
         [DllImport(nameof(AdvApi32), SetLastError = true, CharSet = CharSet.Unicode)]
         public static extern SafeServiceHandler OpenSCManager(string lpMachineName, string lpDatabaseName, ServiceManagerAccess dwDesiredAccess);

--- a/src/Hid.Shared/Hid.Helpers.cs
+++ b/src/Hid.Shared/Hid.Helpers.cs
@@ -4,7 +4,7 @@
 namespace PInvoke
 {
     using System;
-    using System.Runtime.InteropServices;
+    using System.Diagnostics.CodeAnalysis;
     using System.Text;
     using static PInvoke.Kernel32;
 
@@ -12,6 +12,7 @@ namespace PInvoke
     /// Methods and nested types that are not strictly P/Invokes but provide
     /// a slightly higher level of functionality to ease calling into native code.
     /// </content>
+    [SuppressMessage("ReSharper", "InconsistentNaming", Justification = "Functions are named like their native counterparts")]
     public static partial class Hid
     {
         public static Guid HidD_GetHidGuid()
@@ -26,7 +27,7 @@ namespace PInvoke
             var result = HiddAttributes.Create();
             if (!HidD_GetAttributes(hFile, ref result))
             {
-                Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+                throw new Win32Exception();
             }
 
             return result;
@@ -37,7 +38,7 @@ namespace PInvoke
             SafePreparsedDataHandle preparsedDataHandle;
             if (!HidD_GetPreparsedData(hDevice, out preparsedDataHandle))
             {
-                Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+                throw new Win32Exception();
             }
 
             return preparsedDataHandle;
@@ -81,7 +82,7 @@ namespace PInvoke
             string result;
             if (!HidD_GetManufacturerString(hidDeviceObject, out result))
             {
-                Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+                throw new Win32Exception();
             }
 
             return result;
@@ -92,7 +93,7 @@ namespace PInvoke
             string result;
             if (!HidD_GetProductString(hidDeviceObject, out result))
             {
-                Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+                throw new Win32Exception();
             }
 
             return result;
@@ -103,7 +104,7 @@ namespace PInvoke
             string result;
             if (!HidD_GetSerialNumberString(hidDeviceObject, out result))
             {
-                Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+                throw new Win32Exception();
             }
 
             return result;
@@ -126,8 +127,7 @@ namespace PInvoke
                     return true;
                 }
 
-                var errorCode = (Win32ErrorCode)Marshal.GetHRForLastWin32Error();
-                if (errorCode != Win32ErrorCode.ERROR_INVALID_USER_BUFFER)
+                if (GetLastError() != Win32ErrorCode.ERROR_INVALID_USER_BUFFER)
                 {
                     result = null;
                     return false;

--- a/src/Hid.Tests/Hid.cs
+++ b/src/Hid.Tests/Hid.cs
@@ -2,8 +2,7 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 
 using System;
-using System.ComponentModel;
-using System.Runtime.InteropServices;
+using PInvoke;
 using Xunit;
 using static PInvoke.Hid;
 using static PInvoke.Kernel32;
@@ -27,35 +26,35 @@ public class Hid
     [Fact]
     public void HidD_GetManufacturerString_ThrowForInvalidHandle()
     {
-        Assert.Throws<COMException>(() =>
+        Assert.Throws<Win32Exception>(() =>
             HidD_GetManufacturerString(new SafeObjectHandle(new IntPtr(0), false)));
     }
 
     [Fact]
     public void HidD_GetProductString_ThrowForInvalidHandle()
     {
-        Assert.Throws<COMException>(() =>
+        Assert.Throws<Win32Exception>(() =>
             HidD_GetProductString(new SafeObjectHandle(new IntPtr(0), false)));
     }
 
     [Fact]
     public void HidD_GetSerialNumberString_ThrowForInvalidHandle()
     {
-        Assert.Throws<COMException>(() =>
+        Assert.Throws<Win32Exception>(() =>
             HidD_GetSerialNumberString(new SafeObjectHandle(new IntPtr(0), false)));
     }
 
     [Fact]
     public void HidD_GetAttributes_ThrowForInvalidHandle()
     {
-        Assert.Throws<COMException>(() =>
+        Assert.Throws<Win32Exception>(() =>
             HidD_GetAttributes(new SafeObjectHandle(new IntPtr(0), false)));
     }
 
     [Fact]
     public void HidD_GetPreparsedData_ThrowForInvalidHandle()
     {
-        Assert.Throws<COMException>(() =>
+        Assert.Throws<Win32Exception>(() =>
             HidD_GetPreparsedData(new SafeObjectHandle(new IntPtr(0), false)));
     }
 }

--- a/src/Kernel32.Desktop/Kernel32.Helpers.cs
+++ b/src/Kernel32.Desktop/Kernel32.Helpers.cs
@@ -5,7 +5,6 @@ namespace PInvoke
 {
     using System;
     using System.Collections.Generic;
-    using System.Runtime.InteropServices;
     using System.Text;
 
     /// <content>
@@ -27,10 +26,10 @@ namespace PInvoke
                 return entry;
             }
 
-            var lastError = (Win32ErrorCode)Marshal.GetLastWin32Error();
+            var lastError = GetLastError();
             if (lastError != Win32ErrorCode.ERROR_NO_MORE_FILES)
             {
-                Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+                throw new Win32Exception(lastError);
             }
 
             return null;
@@ -49,10 +48,10 @@ namespace PInvoke
                 return entry;
             }
 
-            var lastError = (Win32ErrorCode)Marshal.GetLastWin32Error();
+            var lastError = GetLastError();
             if (lastError != Win32ErrorCode.ERROR_NO_MORE_FILES)
             {
-                Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+                throw new Win32Exception(lastError);
             }
 
             return null;

--- a/src/Kernel32.Desktop/Kernel32.cs
+++ b/src/Kernel32.Desktop/Kernel32.cs
@@ -332,7 +332,7 @@ namespace PInvoke
         /// <param name="share">
         /// The requested sharing mode of the file or device, which can be read, write, both, delete, all of these, or none (refer to the following table). Access requests to attributes or extended attributes are not affected by this flag.
         /// If this parameter is zero and <see cref="CreateFile"/> succeeds, the file or device cannot be shared and cannot be opened again until the handle to the file or device is closed. For more information, see the Remarks section.
-        /// You cannot request a sharing mode that conflicts with the access mode that is specified in an existing request that has an open handle. <see cref="CreateFile"/> would fail and the GetLastError function would return ERROR_SHARING_VIOLATION.
+        /// You cannot request a sharing mode that conflicts with the access mode that is specified in an existing request that has an open handle. <see cref="CreateFile"/> would fail and the <see cref="GetLastError"/> function would return ERROR_SHARING_VIOLATION.
         /// To enable a process to share a file or device while another process has the file or device open, use a compatible combination of one or more of the following values. For more information about valid combinations of this parameter with the dwDesiredAccess parameter, see Creating and Opening Files.
         /// </param>
         /// <param name="securityAttributes">
@@ -364,7 +364,7 @@ namespace PInvoke
         /// </param>
         /// <returns>
         /// If the function succeeds, the return value is an open handle to the specified file, device, named pipe, or mail slot.
-        /// If the function fails, the return value is INVALID_HANDLE_VALUE.To get extended error information, call GetLastError.
+        /// If the function fails, the return value is INVALID_HANDLE_VALUE.To get extended error information, call <see cref="GetLastError"/>.
         /// </returns>
         [DllImport(nameof(Kernel32), CharSet = CharSet.Auto, SetLastError = true)]
         public static extern SafeObjectHandle CreateFile(
@@ -390,8 +390,8 @@ namespace PInvoke
         /// <param name="lpFindFileData">A pointer to the WIN32_FIND_DATA structure that receives information about a found file or directory.</param>
         /// <returns>
         /// If the function succeeds, the return value is a search handle used in a subsequent call to FindNextFile or FindClose, and the lpFindFileData parameter contains information about the first file or directory found.
-        /// If the function fails or fails to locate files from the search string in the lpFileName parameter, the return value is INVALID_HANDLE_VALUE and the contents of lpFindFileData are indeterminate.To get extended error information, call the GetLastError function.
-        /// If the function fails because no matching files can be found, the GetLastError function returns ERROR_FILE_NOT_FOUND.
+        /// If the function fails or fails to locate files from the search string in the lpFileName parameter, the return value is INVALID_HANDLE_VALUE and the contents of lpFindFileData are indeterminate.To get extended error information, call the <see cref="GetLastError"/> function.
+        /// If the function fails because no matching files can be found, the <see cref="GetLastError"/> function returns ERROR_FILE_NOT_FOUND.
         /// </returns>
         [DllImport(nameof(Kernel32), SetLastError = true, CharSet = CharSet.Unicode)]
         public static extern SafeFindFilesHandle FindFirstFile(string lpFileName, out WIN32_FIND_DATA lpFindFileData);
@@ -403,8 +403,8 @@ namespace PInvoke
         /// <param name="lpFindFileData">A pointer to the WIN32_FIND_DATA structure that receives information about the found file or subdirectory.</param>
         /// <returns>
         /// If the function succeeds, the return value is nonzero and the lpFindFileData parameter contains information about the next file or directory found.
-        /// If the function fails, the return value is zero and the contents of lpFindFileData are indeterminate. To get extended error information, call the GetLastError function.
-        /// If the function fails because no more matching files can be found, the GetLastError function returns ERROR_NO_MORE_FILES.
+        /// If the function fails, the return value is zero and the contents of lpFindFileData are indeterminate. To get extended error information, call the <see cref="GetLastError"/> function.
+        /// If the function fails because no more matching files can be found, the <see cref="GetLastError"/> function returns ERROR_NO_MORE_FILES.
         /// </returns>
         [DllImport(nameof(Kernel32), SetLastError = true, CharSet = CharSet.Unicode)]
         public static extern bool FindNextFile(SafeFindFilesHandle hFindFile, out WIN32_FIND_DATA lpFindFileData);
@@ -532,7 +532,7 @@ namespace PInvoke
         /// </param>
         /// <returns>
         /// If the function succeeds, the return value is nonzero.
-        /// <para>If the function fails, the return value is zero.To get extended error information, call GetLastError.</para>
+        /// <para>If the function fails, the return value is zero.To get extended error information, call <see cref="GetLastError"/>.</para>
         /// </returns>
         /// <remarks>Minimum OS: Windows Vista / Windows Server 2008.</remarks>
         [DllImport(nameof(Kernel32), SetLastError = true, CharSet = CharSet.Unicode)]

--- a/src/Kernel32.Shared/Kernel32.Helpers.cs
+++ b/src/Kernel32.Shared/Kernel32.Helpers.cs
@@ -3,7 +3,6 @@
 
 namespace PInvoke
 {
-    using System;
     using System.Runtime.InteropServices;
 
     /// <content>
@@ -12,9 +11,41 @@ namespace PInvoke
     /// </content>
     public static partial class Kernel32
     {
-        // This is where you define methods that assist in calling P/Invoke methods.
-        // For example, if a P/Invoke method requires allocating unmanaged memory
-        // and freeing it up after the call, a helper method in this file would
-        // make "P/Invoking" for most callers much easier and is a welcome addition.
+        /// <summary>
+        /// Returns the error code returned by the last unmanaged function that was called using platform invoke that has
+        /// the <see cref="DllImportAttribute.SetLastError" /> flag set.
+        /// </summary>
+        /// <returns>
+        /// The last error code set by a call to the Win32 SetLastError function.
+        /// <para>
+        /// The Return Value section of the documentation for each function that sets the last-error code notes the
+        /// conditions under which the function sets the last-error code. Most functions that set the thread's last-error code set
+        /// it when they fail. However, some functions also set the last-error code when they succeed. If the function is not
+        /// documented to set the last-error code, the value returned by this function is simply the most recent last-error code to
+        /// have been set; some functions set the last-error code to <see cref="Win32ErrorCode.ERROR_SUCCESS" /> on success and
+        /// others do not.
+        /// </para>
+        /// </returns>
+        /// <remarks>
+        /// This method exists because it is not safe to make a direct platform invoke call to GetLastError to obtain this
+        /// information. If you want to access this error code, you must call <see cref="GetLastError" /> instead of writing your
+        /// own platform invoke definition for GetLastError and calling it. The common language runtime can make internal calls to
+        /// APIs that overwrite the GetLastError maintained by the operating system.
+        /// <para>
+        /// You can use this method to obtain error codes only if you apply the <see cref="DllImportAttribute" /> to the
+        /// method signature and set the <see cref="DllImportAttribute.SetLastError" /> field to true. The process for this varies
+        /// depending upon the source language used: C# and C++ are false by default, but the Declare statement in Visual Basic is
+        /// true.
+        /// </para>
+        /// </remarks>
+        /// <devremarks>
+        /// See
+        /// https://stackoverflow.com/questions/17918266/winapi-getlasterror-vs-marshal-getlastwin32error/17918729#17918729 for
+        /// more details.
+        /// </devremarks>
+        public static Win32ErrorCode GetLastError()
+        {
+            return (Win32ErrorCode)Marshal.GetLastWin32Error();
+        }
     }
 }

--- a/src/Kernel32.Shared/Kernel32.cs
+++ b/src/Kernel32.Shared/Kernel32.cs
@@ -226,46 +226,6 @@ namespace PInvoke
         [DllImport(nameof(Kernel32), SetLastError = true)]
         private static extern bool CloseHandle(IntPtr hObject);
 
-        /// <summary>
-        /// Retrieves the calling thread's last-error code value. The last-error code is maintained on a per-thread basis.
-        /// Multiple threads do not overwrite each other's last-error code.
-        /// </summary>
-        /// <returns>
-        /// The return value is the calling thread's last-error code.
-        /// <para>
-        /// The Return Value section of the documentation for each function that sets the last-error code notes the
-        /// conditions under which the function sets the last-error code. Most functions that set the thread's last-error code set
-        /// it when they fail. However, some functions also set the last-error code when they succeed. If the function is not
-        /// documented to set the last-error code, the value returned by this function is simply the most recent last-error code to
-        /// have been set; some functions set the last-error code to 0 on success and others do not.
-        /// </para>
-        /// </returns>
-        /// <remarks>
-        /// Functions executed by the calling thread set this value by calling the <see cref="SetLastError" /> function.
-        /// You should call the GetLastError function immediately when a function's return value indicates that such a call will
-        /// return useful data. That is because some functions call <see cref="SetLastError" /> with a zero when they succeed,
-        /// wiping out the error code set by the most recently failed function.
-        /// <para>To obtain an error string for system error codes, use the FormatMessage function.</para>
-        /// </remarks>
-        [DllImport(nameof(Kernel32))]
-        public static extern Win32ErrorCode GetLastError();
-
-        /// <summary>Sets the last-error code for the calling thread.</summary>
-        /// <param name="dwErrCode">The last-error code for the thread.</param>
-        /// <remarks>
-        /// The last-error code is kept in thread local storage so that multiple threads do not overwrite each other's values.
-        /// <para>
-        /// Most functions call SetLastError only when they fail. However, some system functions call SetLastError under
-        /// conditions of success; those cases are noted in each function's documentation.
-        /// </para>
-        /// <para>
-        /// Applications can optionally retrieve the value set by this function by using the GetLastError function
-        /// immediately after a function fails.
-        /// </para>
-        /// </remarks>
-        [DllImport(nameof(Kernel32))]
-        public static extern void SetLastError(Win32ErrorCode dwErrCode);
-
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
         public struct WIN32_FIND_DATA
         {

--- a/src/Kernel32.Shared/Kernel32.cs
+++ b/src/Kernel32.Shared/Kernel32.cs
@@ -226,6 +226,46 @@ namespace PInvoke
         [DllImport(nameof(Kernel32), SetLastError = true)]
         private static extern bool CloseHandle(IntPtr hObject);
 
+        /// <summary>
+        /// Retrieves the calling thread's last-error code value. The last-error code is maintained on a per-thread basis.
+        /// Multiple threads do not overwrite each other's last-error code.
+        /// </summary>
+        /// <returns>
+        /// The return value is the calling thread's last-error code.
+        /// <para>
+        /// The Return Value section of the documentation for each function that sets the last-error code notes the
+        /// conditions under which the function sets the last-error code. Most functions that set the thread's last-error code set
+        /// it when they fail. However, some functions also set the last-error code when they succeed. If the function is not
+        /// documented to set the last-error code, the value returned by this function is simply the most recent last-error code to
+        /// have been set; some functions set the last-error code to 0 on success and others do not.
+        /// </para>
+        /// </returns>
+        /// <remarks>
+        /// Functions executed by the calling thread set this value by calling the <see cref="SetLastError" /> function.
+        /// You should call the GetLastError function immediately when a function's return value indicates that such a call will
+        /// return useful data. That is because some functions call <see cref="SetLastError" /> with a zero when they succeed,
+        /// wiping out the error code set by the most recently failed function.
+        /// <para>To obtain an error string for system error codes, use the FormatMessage function.</para>
+        /// </remarks>
+        [DllImport(nameof(Kernel32))]
+        public static extern Win32ErrorCode GetLastError();
+
+        /// <summary>Sets the last-error code for the calling thread.</summary>
+        /// <param name="dwErrCode">The last-error code for the thread.</param>
+        /// <remarks>
+        /// The last-error code is kept in thread local storage so that multiple threads do not overwrite each other's values.
+        /// <para>
+        /// Most functions call SetLastError only when they fail. However, some system functions call SetLastError under
+        /// conditions of success; those cases are noted in each function's documentation.
+        /// </para>
+        /// <para>
+        /// Applications can optionally retrieve the value set by this function by using the GetLastError function
+        /// immediately after a function fails.
+        /// </para>
+        /// </remarks>
+        [DllImport(nameof(Kernel32))]
+        public static extern void SetLastError(Win32ErrorCode dwErrCode);
+
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
         public struct WIN32_FIND_DATA
         {

--- a/src/Kernel32.Shared/Kernel32.cs
+++ b/src/Kernel32.Shared/Kernel32.cs
@@ -62,10 +62,10 @@ namespace PInvoke
         {
             /// <summary>
             /// The function allocates a buffer large enough to hold the formatted message, and places a pointer to the allocated buffer at the address specified by lpBuffer. The nSize parameter specifies the minimum number of TCHARs to allocate for an output message buffer. The caller should use the LocalFree function to free the buffer when it is no longer needed.
-            /// If the length of the formatted message exceeds 128K bytes, then FormatMessage will fail and a subsequent call to GetLastError will return ERROR_MORE_DATA.
+            /// If the length of the formatted message exceeds 128K bytes, then FormatMessage will fail and a subsequent call to <see cref="GetLastError"/> will return <see cref="Win32ErrorCode.ERROR_MORE_DATA"/>.
             /// In previous versions of Windows, this value was not available for use when compiling Windows Store apps. As of Windows 10 this value can be used.
             /// Windows Server 2003 and Windows XP:
-            /// If the length of the formatted message exceeds 128K bytes, then FormatMessage will not automatically fail with an error of ERROR_MORE_DATA.
+            /// If the length of the formatted message exceeds 128K bytes, then FormatMessage will not automatically fail with an error of <see cref="Win32ErrorCode.ERROR_MORE_DATA"/>.
             /// Windows 10:
             /// LocalFree is not in the modern SDK, so it cannot be used to free the result buffer. Instead, use HeapFree (GetProcessHeap(), allocatedMessage). In this case, this is the same as calling LocalFree on memory.
             /// Important: LocalAlloc() has different options: LMEM_FIXED, and LMEM_MOVABLE. FormatMessage() uses LMEM_FIXED, so HeapFree can be used. If LMEM_MOVABLE is used, HeapFree cannot be used.
@@ -80,7 +80,7 @@ namespace PInvoke
 
             /// <summary>
             /// The lpSource parameter is a module handle containing the message-table resource(s) to search. If this lpSource handle is NULL, the current process's application image file will be searched. This flag cannot be used with <see cref="FromString"/>.
-            /// If the module has no message table resource, the function fails with ERROR_RESOURCE_TYPE_NOT_FOUND.
+            /// If the module has no message table resource, the function fails with <see cref="Win32ErrorCode.ERROR_RESOURCE_TYPE_NOT_FOUND"/>.
             /// </summary>
             FromHModule = 0x800,
 
@@ -91,7 +91,7 @@ namespace PInvoke
 
             /// <summary>
             /// The function should search the system message-table resource(s) for the requested message. If this flag is specified with <see cref="FromHModule"/>, the function searches the system message table if the message is not found in the module specified by lpSource. This flag cannot be used with <see cref="FromString"/>.
-            /// If this flag is specified, an application can pass the result of the GetLastError function to retrieve the message text for a system-defined error.
+            /// If this flag is specified, an application can pass the result of the <see cref="GetLastError"/> function to retrieve the message text for a system-defined error.
             /// </summary>
             FromSystem = 0x1000,
 
@@ -139,7 +139,7 @@ namespace PInvoke
         /// <param name="dwAdditionalFlags">Specifies additional flags that control the search.</param>
         /// <returns>
         /// If the function succeeds, the return value is a search handle used in a subsequent call to FindNextFile or FindClose, and the lpFindFileData parameter contains information about the first file or directory found.
-        /// If the function fails or fails to locate files from the search string in the lpFileName parameter, the return value is INVALID_HANDLE_VALUE and the contents of lpFindFileData are indeterminate.To get extended error information, call the GetLastError function.
+        /// If the function fails or fails to locate files from the search string in the lpFileName parameter, the return value is INVALID_HANDLE_VALUE and the contents of lpFindFileData are indeterminate.To get extended error information, call the <see cref="GetLastError"/> function.
         /// </returns>
         [DllImport(nameof(Kernel32))]
         public static extern SafeFindFilesHandle FindFirstFileEx(string lpFileName, FINDEX_INFO_LEVELS fInfoLevelId, out WIN32_FIND_DATA lpFindFileData, FINDEX_SEARCH_OPS fSearchOp, IntPtr lpSearchFilter, FindFirstFileExFlags dwAdditionalFlags);
@@ -186,7 +186,7 @@ namespace PInvoke
         /// </param>
         /// <returns>
         /// If the function succeeds, the return value is the number of TCHARs stored in the output buffer, excluding the terminating null character.
-        /// If the function fails, the return value is zero.To get extended error information, call GetLastError.
+        /// If the function fails, the return value is zero.To get extended error information, call <see cref="GetLastError"/>.
         /// </returns>
         [DllImport(nameof(Kernel32), CharSet = CharSet.Unicode, SetLastError = true)]
         public static extern int FormatMessage(FormatMessageFlags dwFlags, IntPtr lpSource, uint dwMessageId, uint dwLanguageId, StringBuilder lpBuffer, int nSize, IntPtr[] Arguments);
@@ -210,7 +210,7 @@ namespace PInvoke
         /// <param name="hFindFile">The file search handle.</param>
         /// <returns>
         /// If the function succeeds, the return value is nonzero.
-        /// <para>If the function fails, the return value is zero. To get extended error information, call GetLastError.</para>
+        /// <para>If the function fails, the return value is zero. To get extended error information, call <see cref="GetLastError"/>.</para>
         /// </returns>
         [DllImport(nameof(Kernel32), SetLastError = true)]
         private static extern bool FindClose(IntPtr hFindFile);
@@ -221,7 +221,7 @@ namespace PInvoke
         /// <param name="hObject">A valid handle to an open object.</param>
         /// <returns>
         /// If the function succeeds, the return value is nonzero.
-        /// If the function fails, the return value is zero.To get extended error information, call GetLastError.
+        /// If the function fails, the return value is zero.To get extended error information, call <see cref="GetLastError"/>.
         /// </returns>
         [DllImport(nameof(Kernel32), SetLastError = true)]
         private static extern bool CloseHandle(IntPtr hObject);

--- a/src/Kernel32.Shared/Win32Exception.cs
+++ b/src/Kernel32.Shared/Win32Exception.cs
@@ -151,7 +151,7 @@ namespace PInvoke
 
                 errorMsg = sb.ToString(0, i);
             }
-            else if (Marshal.GetLastWin32Error() == (int)Win32ErrorCode.ERROR_INSUFFICIENT_BUFFER)
+            else if (GetLastError() == Win32ErrorCode.ERROR_INSUFFICIENT_BUFFER)
             {
                 return false;
             }

--- a/src/SetupApi.Desktop/SetupApi.Helpers.cs
+++ b/src/SetupApi.Desktop/SetupApi.Helpers.cs
@@ -6,6 +6,7 @@ namespace PInvoke
     using System;
     using System.Collections.Generic;
     using System.Runtime.InteropServices;
+    using static Kernel32;
 
     /// <content>
     /// Methods and nested types that are not strictly P/Invokes but provide
@@ -38,7 +39,7 @@ namespace PInvoke
             var result = SetupDiGetClassDevs((NullableGuid)classGuid, enumerator, hwndParent, flags);
             if (result.IsInvalid)
             {
-                Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+                throw new Win32Exception();
             }
 
             return result;
@@ -63,10 +64,10 @@ namespace PInvoke
 
                 if (!result)
                 {
-                    var lastError = (Win32ErrorCode)Marshal.GetLastWin32Error();
+                    var lastError = GetLastError();
                     if (lastError != Win32ErrorCode.ERROR_NO_MORE_ITEMS)
                     {
-                        Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+                        throw new Win32Exception(lastError);
                     }
 
                     yield break;
@@ -94,11 +95,10 @@ namespace PInvoke
                 null);
 
             // As we passed an empty buffer we know that the function will fail, not need to check the result.
-            var lastError = (Win32ErrorCode)Marshal.GetLastWin32Error();
+            var lastError = GetLastError();
             if (lastError != Win32ErrorCode.ERROR_INSUFFICIENT_BUFFER)
             {
-                Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
-                return null;
+                throw new Win32Exception(lastError);
             }
 
             var buffer = Marshal.AllocHGlobal((int)requiredSize.Value);

--- a/src/SetupApi.Desktop/SetupApi.cs
+++ b/src/SetupApi.Desktop/SetupApi.cs
@@ -82,7 +82,7 @@ namespace PInvoke
         /// <param name="memberIndex">
         /// A zero-based index into the list of interfaces in the device information set. The caller
         /// should call this function first with MemberIndex set to zero to obtain the first interface. Then, repeatedly increment
-        /// MemberIndex and retrieve an interface until this function fails and GetLastError returns
+        /// MemberIndex and retrieve an interface until this function fails and <see cref="Kernel32.GetLastError"/> returns
         /// <see cref="Win32ErrorCode.ERROR_NO_MORE_ITEMS" />.
         /// </param>
         /// <param name="deviceInterfaceData">


### PR DESCRIPTION
- Use `Win32Exception` in places that were still using `COMException`
- Add `GetLastError` helper (With an XML doc about why it isn't a `DllImport` and shouldn't be)
- Add `<see cref="GetLastError" />` when it's evoked in the XML docs.
