### PR TITLE
User32

### DIFF
--- a/src/User32.Desktop/User32+FLASHWINFO.cs
+++ b/src/User32.Desktop/User32+FLASHWINFO.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) to owners found in https://github.com/AArnott/pinvoke/blob/master/COPYRIGHT.md. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+
+namespace PInvoke
+{
+    using System;
+    using System.Runtime.InteropServices;
+
+    /// <content>Contains the <see cref="FLASHWINFO" /> nested type.</content>
+    public partial class User32
+    {
+        /// <summary>
+        ///     Contains the flash status for a window and the number of times the system should flash the window. Used in
+        ///     <see cref="FlashWindowEx" />.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        public struct FLASHWINFO
+        {
+            /// <summary>The size of the structure, in bytes.</summary>
+            public int cbSize;
+
+            /// <summary>A handle to the window to be flashed. The window can be either opened or minimized.</summary>
+            public IntPtr hwnd;
+
+            /// <summary>The flash status</summary>
+            public FlashWindowFlags dwFlags;
+
+            /// <summary>The number of times to flash the window.</summary>
+            public int uCount;
+
+            /// <summary>
+            ///     The rate at which the window is to be flashed, in milliseconds. If <see cref="dwTimeout"/> is zero, the
+            ///     function uses the default cursor blink rate.
+            /// </summary>
+            public int dwTimeout;
+
+            public static FLASHWINFO Create()
+            {
+                return new FLASHWINFO
+                {
+                    cbSize = Marshal.SizeOf(typeof(FLASHWINFO))
+                };
+            }
+        }
+    }
+}

--- a/src/User32.Desktop/User32+FLASHWINFO.cs
+++ b/src/User32.Desktop/User32+FLASHWINFO.cs
@@ -34,6 +34,10 @@ namespace PInvoke
             /// </summary>
             public int dwTimeout;
 
+            /// <summary>
+            /// Create a new instance of <see cref="FLASHWINFO"/> with <see cref="cbSize"/> set to the correct value.
+            /// </summary>
+            /// <returns>A new instance of <see cref="FLASHWINFO"/> with <see cref="cbSize"/> set to the correct value.</returns>
             public static FLASHWINFO Create()
             {
                 return new FLASHWINFO

--- a/src/User32.Desktop/User32+FlashWindowFlags.cs
+++ b/src/User32.Desktop/User32+FlashWindowFlags.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) to owners found in https://github.com/AArnott/pinvoke/blob/master/COPYRIGHT.md. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+
+namespace PInvoke
+{
+    /// <content>
+    /// Contains the <see cref="FlashWindowFlags"/> nested type.
+    /// </content>
+    public partial class User32
+    {
+        /// <summary>The flash status stored in <see cref="FLASHWINFO" /> and used in <see cref="FlashWindowEx" />.</summary>
+        public enum FlashWindowFlags
+        {
+            /// <summary>
+            ///     Flash both the window caption and taskbar button. This is equivalent to setting the FLASHW_CAPTION |
+            ///     FLASHW_TRAY flags.
+            /// </summary>
+            FLASHW_ALL = 0x00000003,
+
+            /// <summary>Flash the window caption.</summary>
+            FLASHW_CAPTION = 0x00000001,
+
+            /// <summary>Stop flashing. The system restores the window to its original state.</summary>
+            FLASHW_STOP = 0,
+
+            /// <summary>Flash continuously, until the <see cref="FLASHW_STOP" /> flag is set.</summary>
+            FLASHW_TIMER = 0x00000004,
+
+            /// <summary>Flash continuously until the window comes to the foreground.</summary>
+            FLASHW_TIMERNOFG = 0x0000000C,
+
+            /// <summary>Flash the taskbar button.</summary>
+            FLASHW_TRAY = 0x00000002
+        }
+    }
+}

--- a/src/User32.Desktop/User32+GetAncestorFlags.cs
+++ b/src/User32.Desktop/User32+GetAncestorFlags.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) to owners found in https://github.com/AArnott/pinvoke/blob/master/COPYRIGHT.md. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+
+namespace PInvoke
+{
+    /// <content>
+    /// Contains the <see cref="GetAncestorFlags"/> nested type.
+    /// </content>
+    public partial class User32
+    {
+        /// <summary>The ancestor to be retrieved by <see cref="GetAncestor" />.</summary>
+        public enum GetAncestorFlags
+        {
+            /// <summary>Retrieves the parent window. This does not include the owner, as it does with the GetParent function.</summary>
+            GA_PARENT = 1,
+
+            /// <summary>Retrieves the root window by walking the chain of parent windows.</summary>
+            GA_ROOT = 2,
+
+            /// <summary>Retrieves the owned root window by walking the chain of parent and owner windows returned by GetParent.</summary>
+            GA_ROOTOWNER = 3
+        }
+    }
+}

--- a/src/User32.Desktop/User32+MENUITEMINFO.cs
+++ b/src/User32.Desktop/User32+MENUITEMINFO.cs
@@ -1,0 +1,162 @@
+﻿// Copyright (c) to owners found in https://github.com/AArnott/pinvoke/blob/master/COPYRIGHT.md. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+
+namespace PInvoke
+{
+    using System;
+    using System.Runtime.InteropServices;
+
+    /// <content>
+    /// Contains the <see cref="MENUITEMINFO"/> nested type.
+    /// </content>
+    public partial class User32
+    {
+        /// <summary>
+        /// Contains information about a menu item.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+        public struct MENUITEMINFO
+        {
+            /// <summary>The size of the structure, in bytes.</summary>
+            public int cbSize;
+
+            /// <summary>Indicates the members to be retrieved or set.</summary>
+            public MenuMembersMask fMask;
+
+            /// <summary>The menu item type.</summary>
+            public MenuItemType fType;
+
+            /// <summary>The menu item state.</summary>
+            public MenuItemState fState;
+
+            /// <summary>
+            ///     An application-defined value that identifies the menu item. Set <see cref="fMask" /> to
+            ///     <see cref="MenuMembersMask.MIIM_ID" /> to use <see cref="wID" />.
+            /// </summary>
+            public int wID;
+
+            /// <summary>
+            ///     A handle to the drop-down menu or submenu associated with the menu item. If the menu item is not an item that
+            ///     opens a drop-down menu or submenu, this member is <see cref="IntPtr.Zero" />. Set <see cref="fMask" /> to
+            ///     <see cref="MenuMembersMask.MIIM_SUBMENU" /> to use hSubMenu.
+            /// </summary>
+            public IntPtr hSubMenu;
+
+            /// <summary>
+            ///     A handle to the bitmap to display next to the item if it is selected. If this member is
+            ///     <see cref="IntPtr.Zero" />, a default bitmap is used. If the <see cref="MenuItemType.MFT_RADIOCHECK" /> type value
+            ///     is specified, the default bitmap is a bullet. Otherwise, it is a check mark. Set fMask to
+            ///     <see cref="MenuMembersMask.MIIM_CHECKMARKS" /> to use <see cref="hbmpChecked" />.
+            /// </summary>
+            public IntPtr hbmpChecked;
+
+            /// <summary>
+            ///     A handle to the bitmap to display next to the item if it is not selected. If this member is
+            ///     <see cref="IntPtr.Zero" />, no bitmap is used. Set <see cref="fMask" /> to
+            ///     <see cref="MenuMembersMask.MIIM_CHECKMARKS" /> to use <see cref="hbmpUnchecked" />.
+            /// </summary>
+            public IntPtr hbmpUnchecked;
+
+            /// <summary>
+            ///     An application-defined value associated with the menu item. Set <see cref="fMask" /> to
+            ///     <see cref="MenuMembersMask.MIIM_DATA" /> to use <see cref="dwItemData" />.
+            /// </summary>
+            public IntPtr dwItemData;
+
+            /// <summary>
+            ///     The contents of the menu item. The meaning of this member depends on the value of fType and is used only if the
+            ///     MIIM_TYPE flag is set in the fMask member.
+            ///     <para>
+            ///         To retrieve a menu item of type <see cref="MenuItemType.MFT_STRING" />, first find the size of the string by
+            ///         setting the <see cref="dwTypeData" />
+            ///         member of <see cref="MENUITEMINFO" /> to <see cref="IntPtr.Zero" /> and then calling
+            ///         <see cref="GetMenuItemInfo" />. The value of <see cref="cch" />+1 is the size needed. Then allocate a buffer of
+            ///         this size, place the pointer to the buffer in dwTypeData, increment cch, and call
+            ///         <see cref="GetMenuItemInfo" /> once again to fill the buffer with the string. If the retrieved menu item is of
+            ///         some other type, then <see cref="GetMenuItemInfo" /> sets the <see cref="dwTypeData" /> member to a value whose
+            ///         type is specified by the <see cref="fType" /> member.
+            ///     </para>
+            ///     <para>
+            ///         When using with the <see cref="SetMenuItemInfo" /> function, this member should contain a value whose type is
+            ///         specified by the <see cref="fType" /> member.
+            ///     </para>
+            ///     <para>
+            ///         dwTypeData is used only if the <see cref="MenuMembersMask.MIIM_STRING" /> flag is set in the
+            ///         <see cref="fMask" /> member
+            ///     </para>
+            /// </summary>
+            public string dwTypeData;
+
+            /// <summary>
+            ///     The length of the menu item text, in characters, when information is received about a menu item of the
+            ///     <see cref="MenuItemType.MFT_STRING" />
+            ///     type. However, <see cref="cch" /> is used only if the <see cref="MenuMembersMask.MIIM_TYPE" /> flag is set in the
+            ///     <see cref="fMask" /> member and is zero otherwise. Also, <see cref="cch" />
+            ///     is ignored when the content of a menu item is set by calling <see cref="SetMenuItemInfo" />.
+            ///     <para>
+            ///         Note that, before calling <see cref="GetMenuItemInfo" />, the application must set <see cref="cch" /> to the
+            ///         length of the buffer pointed to by the <see cref="dwTypeData" /> member. If the retrieved menu item is of type
+            ///         <see cref="MenuItemType.MFT_STRING" /> (as indicated by the <see cref="fType" />
+            ///         member), then <see cref="GetMenuItemInfo" /> changes <see cref="cch" /> to the length of the menu item text. If
+            ///         the retrieved menu item is of some other type, <see cref="GetMenuItemInfo" /> sets the <see cref="cch" /> field
+            ///         to zero.
+            ///     </para>
+            ///     <para>
+            ///         The <see cref="cch" /> member is used when the <see cref="MenuMembersMask.MIIM_STRING" /> flag is set in the
+            ///         <see cref="fMask" /> member.
+            ///     </para>
+            /// </summary>
+            public int cch;
+
+            /// <summary>
+            ///     A handle to the bitmap to be displayed, or it can be one of the following values :
+            ///     <para>
+            ///         <see cref="HBMMENU_CALLBACK" />
+            ///     </para>
+            ///     <para>
+            ///         <see cref="HBMMENU_MBAR_CLOSE" />
+            ///     </para>
+            ///     <para>
+            ///         <see cref="HBMMENU_MBAR_CLOSE_D" />
+            ///     </para>
+            ///     <para>
+            ///         <see cref="HBMMENU_MBAR_MINIMIZE" />
+            ///     </para>
+            ///     <para>
+            ///         <see cref="HBMMENU_MBAR_MINIMIZE_D" />
+            ///     </para>
+            ///     <para>
+            ///         <see cref="HBMMENU_MBAR_RESTORE" />
+            ///     </para>
+            ///     <para>
+            ///         <see cref="HBMMENU_POPUP_CLOSE" />
+            ///     </para>
+            ///     <para>
+            ///         <see cref="HBMMENU_POPUP_MAXIMIZE" />
+            ///     </para>
+            ///     <para>
+            ///         <see cref="HBMMENU_POPUP_MINIMIZE" />
+            ///     </para>
+            ///     <para>
+            ///         <see cref="HBMMENU_POPUP_RESTORE" />
+            ///     </para>
+            ///     <para>
+            ///         <see cref="HBMMENU_SYSTEM" />
+            ///     </para>
+            /// </summary>
+            public IntPtr hbmpItem;
+
+            /// <summary>
+            /// Create a new instance of <see cref="MENUITEMINFO"/> with <see cref="cbSize"/> set to the correct value.
+            /// </summary>
+            /// <returns>A new instance of <see cref="MENUITEMINFO"/> with <see cref="cbSize"/> set to the correct value.</returns>
+            public MENUITEMINFO Create()
+            {
+                return new MENUITEMINFO
+                {
+                    cbSize = Marshal.SizeOf(typeof(MENUITEMINFO))
+                };
+            }
+        }
+    }
+}

--- a/src/User32.Desktop/User32+MapVirtualKeyTranslation.cs
+++ b/src/User32.Desktop/User32+MapVirtualKeyTranslation.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) to owners found in https://github.com/AArnott/pinvoke/blob/master/COPYRIGHT.md. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+
+namespace PInvoke
+{
+    /// <content>
+    /// Contains the <see cref="MapVirtualKeyTranslation"/> nested type.
+    /// </content>
+    public partial class User32
+    {
+        /// <summary>The translation to be performed in <see cref="MapVirtualKey" />.</summary>
+        public enum MapVirtualKeyTranslation
+        {
+            /// <summary>
+            ///     uCode is a virtual-key code and is translated into an unshifted character value in the low-order word of the
+            ///     return value. Dead keys (diacritics) are indicated by setting the top bit of the return value. If there is no
+            ///     translation, the function returns 0.
+            /// </summary>
+            MAPVK_VK_TO_CHAR = 2,
+
+            /// <summary>
+            ///     uCode is a virtual-key code and is translated into a scan code. If it is a virtual-key code that does not
+            ///     distinguish between left- and right-hand keys, the left-hand scan code is returned. If there is no translation, the
+            ///     function returns 0.
+            /// </summary>
+            MAPVK_VK_TO_VSC = 0,
+
+            /// <summary>
+            ///     uCode is a scan code and is translated into a virtual-key code that does not distinguish between left- and
+            ///     right-hand keys. If there is no translation, the function returns 0.
+            /// </summary>
+            MAPVK_VSC_TO_VK = 1,
+
+            /// <summary>
+            ///     uCode is a scan code and is translated into a virtual-key code that distinguishes between left- and right-hand
+            ///     keys. If there is no translation, the function returns 0.
+            /// </summary>
+            MAPVK_VSC_TO_VK_EX = 3
+        }
+    }
+}

--- a/src/User32.Desktop/User32+MenuItemFlags.cs
+++ b/src/User32.Desktop/User32+MenuItemFlags.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) to owners found in https://github.com/AArnott/pinvoke/blob/master/COPYRIGHT.md. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+
+namespace PInvoke
+{
+    using System;
+
+    /// <content>
+    /// Contains the <see cref="MenuItemFlags"/> nested type.
+    /// </content>
+    public partial class User32
+    {
+        /// <summary>
+        /// Controls the appearance and behavior of a menu item
+        /// </summary>
+        [Flags]
+        public enum MenuItemFlags
+        {
+            /// <summary>Uses a bitmap as the menu item. The lpNewItem parameter contains a handle to the bitmap.</summary>
+            MF_BITMAP = 0x00000004,
+
+            /// <summary>
+            ///     Places a check mark next to the menu item. If the application provides check-mark bitmaps (see
+            ///     SetMenuItemBitmaps) this flag displays the check-mark bitmap next to the menu item.
+            /// </summary>
+            MF_CHECKED = 0x00000008,
+
+            /// <summary>Disables the menu item so that it cannot be selected, but the flag does not gray it.</summary>
+            MF_DISABLED = 0x00000002,
+
+            /// <summary>Enables the menu item so that it can be selected, and restores it from its grayed state.</summary>
+            MF_ENABLED = 0x00000000,
+
+            /// <summary>Disables the menu item and grays it so that it cannot be selected.</summary>
+            MF_GRAYED = 0x00000001,
+
+            /// <summary>
+            ///     Functions the same as the MF_MENUBREAK flag for a menu bar. For a drop-down menu, submenu, or shortcut menu,
+            ///     the new column is separated from the old column by a vertical line.
+            /// </summary>
+            MF_MENUBARBREAK = 0x00000020,
+
+            /// <summary>
+            ///     Places the item on a new line (for a menu bar) or in a new column (for a drop-down menu, submenu, or shortcut
+            ///     menu) without separating columns.
+            /// </summary>
+            MF_MENUBREAK = 0x00000040,
+
+            /// <summary>
+            ///     Specifies that the item is an owner-drawn item. Before the menu is displayed for the first time, the window
+            ///     that owns the menu receives a WM_MEASUREITEM message to retrieve the width and height of the menu item. The
+            ///     WM_DRAWITEM message is then sent to the window procedure of the owner window whenever the appearance of the menu
+            ///     item must be updated.
+            /// </summary>
+            MF_OWNERDRAW = 0x00000100,
+
+            /// <summary>
+            ///     Specifies that the menu item opens a drop-down menu or submenu. The uIDNewItem parameter specifies a handle to
+            ///     the drop-down menu or submenu. This flag is used to add a menu name to a menu bar, or a menu item that opens a
+            ///     submenu to a drop-down menu, submenu, or shortcut menu.
+            /// </summary>
+            MF_POPUP = 0x00000010,
+
+            /// <summary>
+            ///     Draws a horizontal dividing line. This flag is used only in a drop-down menu, submenu, or shortcut menu. The
+            ///     line cannot be grayed, disabled, or highlighted. The lpNewItem and uIDNewItem parameters are ignored.
+            /// </summary>
+            MF_SEPARATOR = 0x00000800,
+
+            /// <summary>Specifies that the menu item is a text string; the lpNewItem parameter is a pointer to the string.</summary>
+            MF_STRING = 0x00000000,
+
+            /// <summary>
+            ///     Does not place a check mark next to the item (default). If the application supplies check-mark bitmaps (see
+            ///     SetMenuItemBitmaps), this flag displays the clear bitmap next to the menu item.
+            /// </summary>
+            MF_UNCHECKED = 0x00000000
+        }
+    }
+}

--- a/src/User32.Desktop/User32+MenuItemState.cs
+++ b/src/User32.Desktop/User32+MenuItemState.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) to owners found in https://github.com/AArnott/pinvoke/blob/master/COPYRIGHT.md. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+
+namespace PInvoke
+{
+    /// <content>
+    /// Contains the <see cref="MenuItemState"/> nested type.
+    /// </content>
+    public partial class User32
+    {
+        /// <summary>The menu item state in <see cref="MENUITEMINFO" />.</summary>
+        public enum MenuItemState
+        {
+            /// <summary>
+            ///     Checks the menu item. For more information about selected menu items, see the
+            ///     <see cref="MENUITEMINFO.hbmpChecked" /> member.
+            /// </summary>
+            MFS_CHECKED,
+
+            /// <summary>
+            ///     Specifies that the menu item is the default. A menu can contain only one default menu item, which is displayed
+            ///     in bold.
+            /// </summary>
+            MFS_DEFAULT,
+
+            /// <summary>
+            ///     Disables the menu item and grays it so that it cannot be selected. This is equivalent to
+            ///     <see cref="MFS_GRAYED" />.
+            /// </summary>
+            MFS_DISABLED,
+
+            /// <summary>Enables the menu item so that it can be selected. This is the default state.</summary>
+            MFS_ENABLED,
+
+            /// <summary>
+            ///     Disables the menu item and grays it so that it cannot be selected. This is equivalent to
+            ///     <see cref="MFS_DISABLED" />.
+            /// </summary>
+            MFS_GRAYED,
+
+            /// <summary>Highlights the menu item.</summary>
+            MFS_HILITE,
+
+            /// <summary>Unchecks the menu item. For more information about clear menu items, see the hbmpChecked member.</summary>
+            MFS_UNCHECKED,
+
+            /// <summary>Removes the highlight from the menu item. This is the default state.</summary>
+            MFS_UNHILITE
+        }
+    }
+}

--- a/src/User32.Desktop/User32+MenuItemType.cs
+++ b/src/User32.Desktop/User32+MenuItemType.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) to owners found in https://github.com/AArnott/pinvoke/blob/master/COPYRIGHT.md. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+
+namespace PInvoke
+{
+    using System;
+
+    /// <content>
+    /// Contains the <see cref="MenuItemType"/> nested type.
+    /// </content>
+    public partial class User32
+    {
+        /// <summary>
+        /// The menu item type in <see cref="MENUITEMINFO"/>.
+        /// </summary>
+        [Flags]
+        public enum MenuItemType
+        {
+            /// <summary>
+            ///     Displays the menu item using a bitmap. The low-order word of the <see cref="MENUITEMINFO.dwTypeData" /> member is
+            ///     the bitmap handle, and the <see cref="MENUITEMINFO.cch" /> member is ignored.
+            ///     <para>
+            ///         <see cref="MFT_BITMAP" /> is replaced by <see cref="MenuMembersMask.MIIM_BITMAP" /> and
+            ///         <see cref="MENUITEMINFO.hbmpItem" />.
+            ///     </para>
+            /// </summary>
+            MFT_BITMAP = 0x00000004,
+
+            /// <summary>
+            ///     Places the menu item on a new line (for a menu bar) or in a new column (for a drop-down menu, submenu, or
+            ///     shortcut menu). For a drop-down menu, submenu, or shortcut menu, a vertical line separates the new column from the
+            ///     old.
+            /// </summary>
+            MFT_MENUBARBREAK = 0x00000020,
+
+            /// <summary>
+            ///     Places the menu item on a new line (for a menu bar) or in a new column (for a drop-down menu, submenu, or
+            ///     shortcut menu). For a drop-down menu, submenu, or shortcut menu, the columns are not separated by a vertical line.
+            /// </summary>
+            MFT_MENUBREAK = 0x00000040,
+
+            /// <summary>
+            ///     Assigns responsibility for drawing the menu item to the window that owns the menu. The window receives a
+            ///     WM_MEASUREITEM message before the menu is displayed for the first time, and a WM_DRAWITEM message whenever the
+            ///     appearance of the menu item must be updated. If this value is specified, the dwTypeData member contains an
+            ///     application-defined value.
+            /// </summary>
+            MFT_OWNERDRAW = 0x00000100,
+
+            /// <summary>
+            ///     Displays selected menu items using a radio-button mark instead of a check mark if the
+            ///     <see cref="MENUITEMINFO.hbmpChecked" /> member is <see cref="IntPtr.Zero" />.
+            /// </summary>
+            MFT_RADIOCHECK = 0x00000200,
+
+            /// <summary>
+            ///     Right-justifies the menu item and any subsequent items. This value is valid only if the menu item is in a menu
+            ///     bar.
+            /// </summary>
+            MFT_RIGHTJUSTIFY = 0x00004000,
+
+            /// <summary>
+            ///     Specifies that menus cascade right-to-left (the default is left-to-right). This is used to support
+            ///     right-to-left languages, such as Arabic and Hebrew.
+            /// </summary>
+            MFT_RIGHTORDER = 0x00002000,
+
+            /// <summary>
+            ///     Specifies that the menu item is a separator. A menu item separator appears as a horizontal dividing line. The
+            ///     dwTypeData and cch members are ignored. This value is valid only in a drop-down menu, submenu, or shortcut menu.
+            /// </summary>
+            MFT_SEPARATOR = 0x00000800,
+
+            /// <summary>
+            ///     Displays the menu item using a text string. The <see cref="MENUITEMINFO.dwTypeData" /> member is the pointer
+            ///     to a null-terminated string, and the <see cref="MENUITEMINFO.cch" /> member is the length of the string.
+            ///     <para><see cref="MFT_STRING" /> is replaced by <see cref="MenuMembersMask.MIIM_STRING" />.</para>
+            /// </summary>
+            MFT_STRING = 0x00000000
+        }
+    }
+}

--- a/src/User32.Desktop/User32+MenuMembersMask.cs
+++ b/src/User32.Desktop/User32+MenuMembersMask.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) to owners found in https://github.com/AArnott/pinvoke/blob/master/COPYRIGHT.md. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+
+namespace PInvoke
+{
+    using System;
+
+    /// <content>
+    /// Contains the <see cref="MenuMembersMask"/> nested type.
+    /// </content>
+    public partial class User32
+    {
+        /// <summary>Indicates the members to be retrieved or set in <see cref="MENUITEMINFO" />.</summary>
+        [Flags]
+        public enum MenuMembersMask
+        {
+            /// <summary>Retrieves or sets the <see cref="MENUITEMINFO.hbmpItem" /> member.</summary>
+            MIIM_BITMAP = 0x00000080,
+
+            /// <summary>Retrieves or sets the <see cref="MENUITEMINFO.hbmpChecked" /> and <see cref="MENUITEMINFO.hbmpUnchecked" />
+            ///     members.</summary>
+            MIIM_CHECKMARKS = 0x00000008,
+
+            /// <summary>Retrieves or sets the <see cref="MENUITEMINFO.dwItemData" /> member.</summary>
+            MIIM_DATA = 0x00000020,
+
+            /// <summary>Retrieves or sets the <see cref="MENUITEMINFO.fType" /> member.</summary>
+            MIIM_FTYPE = 0x00000100,
+
+            /// <summary>Retrieves or sets the <see cref="MENUITEMINFO.wID" /> member.</summary>
+            MIIM_ID = 0x00000002,
+
+            /// <summary>Retrieves or sets the <see cref="MENUITEMINFO.fState" /> member.</summary>
+            MIIM_STATE = 0x00000001,
+
+            /// <summary>Retrieves or sets the <see cref="MENUITEMINFO.dwTypeData" /> member.</summary>
+            MIIM_STRING = 0x00000040,
+
+            /// <summary>Retrieves or sets the <see cref="MENUITEMINFO.hSubMenu" /> member.</summary>
+            MIIM_SUBMENU = 0x00000004,
+
+            /// <summary>
+            ///     Retrieves or sets the <see cref="MENUITEMINFO.fType" /> and <see cref="MENUITEMINFO.dwTypeData" /> members.
+            ///     <para>MIIM_TYPE is replaced by <see cref="MIIM_BITMAP" />, <see cref="MIIM_FTYPE" />, and
+            ///         <see cref="MIIM_STRING" />.</para>
+            /// </summary>
+            MIIM_TYPE = 0x00000010
+        }
+    }
+}

--- a/src/User32.Desktop/User32+SafeHookHandle.cs
+++ b/src/User32.Desktop/User32+SafeHookHandle.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) to owners found in https://github.com/AArnott/pinvoke/blob/master/COPYRIGHT.md. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+
+namespace PInvoke
+{
+    using System;
+    using System.Runtime.InteropServices;
+
+    /// <content>
+    /// Contains the <see cref="SafeHookHandle"/> nested type.
+    /// </content>
+    public static partial class User32
+    {
+        /// <summary>
+        /// Represents a windows Hook that can be removed with <see cref="UnhookWindowsHookEx"/>.
+        /// </summary>
+        public class SafeHookHandle : SafeHandle
+        {
+            public static readonly SafeHookHandle Null = new SafeHookHandle();
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="SafeHookHandle"/> class.
+            /// </summary>
+            public SafeHookHandle()
+                : base(IntPtr.Zero, true)
+            {
+            }
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="SafeHookHandle"/> class.
+            /// </summary>
+            /// <param name="preexistingHandle">An object that represents the pre-existing handle to use.</param>
+            /// <param name="ownsHandle"><see langword="true"/> to reliably release the handle during the finalization
+            /// phase; <see langword="false"/> to prevent reliable release.</param>
+            public SafeHookHandle(IntPtr preexistingHandle, bool ownsHandle)
+                : base(IntPtr.Zero, ownsHandle)
+            {
+                this.SetHandle(preexistingHandle);
+            }
+
+            /// <inheritdoc />
+            public override bool IsInvalid => this.handle == IntPtr.Zero;
+
+            /// <inheritdoc />
+            protected override bool ReleaseHandle() => UnhookWindowsHookEx(this.handle);
+        }
+    }
+}

--- a/src/User32.Desktop/User32+WindowsHookType.cs
+++ b/src/User32.Desktop/User32+WindowsHookType.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) to owners found in https://github.com/AArnott/pinvoke/blob/master/COPYRIGHT.md. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+
+namespace PInvoke
+{
+    using System;
+
+    /// <content>Contains the <see cref="WindowsHookType" /> nested type.</content>
+    public partial class User32
+    {
+        /// <summary>The type of hook procedure to be installed by <see cref="SetWindowsHookEx(WindowsHookType,IntPtr,IntPtr,int)" />.</summary>
+        public enum WindowsHookType
+        {
+            /// <summary>
+            ///     Installs a hook procedure that monitors messages generated as a result of an input event in a dialog box,
+            ///     message box, menu, or scroll bar.
+            /// </summary>
+            WH_MSGFILTER = -1,
+
+            /// <summary>
+            ///     Installs a hook procedure that records input messages posted to the system message queue. This hook is useful
+            ///     for recording macros.
+            /// </summary>
+            WH_JOURNALRECORD = 0,
+
+            /// <summary>Installs a hook procedure that posts messages previously recorded by a WH_JOURNALRECORD hook procedure.</summary>
+            WH_JOURNALPLAYBACK = 1,
+
+            /// <summary>Installs a hook procedure that monitors keystroke messages.</summary>
+            WH_KEYBOARD = 2,
+
+            /// <summary>Installs a hook procedure that monitors messages posted to a message queue.</summary>
+            WH_GETMESSAGE = 3,
+
+            /// <summary>
+            ///     Installs a hook procedure that monitors messages before the system sends them to the destination window
+            ///     procedure.
+            /// </summary>
+            WH_CALLWNDPROC = 4,
+
+            /// <summary>Installs a hook procedure that receives notifications useful to a CBT application.</summary>
+            WH_CBT = 5,
+
+            /// <summary>
+            ///     nstalls a hook procedure that monitors messages generated as a result of an input event in a dialog box,
+            ///     message box, menu, or scroll bar. The hook procedure monitors these messages for all applications in the same
+            ///     desktop as the calling thread.
+            /// </summary>
+            WH_SYSMSGFILTER = 6,
+
+            /// <summary>Installs a hook procedure that monitors mouse messages.</summary>
+            WH_MOUSE = 7,
+
+            WH_HARDWARE = 8,
+
+            /// <summary>Installs a hook procedure useful for debugging other hook procedures.</summary>
+            WH_DEBUG = 9,
+
+            /// <summary>Installs a hook procedure that receives notifications useful to shell applications.</summary>
+            WH_SHELL = 10,
+
+            /// <summary>
+            ///     Installs a hook procedure that will be called when the application's foreground thread is about to become
+            ///     idle. This hook is useful for performing low priority tasks during idle time.
+            /// </summary>
+            WH_FOREGROUNDIDLE = 11,
+
+            /// <summary>
+            ///     Installs a hook procedure that monitors messages after they have been processed by the destination window
+            ///     procedure.
+            /// </summary>
+            WH_CALLWNDPROCRET = 12,
+
+            /// <summary>Installs a hook procedure that monitors low-level keyboard input events.</summary>
+            WH_KEYBOARD_LL = 13,
+
+            /// <summary>Installs a hook procedure that monitors low-level mouse input events.</summary>
+            WH_MOUSE_LL = 14
+        }
+    }
+}

--- a/src/User32.Desktop/User32.Desktop.csproj
+++ b/src/User32.Desktop/User32.Desktop.csproj
@@ -21,9 +21,14 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="User32+FlashWindowFlags.cs" />
+    <Compile Include="User32+FLASHWINFO.cs" />
+    <Compile Include="User32+SafeHookHandle.cs" />
+    <Compile Include="User32+GetAncestorFlags.cs" />
     <Compile Include="User32+SetWindowLongFlags.cs" />
     <Compile Include="User32+SetWindowPosFlags.cs" />
     <Compile Include="User32+WindowLongIndexFlags.cs" />
+    <Compile Include="User32+WindowsHookType.cs" />
     <Compile Include="User32+WindowShowStyle.cs" />
     <Compile Include="User32.cs" />
     <Compile Include="User32.Helpers.cs" />
@@ -42,6 +47,9 @@
     <Content Include="User32.exports.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), EnlistmentInfo.targets))\EnlistmentInfo.targets" Condition=" '$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), EnlistmentInfo.targets))' != '' " />

--- a/src/User32.Desktop/User32.Desktop.csproj
+++ b/src/User32.Desktop/User32.Desktop.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <Compile Include="User32+FlashWindowFlags.cs" />
     <Compile Include="User32+FLASHWINFO.cs" />
+    <Compile Include="User32+MapVirtualKeyTranslation.cs" />
     <Compile Include="User32+MenuItemFlags.cs" />
     <Compile Include="User32+MENUITEMINFO.cs" />
     <Compile Include="User32+MenuItemState.cs" />

--- a/src/User32.Desktop/User32.Desktop.csproj
+++ b/src/User32.Desktop/User32.Desktop.csproj
@@ -23,6 +23,11 @@
   <ItemGroup>
     <Compile Include="User32+FlashWindowFlags.cs" />
     <Compile Include="User32+FLASHWINFO.cs" />
+    <Compile Include="User32+MenuItemFlags.cs" />
+    <Compile Include="User32+MENUITEMINFO.cs" />
+    <Compile Include="User32+MenuItemState.cs" />
+    <Compile Include="User32+MenuItemType.cs" />
+    <Compile Include="User32+MenuMembersMask.cs" />
     <Compile Include="User32+SafeHookHandle.cs" />
     <Compile Include="User32+GetAncestorFlags.cs" />
     <Compile Include="User32+SetWindowLongFlags.cs" />

--- a/src/User32.Desktop/User32.cs
+++ b/src/User32.Desktop/User32.cs
@@ -373,6 +373,14 @@ namespace PInvoke
         [DllImport(nameof(User32), SetLastError = true, CharSet = CharSet.Unicode)]
         public static extern int MapVirtualKey(int uCode, MapVirtualKeyTranslation uMapType);
 
+        /// <summary>Retrieves the window handle to the active window attached to the calling thread's message queue.</summary>
+        /// <returns>
+        ///     The return value is the handle to the active window attached to the calling thread's message queue. Otherwise,
+        ///     the return value is <see cref="IntPtr.Zero" />.
+        /// </returns>
+        [DllImport(nameof(User32), SetLastError = true)]
+        public static extern IntPtr GetActiveWindow();
+
         /// <summary>
         ///     Removes a hook procedure installed in a hook chain by the
         ///     <see cref="SetWindowsHookEx(WindowsHookType,IntPtr,IntPtr,int)" /> function.

--- a/src/User32.Desktop/User32.cs
+++ b/src/User32.Desktop/User32.cs
@@ -11,6 +11,42 @@ namespace PInvoke
     /// </summary>
     public static partial class User32
     {
+        /// <summary>
+        ///     A bitmap that is drawn by the window that owns the menu. The application must process the WM_MEASUREITEM and
+        ///     WM_DRAWITEM messages.
+        /// </summary>
+        public static readonly IntPtr HBMMENU_CALLBACK = new IntPtr(-1);
+
+        /// <summary>Close button for the menu bar.</summary>
+        public static readonly IntPtr HBMMENU_MBAR_CLOSE = new IntPtr(5);
+
+        /// <summary>Disabled close button for the menu bar.</summary>
+        public static readonly IntPtr HBMMENU_MBAR_CLOSE_D = new IntPtr(6);
+
+        /// <summary>Minimize button for the menu bar.</summary>
+        public static readonly IntPtr HBMMENU_MBAR_MINIMIZE = new IntPtr(3);
+
+        /// <summary>Disabled minimize button for the menu bar.</summary>
+        public static readonly IntPtr HBMMENU_MBAR_MINIMIZE_D = new IntPtr(7);
+
+        /// <summary>Restore button for the menu bar.</summary>
+        public static readonly IntPtr HBMMENU_MBAR_RESTORE = new IntPtr(2);
+
+        /// <summary>Close button for the submenu.</summary>
+        public static readonly IntPtr HBMMENU_POPUP_CLOSE = new IntPtr(8);
+
+        /// <summary>Maximize button for the submenu.</summary>
+        public static readonly IntPtr HBMMENU_POPUP_MAXIMIZE = new IntPtr(10);
+
+        /// <summary>Minimize button for the submenu.</summary>
+        public static readonly IntPtr HBMMENU_POPUP_MINIMIZE = new IntPtr(11);
+
+        /// <summary>Restore button for the submenu.</summary>
+        public static readonly IntPtr HBMMENU_POPUP_RESTORE = new IntPtr(9);
+
+        /// <summary>Windows icon or the icon of the window specified in <see cref="MENUITEMINFO.dwItemData" />.</summary>
+        public static readonly IntPtr HBMMENU_SYSTEM = new IntPtr(1);
+
         public delegate int WindowsHookDelegate(int code, IntPtr wParam, IntPtr lParam);
 
         [DllImport(nameof(User32))]
@@ -213,6 +249,108 @@ namespace PInvoke
         public static extern bool FlashWindowEx(ref FLASHWINFO pwfi);
 
         /// <summary>
+        ///     Enables the application to access the window menu (also known as the system menu or the control menu) for
+        ///     copying and modifying.
+        /// </summary>
+        /// <param name="hWnd">A handle to the window that will own a copy of the window menu.</param>
+        /// <param name="bRevert">
+        ///     The action to be taken. If this parameter is FALSE, GetSystemMenu returns a handle to the copy of
+        ///     the window menu currently in use. The copy is initially identical to the window menu, but it can be modified. If
+        ///     this parameter is TRUE, GetSystemMenu resets the window menu back to the default state. The previous window menu,
+        ///     if any, is destroyed.
+        /// </param>
+        /// <returns>
+        ///     If the bRevert parameter is FALSE, the return value is a handle to a copy of the window menu. If the bRevert
+        ///     parameter is TRUE, the return value is NULL.
+        /// </returns>
+        [DllImport(nameof(User32), SetLastError = true)]
+        public static extern IntPtr GetSystemMenu(IntPtr hWnd, bool bRevert);
+
+        /// <summary>
+        ///     Appends a new item to the end of the specified menu bar, drop-down menu, submenu, or shortcut menu. You can
+        ///     use this function to specify the content, appearance, and behavior of the menu item.
+        /// </summary>
+        /// <param name="hMenu">A handle to the menu bar, drop-down menu, submenu, or shortcut menu to be changed.</param>
+        /// <param name="uFlags">Controls the appearance and behavior of the new menu item</param>
+        /// <param name="uIdNewItem">
+        ///     The identifier of the new menu item or, if the uFlags parameter is set to
+        ///     <see cref="MenuItemFlags.MF_POPUP" />, a handle to the drop-down menu or submenu.
+        /// </param>
+        /// <param name="lpNewItem">
+        ///     The content of the new menu item. The interpretation of lpNewItem depends on whether the uFlags parameter includes
+        ///     the following values.
+        ///     <para><see cref="MenuItemFlags.MF_BITMAP" />: Contains a bitmap handle.</para>
+        ///     <para>
+        ///         <see cref="MenuItemFlags.MF_OWNERDRAW" />: Contains an application-supplied value that can be used to
+        ///         maintain additional data related to the menu item. The value is in the itemData member of the structure pointed
+        ///         to by the lParam parameter of the WM_MEASUREITEM or WM_DRAWITEM message sent when the menu is created or its
+        ///         appearance is updated.
+        ///     </para>
+        ///     <para><see cref="MenuItemFlags.MF_STRING" />: Contains a pointer to a null-terminated string.</para>
+        /// </param>
+        /// <returns>
+        ///     If the function succeeds, the return value is true.
+        ///     <para>If the function fails, the return value is false. To get extended error information, call GetLastError.</para>
+        /// </returns>
+        [DllImport(nameof(User32), SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern bool AppendMenu(
+            IntPtr hMenu,
+            MenuItemFlags uFlags,
+            IntPtr uIdNewItem,
+            string lpNewItem);
+
+        /// <summary>Changes information about a menu item.</summary>
+        /// <param name="hMenu">A handle to the menu that contains the menu item.</param>
+        /// <param name="uItem">
+        ///     The identifier or position of the menu item to change. The meaning of this parameter depends on the
+        ///     value of <paramref name="fByPosition" />.
+        /// </param>
+        /// <param name="fByPosition">
+        ///     The meaning of uItem. If this parameter is FALSE, uItem is a menu item identifier. Otherwise,
+        ///     it is a menu item position.
+        /// </param>
+        /// <param name="lpmii">
+        ///     A <see cref="MENUITEMINFO" /> structure that contains information about the menu item and specifies
+        ///     which menu item attributes to change.
+        /// </param>
+        /// <returns>
+        ///     If the function succeeds, the return value is true.
+        ///     <para>If the function fails, the return value is false. To get extended error information, call GetLastError.</para>
+        /// </returns>
+        [DllImport(nameof(User32), SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern bool SetMenuItemInfo(
+            IntPtr hMenu,
+            uint uItem,
+            bool fByPosition,
+            [In] ref MENUITEMINFO lpmii);
+
+        /// <summary>Retrieves information about a menu item.</summary>
+        /// <param name="hMenu">A handle to the menu that contains the menu item.</param>
+        /// <param name="uItem">
+        ///     The identifier or position of the menu item to get information about. The meaning of this parameter
+        ///     depends on the value of <paramref name="fByPosition" />.
+        /// </param>
+        /// <param name="fByPosition">
+        ///     The meaning of <paramref name="uItem" />. If this parameter is FALSE,
+        ///     <paramref name="uItem" /> is a menu item identifier. Otherwise, it is a menu item position.
+        /// </param>
+        /// <param name="lpmii">
+        ///     A <see cref="MENUITEMINFO" /> structure that specifies the information to retrieve and receives
+        ///     information about the menu item. Note that you must set the cbSize member to <code>sizeof(MENUITEMINFO)</code>
+        ///     before calling this function (Either manually or by using <see cref="MENUITEMINFO.Create" />).
+        /// </param>
+        /// <returns>
+        ///     If the function succeeds, the return value is true.
+        ///     <para>If the function fails, the return value is false. To get extended error information, call GetLastError.</para>
+        /// </returns>
+        [DllImport(nameof(User32), SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern bool GetMenuItemInfo(
+            IntPtr hMenu,
+            uint uItem,
+            bool fByPosition,
+            ref MENUITEMINFO lpmii);
+
+        /// <summary>
         ///     Removes a hook procedure installed in a hook chain by the
         ///     <see cref="SetWindowsHookEx(WindowsHookType,IntPtr,IntPtr,int)" /> function.
         /// </summary>
@@ -221,8 +359,8 @@ namespace PInvoke
         ///     <see cref="SetWindowsHookEx(WindowsHookType,IntPtr,IntPtr,int)" />.
         /// </param>
         /// <returns>
-        ///     If the function succeeds, the return value is a nonzero value.
-        ///     <para>If the function fails, the return value is zero. To get extended error information, call GetLastError.</para>
+        ///     If the function succeeds, the return value is true.
+        ///     <para>If the function fails, the return value is false. To get extended error information, call GetLastError.</para>
         /// </returns>
         [DllImport(nameof(User32), SetLastError = true)]
         private static extern bool UnhookWindowsHookEx(IntPtr hhk);

--- a/src/User32.Desktop/User32.cs
+++ b/src/User32.Desktop/User32.cs
@@ -11,6 +11,8 @@ namespace PInvoke
     /// </summary>
     public static partial class User32
     {
+        public delegate int WindowsHookDelegate(int code, IntPtr wParam, IntPtr lParam);
+
         [DllImport(nameof(User32))]
         public static extern int SetWindowLong(IntPtr hWnd, WindowLongIndexFlags nIndex, SetWindowLongFlags dwNewLong);
 
@@ -45,5 +47,184 @@ namespace PInvoke
 
         [DllImport(nameof(User32))]
         public static extern int SendMessage(IntPtr hWnd, int wMsg, IntPtr wParam, IntPtr lParam);
+
+        /// <summary>
+        ///     Brings the thread that created the specified window into the foreground and activates the window. Keyboard
+        ///     input is directed to the window, and various visual cues are changed for the user. The system assigns a slightly
+        ///     higher priority to the thread that created the foreground window than it does to other threads.
+        /// </summary>
+        /// <param name="hWnd">A handle to the window that should be activated and brought to the foreground.</param>
+        /// <returns>
+        ///     If the window was brought to the foreground, the return value is true.
+        ///     <para>If the window was not brought to the foreground, the return value is false.</para>
+        /// </returns>
+        [DllImport(nameof(User32), SetLastError = true)]
+        public static extern bool SetForegroundWindow(IntPtr hWnd);
+
+        /// <summary>Retrieves the handle to the ancestor of the specified window.</summary>
+        /// <param name="hWnd">
+        ///     A handle to the window whose ancestor is to be retrieved. If this parameter is the desktop window,
+        ///     the function returns <see cref="IntPtr.Zero" />.
+        /// </param>
+        /// <param name="gaFlags">The ancestor to be retrieved.</param>
+        /// <returns>The handle to the ancestor window.</returns>
+        [DllImport(nameof(User32), SetLastError = true)]
+        public static extern IntPtr GetAncestor(IntPtr hWnd, GetAncestorFlags gaFlags);
+
+        /// <summary>
+        ///     Installs an application-defined hook procedure into a hook chain. You would install a hook procedure to
+        ///     monitor the system for certain types of events. These events are associated either with a specific thread or with
+        ///     all threads in the same desktop as the calling thread.
+        /// </summary>
+        /// <param name="idHook">The type of hook procedure to be installed.</param>
+        /// <param name="lpfn">
+        ///     A pointer to the hook procedure. If the <paramref name="dwThreadId" /> parameter is zero or
+        ///     specifies the identifier of a thread created by a different process, the <paramref name="lpfn" /> parameter must
+        ///     point to a hook procedure in a DLL. Otherwise, <paramref name="lpfn" /> can point to a hook procedure in the code
+        ///     associated with the current process.
+        /// </param>
+        /// <param name="hMod">
+        ///     A handle to the DLL containing the hook procedure pointed to by the <paramref name="lpfn" />
+        ///     parameter. The <paramref name="hMod" /> parameter must be set to <see cref="IntPtr.Zero" /> if the
+        ///     <paramref name="dwThreadId" /> parameter specifies a thread created by the current process and if the hook
+        ///     procedure is within the code associated with the current process.
+        /// </param>
+        /// <param name="dwThreadId">
+        ///     The identifier of the thread with which the hook procedure is to be associated. For desktop
+        ///     apps, if this parameter is zero, the hook procedure is associated with all existing threads running in the same
+        ///     desktop as the calling thread. For Windows Store apps, see the Remarks section.
+        /// </param>
+        /// <returns>
+        ///     If the function succeeds, the return value is the handle to the hook procedure.
+        ///     <para>
+        ///         If the function fails, the return value is an invalid handle. To get extended error information,
+        ///         call GetLastError.
+        ///     </para>
+        /// </returns>
+        [DllImport(nameof(User32), SetLastError = true)]
+        public static extern SafeHookHandle SetWindowsHookEx(
+            WindowsHookType idHook,
+            WindowsHookDelegate lpfn,
+            IntPtr hMod,
+            int dwThreadId);
+
+        /// <summary>
+        ///     Installs an application-defined hook procedure into a hook chain. You would install a hook procedure to
+        ///     monitor the system for certain types of events. These events are associated either with a specific thread or with
+        ///     all threads in the same desktop as the calling thread.
+        /// </summary>
+        /// <param name="idHook">The type of hook procedure to be installed.</param>
+        /// <param name="lpfn">
+        ///     A pointer to the hook procedure. If the <paramref name="dwThreadId" /> parameter is zero or
+        ///     specifies the identifier of a thread created by a different process, the <paramref name="lpfn" /> parameter must
+        ///     point to a hook procedure in a DLL. Otherwise, <paramref name="lpfn" /> can point to a hook procedure in the code
+        ///     associated with the current process.
+        /// </param>
+        /// <param name="hMod">
+        ///     A handle to the DLL containing the hook procedure pointed to by the <paramref name="lpfn" />
+        ///     parameter. The <paramref name="hMod" /> parameter must be set to <see cref="IntPtr.Zero" /> if the
+        ///     <paramref name="dwThreadId" /> parameter specifies a thread created by the current process and if the hook
+        ///     procedure is within the code associated with the current process.
+        /// </param>
+        /// <param name="dwThreadId">
+        ///     The identifier of the thread with which the hook procedure is to be associated. For desktop
+        ///     apps, if this parameter is zero, the hook procedure is associated with all existing threads running in the same
+        ///     desktop as the calling thread. For Windows Store apps, see the Remarks section.
+        /// </param>
+        /// <returns>
+        ///     If the function succeeds, the return value is the handle to the hook procedure.
+        ///     <para>
+        ///         If the function fails, the return value is an invalid handle. To get extended error information,
+        ///         call GetLastError.
+        ///     </para>
+        /// </returns>
+        [DllImport(nameof(User32), SetLastError = true)]
+        public static extern SafeHookHandle SetWindowsHookEx(
+            WindowsHookType idHook,
+            IntPtr lpfn,
+            IntPtr hMod,
+            int dwThreadId);
+
+        /// <summary>
+        ///     Passes the hook information to the next hook procedure in the current hook chain. A hook procedure can call
+        ///     this function either before or after processing the hook information.
+        /// </summary>
+        /// <param name="hhk">This parameter is ignored.</param>
+        /// <param name="nCode">
+        ///     The hook code passed to the current hook procedure. The next hook procedure uses this code to
+        ///     determine how to process the hook information.
+        /// </param>
+        /// <param name="wParam">
+        ///     The wParam value passed to the current hook procedure. The meaning of this parameter depends on
+        ///     the type of hook associated with the current hook chain.
+        /// </param>
+        /// <param name="lParam">
+        ///     The lParam value passed to the current hook procedure. The meaning of this parameter depends on
+        ///     the type of hook associated with the current hook chain.
+        /// </param>
+        /// <returns>
+        ///     This value is returned by the next hook procedure in the chain. The current hook procedure must also return
+        ///     this value. The meaning of the return value depends on the hook type. For more information, see the descriptions of
+        ///     the individual hook procedures.
+        /// </returns>
+        [DllImport(nameof(User32), SetLastError = true)]
+        public static extern int CallNextHookEx(
+            IntPtr hhk,
+            int nCode,
+            IntPtr wParam,
+            IntPtr lParam);
+
+        /// <summary>
+        ///     Sets the mouse capture to the specified window belonging to the current thread.SetCapture captures mouse input
+        ///     either when the mouse is over the capturing window, or when the mouse button was pressed while the mouse was over
+        ///     the capturing window and the button is still down. Only one window at a time can capture the mouse.
+        ///     <para>
+        ///         If the mouse cursor is over a window created by another thread, the system will direct mouse input to the
+        ///         specified window only if a mouse button is down.
+        ///     </para>
+        /// </summary>
+        /// <param name="hWnd">A handle to the window in the current thread that is to capture the mouse.</param>
+        /// <returns>
+        ///     The return value is a handle to the window that had previously captured the mouse. If there is no such window,
+        ///     the return value is <see cref="IntPtr.Zero" />.
+        /// </returns>
+        [DllImport(nameof(User32), SetLastError = true)]
+        public static extern IntPtr SetCapture(IntPtr hWnd);
+
+        /// <summary>
+        ///     Releases the mouse capture from a window in the current thread and restores normal mouse input processing. A
+        ///     window that has captured the mouse receives all mouse input, regardless of the position of the cursor, except when
+        ///     a mouse button is clicked while the cursor hot spot is in the window of another thread.
+        /// </summary>
+        /// <returns>
+        ///     If the function succeeds, the return value is true.
+        ///     <para>If the function fails, the return value is false. To get extended error information, call GetLastError.</para>
+        /// </returns>
+        [DllImport(nameof(User32), SetLastError = true)]
+        public static extern bool ReleaseCapture();
+
+        /// <summary>Flashes the specified window. It does not change the active state of the window.</summary>
+        /// <param name="pwfi">A pointer to a <see cref="FLASHWINFO" /> structure.</param>
+        /// <returns>
+        ///     The return value specifies the window's state before the call to the FlashWindowEx function. If the window
+        ///     caption was drawn as active before the call, the return value is nonzero. Otherwise, the return value is zero.
+        /// </returns>
+        [DllImport(nameof(User32), SetLastError = true)]
+        public static extern bool FlashWindowEx(ref FLASHWINFO pwfi);
+
+        /// <summary>
+        ///     Removes a hook procedure installed in a hook chain by the
+        ///     <see cref="SetWindowsHookEx(WindowsHookType,IntPtr,IntPtr,int)" /> function.
+        /// </summary>
+        /// <param name="hhk">
+        ///     A handle to the hook to be removed. This parameter is a hook handle obtained by a previous call to
+        ///     <see cref="SetWindowsHookEx(WindowsHookType,IntPtr,IntPtr,int)" />.
+        /// </param>
+        /// <returns>
+        ///     If the function succeeds, the return value is a nonzero value.
+        ///     <para>If the function fails, the return value is zero. To get extended error information, call GetLastError.</para>
+        /// </returns>
+        [DllImport(nameof(User32), SetLastError = true)]
+        private static extern bool UnhookWindowsHookEx(IntPtr hhk);
     }
 }

--- a/src/User32.Desktop/User32.cs
+++ b/src/User32.Desktop/User32.cs
@@ -351,6 +351,29 @@ namespace PInvoke
             ref MENUITEMINFO lpmii);
 
         /// <summary>
+        ///     Translates (maps) a virtual-key code into a scan code or character value, or translates a scan code into a
+        ///     virtual-key code.
+        ///     <para>
+        ///         To specify a handle to the keyboard layout to use for translating the specified code, use the MapVirtualKeyEx
+        ///         function.
+        ///     </para>
+        /// </summary>
+        /// <param name="uCode">
+        ///     The virtual key code or scan code for a key. How this value is interpreted depends on the value of
+        ///     the uMapType parameter.
+        /// </param>
+        /// <param name="uMapType">
+        ///     The translation to be performed. The value of this parameter depends on the value of the uCode
+        ///     parameter.
+        /// </param>
+        /// <returns>
+        ///     The return value is either a scan code, a virtual-key code, or a character value, depending on the value of
+        ///     <paramref name="uCode" /> and <paramref name="uMapType" />. If there is no translation, the return value is zero.
+        /// </returns>
+        [DllImport(nameof(User32), SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern int MapVirtualKey(int uCode, MapVirtualKeyTranslation uMapType);
+
+        /// <summary>
         ///     Removes a hook procedure installed in a hook chain by the
         ///     <see cref="SetWindowsHookEx(WindowsHookType,IntPtr,IntPtr,int)" /> function.
         /// </summary>


### PR DESCRIPTION
I searched our internal codebase for all `user32.dll` usages and added all the missing ones :
- SetForegroundWindow
- GetAncestor
- SetWindowsHookEx
- CallNextHookEx
- UnhookWindowsHookEx
- SetCapture
- ReleaseCapture
- FlashWindowEx
- GetSystemMenu
- AppendMenu
- SetMenuItemInfo
- GetMenuItemInfo
- MapVirtualKey
- GetActiveWindow

Remarks :
- I placed the constants directly at the top of `User32.cs` I don't know where we want to place them.
- `SetWindowsHookEx` is present twice as the delegate version would be unusable for the remote-dll case but it's the easiest way when the hook is on a process-local window.
- I tried to have `int` instead of `uint`
- I investigated the creation of a `SafeHandle` for menu items, but they often shouldn't be destroyed after usage so it would produce bugs.
