### PR TITLE
Fix warning when loading the solution.

### DIFF
--- a/src/PInvoke.sln
+++ b/src/PInvoke.sln
@@ -23,7 +23,7 @@ Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "BCrypt.NuGet", "BCrypt.NuGe
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{F00A1FA3-A9AF-450E-A45C-AC59E108F45A}"
 	ProjectSection(SolutionItems) = preProject
-		Create-PInvokeTxtFile.ps1 = ..\tools\Create-PInvokeTxtFile.ps1
+		..\tools\Create-PInvokeTxtFile.ps1 = ..\tools\Create-PInvokeTxtFile.ps1
 		EnlistmentInfo.props = EnlistmentInfo.props
 		EnlistmentInfo.targets = EnlistmentInfo.targets
 		NuProj.Extra.targets = NuProj.Extra.targets


### PR DESCRIPTION
When loading the solution the following warning pops up.

> One or more projects in the solution were not loaded correctly.
