### PR TITLE
Display only the status of master for appveyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 P/Invoke
 =======
 
-[![Build status](https://ci.appveyor.com/api/projects/status/idu56hy4jwytxd3x?svg=true)](https://ci.appveyor.com/project/AArnott/pinvoke)
+[![Build status](https://ci.appveyor.com/api/projects/status/idu56hy4jwytxd3x?branch=master&svg=true)](https://ci.appveyor.com/project/AArnott/pinvoke)
 [![Join the chat at https://gitter.im/AArnott/pinvoke](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/AArnott/pinvoke?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 A library intended to contain all P/Invoke method signatures for popular operating systems.


### PR DESCRIPTION
It was displaying the latest build for any branch or PR so could display a
failure when master was building cleanly.
