### PR TITLE
Add ps1 scripts to generate coverage report

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ ncrypt.dll   |`PInvoke.NCrypt`  | [![NuGet](https://img.shields.io/nuget/dt/PInv
 setupapi.dll |`PInvoke.SetupApi`| [![NuGet](https://img.shields.io/nuget/dt/PInvoke.SetupApi.svg)](https://www.nuget.org/packages/PInvoke.SetupApi)|[Windows setup API][SetupApi]
 user32.dll   |`PInvoke.User32`  | [![NuGet](https://img.shields.io/nuget/dt/PInvoke.User32.svg)](https://www.nuget.org/packages/PInvoke.User32)|Windows User Interface
 
+Check out the [P/Invoke coverage](coverage.md) we have for each library.
+
 ## Contribution
 
 Please consider [contributing](CONTRIB.md) more P/Invoke method signatures to this project.

--- a/coverage.md
+++ b/coverage.md
@@ -1,0 +1,13 @@
+# P/Invoke coverage report
+
+Coverage  | Package
+----------|--------
+![P/Invokes](https://img.shields.io/badge/AdvApi32-7/660-red.svg) | [AdvApi32](https://www.nuget.org/packages/PInvoke.AdvApi32)
+![P/Invokes](https://img.shields.io/badge/BCrypt-24/58-orange.svg) | [BCrypt](https://www.nuget.org/packages/PInvoke.BCrypt)
+![P/Invokes](https://img.shields.io/badge/Gdi32-1/810-red.svg) | [Gdi32](https://www.nuget.org/packages/PInvoke.Gdi32)
+![P/Invokes](https://img.shields.io/badge/Hid-9/44-red.svg) | [Hid](https://www.nuget.org/packages/PInvoke.Hid)
+![P/Invokes](https://img.shields.io/badge/ImageHlp-2/131-red.svg) | [ImageHlp](https://www.nuget.org/packages/PInvoke.ImageHlp)
+![P/Invokes](https://img.shields.io/badge/Kernel32-34/1324-red.svg) | [Kernel32](https://www.nuget.org/packages/PInvoke.Kernel32)
+![P/Invokes](https://img.shields.io/badge/NCrypt-6/138-red.svg) | [NCrypt](https://www.nuget.org/packages/PInvoke.NCrypt)
+![P/Invokes](https://img.shields.io/badge/SetupApi-5/492-red.svg) | [SetupApi](https://www.nuget.org/packages/PInvoke.SetupApi)
+![P/Invokes](https://img.shields.io/badge/User32-8/784-red.svg) | [User32](https://www.nuget.org/packages/PInvoke.User32)

--- a/tools/Get-Shield.ps1
+++ b/tools/Get-Shield.ps1
@@ -1,0 +1,62 @@
+<#
+.SYNOPSIS
+Compares a LIBNAME.exports.txt file to a LIBNAME.pinvokes.txt file and
+produces a string that may produce a shield/badge for online viewing.
+
+.PARAMETER Directory
+The directory where the exports and pinvokes files are to be found.
+
+.PARAMETER Library
+The simple name of the library (without the file extension). 
+#>
+Param(
+	[Parameter(Mandatory=$true)]
+	[string]$Directory,
+	[Parameter(Mandatory=$true)]
+	[string]$Library
+)
+
+Function Get-ShieldColor {
+	[CmdletBinding()]
+	Param(
+		$ExportCount,
+		$PInvokeCount
+	)
+
+	$coverage = 100 * $PInvokeCount / $ExportCount
+	if ($coverage -eq 100) {
+		"green"
+	} elseif ($coverage -ge 70) {
+		"yellowgreen"
+	} elseif ($coverage -ge 30) {
+		"orange"
+	} elseif ($coverage -gt 0) {
+		"red"
+	} else {
+		"lightgrey"
+	}
+}
+
+$ExportsPath = Join-Path $Directory "$Library.exports.txt"
+$PInvokesPath = Join-Path $Directory "$Library.pinvokes.txt"
+	
+$shield = New-Object PSObject
+Add-Member -InputObject $shield -Name Subject -Value $Library -MemberType NoteProperty
+
+$exportCount = (Get-Content -Path $ExportsPath).Count
+$pinvokeCount = (Get-Content -Path $PInvokesPath).Count
+Add-Member -InputObject $shield -Name Status -Value "$pinvokeCount/$exportCount" -MemberType NoteProperty
+
+$color = Get-ShieldColor -ExportCount $exportCount -PInvokeCount $pinvokeCount
+Add-Member -InputObject $shield -Name Color -Value $color -MemberType NoteProperty
+
+$tuple = "$($shield.subject)-$($shield.status)-$($shield.color)"
+Add-Member -InputObject $shield -Name Tuple -Value $tuple -MemberType NoteProperty
+
+$svg = "https://img.shields.io/badge/$tuple.svg"
+Add-Member -InputObject $shield -Name Svg -Value $svg -MemberType NoteProperty
+
+$MarkDown = "![P/Invokes]($svg)"
+Add-Member -InputObject $shield -Name MarkDown -Value $MarkDown -MemberType NoteProperty
+
+return $shield

--- a/tools/Get-Shields.ps1
+++ b/tools/Get-Shields.ps1
@@ -1,0 +1,24 @@
+<#
+.SYNOPSIS
+Gets the shields for all libraries.
+
+.PARAMETER Directory
+The directory to search for the exports and pinvokes files (e.g. bin\debug).
+#>
+Param(
+	[Parameter(Mandatory=$true,Position=0)]
+	[string]$Directory
+)
+
+$Shields = @()
+$pinvokeFiles = Get-ChildItem -Path "$Directory\*.pinvokes.txt" -Recurse
+$pinvokeFiles |% {
+	$null = $_.Name -Match "(?<Library>\w+)\.pinvokes.txt"
+	$Library = $Matches.Library
+	$ExportsPath = Join-Path $_.Directory "$Library.exports.txt"
+	if (Test-Path $ExportsPath)	{
+		$Shields += & "$PSScriptRoot\Get-Shield.ps1" -Directory $_.Directory -Library $Library
+	}
+}
+
+$Shields | Sort-Object Subject

--- a/tools/Update-CoverageReport.ps1
+++ b/tools/Update-CoverageReport.ps1
@@ -1,0 +1,24 @@
+<#
+.SYNOPSIS
+Updates the coverage.md file in the source tree.
+
+.PARAMETER Directory
+The directory to search for the exports and pinvokes files (e.g. bin\debug).
+#>
+Param(
+	[Parameter(Mandatory=$true)]
+	[string]$Directory
+)
+
+$Shields = & "$PSScriptRoot\Get-Shields.ps1" -Directory $Directory
+$CoveragePath = Resolve-Path "$PSScriptRoot\..\coverage.md"
+
+Set-Content -Path $CoveragePath -Value "# P/Invoke coverage report
+
+Coverage  | Package
+----------|--------"
+
+$Shields |% {
+	$NuPkgId = "PInvoke.$($_.Subject)"
+	Add-Content -Path $CoveragePath -Value "$($_.MarkDown) | [$($_.Subject)](https://www.nuget.org/packages/$NuPkgId)"
+}


### PR DESCRIPTION
See [the table that the script produces](https://github.com/AArnott/pinvoke/blob/ef687ac2c0da77b8f78fae9ec12c2954be09c7be/coverage.md)

Fix #24. At least until https://github.com/badges/shields/issues/555 is complete

After a build, just run `tools\Update-CoverageReport.ps1` and it will update the coverage.md file.
