### PR TITLE
Expose BCrypt methods with pointers and ArraySegments

### DIFF
--- a/src/BCrypt.Tests/BCrypt.cs
+++ b/src/BCrypt.Tests/BCrypt.cs
@@ -187,6 +187,27 @@ public class BCrypt
         }
     }
 
+    [Fact]
+    public unsafe void EncryptDecrypt_PointerCornerCases()
+    {
+        using (var provider = BCryptOpenAlgorithmProvider(AlgorithmIdentifiers.BCRYPT_AES_ALGORITHM))
+        {
+            byte[] keyMaterial = new byte[128 / 8];
+            using (var key = BCryptGenerateSymmetricKey(provider, keyMaterial))
+            {
+                int length;
+                BCryptEncrypt(
+                    key,
+                    new ArraySegment<byte>(new byte[0]),
+                    null,
+                    default(ArraySegment<byte>),
+                    new ArraySegment<byte>(new byte[1]),
+                    out length,
+                    BCryptEncryptFlags.None);
+            }
+        }
+    }
+
     /// <summary>
     /// Demonstrates use of an authenticated block chaining mode
     /// that requires use of several more struct types than

--- a/src/BCrypt.Tests/BCrypt.cs
+++ b/src/BCrypt.Tests/BCrypt.cs
@@ -148,8 +148,8 @@ public class BCrypt
                     key,
                     new ArraySegment<byte>(plainTextPadded),
                     null,
-                    default(ArraySegment<byte>),
-                    default(ArraySegment<byte>),
+                    null,
+                    null,
                     out cipherTextLength,
                     BCryptEncryptFlags.None).ThrowOnError();
 
@@ -158,7 +158,7 @@ public class BCrypt
                     key,
                     new ArraySegment<byte>(plainTextPadded),
                     null,
-                    default(ArraySegment<byte>),
+                    null,
                     new ArraySegment<byte>(cipherText),
                     out cipherTextLength,
                     BCryptEncryptFlags.None).ThrowOnError();
@@ -176,7 +176,7 @@ public class BCrypt
                     key,
                     new ArraySegment<byte>(cipherText),
                     null,
-                    default(ArraySegment<byte>),
+                    null,
                     new ArraySegment<byte>(decryptedText),
                     out cbDecrypted,
                     BCryptEncryptFlags.None).ThrowOnError();
@@ -201,6 +201,19 @@ public class BCrypt
                     new ArraySegment<byte>(new byte[0]),
                     null,
                     default(ArraySegment<byte>),
+                    new ArraySegment<byte>(new byte[1]),
+                    out length,
+                    BCryptEncryptFlags.None);
+            }
+
+            using (var key = BCryptGenerateSymmetricKey(provider, keyMaterial))
+            {
+                int length;
+                BCryptEncrypt(
+                    key,
+                    new ArraySegment<byte>(new byte[0]),
+                    null,
+                    null,
                     new ArraySegment<byte>(new byte[1]),
                     out length,
                     BCryptEncryptFlags.None);

--- a/src/BCrypt/BCrypt.Helpers.cs
+++ b/src/BCrypt/BCrypt.Helpers.cs
@@ -320,6 +320,35 @@ namespace PInvoke
             return new ArraySegment<byte>(cipherText, 0, length);
         }
 
+        /// <summary>
+        /// Encrypts a block of data.
+        /// </summary>
+        /// <param name="key">
+        /// The handle of the key to use to encrypt the data. This handle is obtained from one of the key creation functions, such as <see cref="BCryptGenerateSymmetricKey(SafeAlgorithmHandle, byte[], byte[], BCryptGenerateSymmetricKeyFlags)"/>, <see cref="BCryptGenerateKeyPair(SafeAlgorithmHandle, int)"/>, or <see cref="BCryptImportKey(SafeAlgorithmHandle, string, byte[], SafeKeyHandle, byte[], BCryptImportKeyFlags)"/>.
+        /// </param>
+        /// <param name="input">
+        /// The address of a buffer that contains the plaintext to be encrypted. The cbInput parameter contains the size of the plaintext to encrypt.
+        /// </param>
+        /// <param name="paddingInfo">
+        /// A pointer to a structure that contains padding information. This parameter is only used with asymmetric keys and authenticated encryption modes. If an authenticated encryption mode is used, this parameter must point to a BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO structure. If asymmetric keys are used, the type of structure this parameter points to is determined by the value of the dwFlags parameter. Otherwise, the parameter must be set to NULL.
+        /// </param>
+        /// <param name="iv">
+        /// The address of a buffer that contains the initialization vector (IV) to use during encryption. The cbIV parameter contains the size of this buffer. This function will modify the contents of this buffer. If you need to reuse the IV later, make sure you make a copy of this buffer before calling this function.
+        /// This parameter is optional and can be NULL if no IV is used.
+        /// The required size of the IV can be obtained by calling the <see cref="BCryptGetProperty(SafeHandle, string, BCryptGetPropertyFlags)"/> function to get the BCRYPT_BLOCK_LENGTH property.This will provide the size of a block for the algorithm, which is also the size of the IV.
+        /// </param>
+        /// <param name="output">
+        /// The address of the buffer that receives the ciphertext produced by this function. For more information, see Remarks.
+        /// If this parameter is NULL, the <see cref="BCryptEncrypt(SafeKeyHandle, byte[], IntPtr, byte[], BCryptEncryptFlags)"/> function calculates the size needed for the ciphertext of the data passed in the <paramref name="input"/> parameter. In this case, the location pointed to by the <paramref name="outputLength"/> parameter contains this size, and the function returns <see cref="NTStatus.STATUS_SUCCESS"/>.The <paramref name="paddingInfo"/> parameter is not modified.
+        /// If the values of both the <paramref name="output"/> and <paramref name="input"/> parameters are NULL, an error is returned unless an authenticated encryption algorithm is in use.In the latter case, the call is treated as an authenticated encryption call with zero length data, and the authentication tag is returned in the <paramref name="paddingInfo"/> parameter.
+        /// </param>
+        /// <param name="outputLength">
+        /// Receives the number of bytes copied to the <paramref name="output"/> buffer. If <paramref name="output"/> is NULL, this receives the size, in bytes, required for the ciphertext.
+        /// </param>
+        /// <param name="flags">
+        /// A set of flags that modify the behavior of this function. The allowed set of flags depends on the type of key specified by the hKey parameter.
+        /// </param>
+        /// <returns>The encrypted ciphertext.</returns>
         public static unsafe NTStatus BCryptEncrypt(
             SafeKeyHandle key,
             ArraySegment<byte> input,
@@ -413,6 +442,35 @@ namespace PInvoke
             return new ArraySegment<byte>(plainText, 0, length);
         }
 
+        /// <summary>
+        /// Decrypts a block of data.
+        /// </summary>
+        /// <param name="key">
+        /// The handle of the key to use to decrypt the data. This handle is obtained from one of the key creation functions, such as <see cref="BCryptGenerateSymmetricKey(SafeAlgorithmHandle, byte[], byte[], BCryptGenerateSymmetricKeyFlags)"/>, <see cref="BCryptGenerateKeyPair(SafeAlgorithmHandle, int)"/>, or <see cref="BCryptImportKey(SafeAlgorithmHandle, string, byte[], SafeKeyHandle, byte[], BCryptImportKeyFlags)"/>.
+        /// </param>
+        /// <param name="input">
+        /// The address of a buffer that contains the ciphertext to be decrypted. For more information, see Remarks.
+        /// </param>
+        /// <param name="paddingInfo">
+        /// A pointer to a structure that contains padding information. This parameter is only used with asymmetric keys and authenticated encryption modes. If an authenticated encryption mode is used, this parameter must point to a BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO structure. If asymmetric keys are used, the type of structure this parameter points to is determined by the value of the <paramref name="flags"/> parameter. Otherwise, the parameter must be set to NULL.
+        /// </param>
+        /// <param name="iv">
+        /// The address of a buffer that contains the initialization vector (IV) to use during decryption. This function will modify the contents of this buffer. If you need to reuse the IV later, make sure you make a copy of this buffer before calling this function.
+        /// This parameter is optional and can be NULL if no IV is used.
+        /// The required size of the IV can be obtained by calling the <see cref="BCryptGetProperty(SafeHandle, string, BCryptGetPropertyFlags)"/> function to get the <see cref="PropertyNames.BCRYPT_BLOCK_LENGTH"/> property. This will provide the size of a block for the algorithm, which is also the size of the IV.
+        /// </param>
+        /// <param name="output">
+        /// The address of a buffer to receive the plaintext produced by this function. The cbOutput parameter contains the size of this buffer. For more information, see Remarks.
+        /// If this parameter is NULL, the <see cref="BCryptDecrypt(SafeKeyHandle, byte[], IntPtr, byte[], BCryptEncryptFlags)"/> function calculates the size required for the plaintext of the encrypted data passed in the <paramref name="input"/> parameter.In this case, the location pointed to by the <paramref name="outputLength"/> parameter contains this size, and the function returns <see cref="NTStatus.STATUS_SUCCESS"/>.
+        /// If the values of both the <paramref name="output"/> and <paramref name="input" /> parameters are NULL, an error is returned unless an authenticated encryption algorithm is in use.In the latter case, the call is treated as an authenticated encryption call with zero length data, and the authentication tag, passed in the <paramref name="paddingInfo"/> parameter, is verified.
+        /// </param>
+        /// <param name="outputLength">
+        /// A pointer to a ULONG variable to receive the number of bytes copied to the <paramref name="output"/> buffer. If <paramref name="output"/> is NULL, this receives the size, in bytes, required for the plaintext.
+        /// </param>
+        /// <param name="flags">
+        /// A set of flags that modify the behavior of this function. The allowed set of flags depends on the type of key specified by the <paramref name="key"/> parameter.
+        /// </param>
+        /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
         public static unsafe NTStatus BCryptDecrypt(
             SafeKeyHandle key,
             ArraySegment<byte> input,

--- a/src/BCrypt/BCrypt.Helpers.cs
+++ b/src/BCrypt/BCrypt.Helpers.cs
@@ -13,9 +13,14 @@ namespace PInvoke
     public static partial class BCrypt
     {
         /// <summary>
-        /// An array whose content doesn't matter.
+        /// An array that fills in for a null one.
         /// </summary>
-        private static readonly byte[] OneElementDummyArray = new byte[1];
+        private static readonly byte[] NonEmptyArrayReplacesNull = new byte[1];
+
+        /// <summary>
+        /// An array that fills in for one with no elements.
+        /// </summary>
+        private static readonly byte[] NonEmptyArrayReplacesEmpty = new byte[1];
 
         /// <summary>
         /// Loads and initializes a CNG provider.
@@ -361,9 +366,9 @@ namespace PInvoke
             // We have to make sure that the input, which may be null, does
             // not cause a NRE in our fixed expressions below, which cannot do
             // conditional expressions due to C# constraints.
-            EnsureNotNull(ref input);
-            EnsureNotNull(ref iv);
-            EnsureNotNull(ref output);
+            EnsureNotNullOrEmpty(ref input);
+            EnsureNotNullOrEmpty(ref iv);
+            EnsureNotNullOrEmpty(ref output);
 
             fixed (byte* pbInput = &input.Array[input.Offset])
             fixed (byte* pbOutput = &output.Array[output.Offset])
@@ -483,9 +488,9 @@ namespace PInvoke
             // We have to make sure that the input, which may be null, does
             // not cause a NRE in our fixed expressions below, which cannot do
             // conditional expressions due to C# constraints.
-            EnsureNotNull(ref input);
-            EnsureNotNull(ref iv);
-            EnsureNotNull(ref output);
+            EnsureNotNullOrEmpty(ref input);
+            EnsureNotNullOrEmpty(ref iv);
+            EnsureNotNullOrEmpty(ref output);
 
             fixed (byte* pbInput = &input.Array[input.Offset])
             fixed (byte* pbOutput = &output.Array[output.Offset])
@@ -662,25 +667,29 @@ namespace PInvoke
         /// Ensures that the specified byte array is not null.
         /// </summary>
         /// <param name="buffer">The byte buffer to replace with a non-null buffer, if null.</param>
-        private static void EnsureNotNull(ref ArraySegment<byte> buffer)
+        private static void EnsureNotNullOrEmpty(ref ArraySegment<byte> buffer)
         {
             if (buffer.Array == null)
             {
-                buffer = new ArraySegment<byte>(OneElementDummyArray, 0, 0);
+                buffer = new ArraySegment<byte>(NonEmptyArrayReplacesNull, 0, 0);
+            }
+            else if (buffer.Array.Length == 0)
+            {
+                buffer = new ArraySegment<byte>(NonEmptyArrayReplacesEmpty, 0, 0);
             }
         }
 
         /// <summary>
         /// Returns the specified <paramref name="pointer"/>,
         /// or null if <paramref name="buffer"/> was null before a call to
-        /// <see cref="EnsureNotNull(ref ArraySegment{byte})"/>.
+        /// <see cref="EnsureNotNullOrEmpty(ref ArraySegment{byte})"/>.
         /// </summary>
         /// <param name="buffer">The buffer which may have originally been null.</param>
         /// <param name="pointer">The pointer to some element in the buffer.</param>
         /// <returns>The <paramref name="pointer"/> or <c>null</c>.</returns>
         private static unsafe byte* ArrayOrOriginalNull(ArraySegment<byte> buffer, byte* pointer)
         {
-            return buffer.Array == OneElementDummyArray ? null : pointer;
+            return buffer.Array == NonEmptyArrayReplacesNull ? null : pointer;
         }
     }
 }

--- a/src/BCrypt/BCrypt.Helpers.cs
+++ b/src/BCrypt/BCrypt.Helpers.cs
@@ -356,34 +356,38 @@ namespace PInvoke
         /// <returns>The encrypted ciphertext.</returns>
         public static unsafe NTStatus BCryptEncrypt(
             SafeKeyHandle key,
-            ArraySegment<byte> input,
+            ArraySegment<byte>? input,
             void* paddingInfo,
-            ArraySegment<byte> iv,
-            ArraySegment<byte> output,
+            ArraySegment<byte>? iv,
+            ArraySegment<byte>? output,
             out int outputLength,
             BCryptEncryptFlags flags)
         {
+            var inputLocal = input ?? default(ArraySegment<byte>);
+            var ivLocal = iv ?? default(ArraySegment<byte>);
+            var outputLocal = output ?? default(ArraySegment<byte>);
+
             // We have to make sure that the input, which may be null, does
             // not cause a NRE in our fixed expressions below, which cannot do
             // conditional expressions due to C# constraints.
-            EnsureNotNullOrEmpty(ref input);
-            EnsureNotNullOrEmpty(ref iv);
-            EnsureNotNullOrEmpty(ref output);
+            EnsureNotNullOrEmpty(ref inputLocal);
+            EnsureNotNullOrEmpty(ref ivLocal);
+            EnsureNotNullOrEmpty(ref outputLocal);
 
-            fixed (byte* pbInput = &input.Array[input.Offset])
-            fixed (byte* pbOutput = &output.Array[output.Offset])
-            fixed (byte* pbIV = &iv.Array[iv.Offset])
+            fixed (byte* pbInput = &inputLocal.Array[inputLocal.Offset])
+            fixed (byte* pbOutput = &outputLocal.Array[outputLocal.Offset])
+            fixed (byte* pbIV = &ivLocal.Array[ivLocal.Offset])
             {
                 // As we call the P/Invoke method, restore any nulls that were originally there.
                 return BCryptEncrypt(
                     key,
-                    ArrayOrOriginalNull(input, pbInput),
-                    input.Count,
+                    ArrayOrOriginalNull(inputLocal, pbInput),
+                    inputLocal.Count,
                     paddingInfo,
-                    ArrayOrOriginalNull(iv, pbIV),
-                    iv.Count,
-                    ArrayOrOriginalNull(output, pbOutput),
-                    output.Count,
+                    ArrayOrOriginalNull(ivLocal, pbIV),
+                    ivLocal.Count,
+                    ArrayOrOriginalNull(outputLocal, pbOutput),
+                    outputLocal.Count,
                     out outputLength,
                     flags);
             }
@@ -478,34 +482,38 @@ namespace PInvoke
         /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
         public static unsafe NTStatus BCryptDecrypt(
             SafeKeyHandle key,
-            ArraySegment<byte> input,
+            ArraySegment<byte>? input,
             void* paddingInfo,
-            ArraySegment<byte> iv,
-            ArraySegment<byte> output,
+            ArraySegment<byte>? iv,
+            ArraySegment<byte>? output,
             out int outputLength,
             BCryptEncryptFlags flags)
         {
+            var inputLocal = input ?? default(ArraySegment<byte>);
+            var ivLocal = iv ?? default(ArraySegment<byte>);
+            var outputLocal = output ?? default(ArraySegment<byte>);
+
             // We have to make sure that the input, which may be null, does
             // not cause a NRE in our fixed expressions below, which cannot do
             // conditional expressions due to C# constraints.
-            EnsureNotNullOrEmpty(ref input);
-            EnsureNotNullOrEmpty(ref iv);
-            EnsureNotNullOrEmpty(ref output);
+            EnsureNotNullOrEmpty(ref inputLocal);
+            EnsureNotNullOrEmpty(ref ivLocal);
+            EnsureNotNullOrEmpty(ref outputLocal);
 
-            fixed (byte* pbInput = &input.Array[input.Offset])
-            fixed (byte* pbOutput = &output.Array[output.Offset])
-            fixed (byte* pbIV = &iv.Array[iv.Offset])
+            fixed (byte* pbInput = &inputLocal.Array[inputLocal.Offset])
+            fixed (byte* pbOutput = &outputLocal.Array[outputLocal.Offset])
+            fixed (byte* pbIV = &ivLocal.Array[ivLocal.Offset])
             {
                 // As we call the P/Invoke method, restore any nulls that were originally there.
                 return BCryptDecrypt(
                     key,
-                    ArrayOrOriginalNull(input, pbInput),
-                    input.Count,
+                    ArrayOrOriginalNull(inputLocal, pbInput),
+                    inputLocal.Count,
                     paddingInfo,
-                    ArrayOrOriginalNull(iv, pbIV),
-                    iv.Count,
-                    ArrayOrOriginalNull(output, pbOutput),
-                    output.Count,
+                    ArrayOrOriginalNull(ivLocal, pbIV),
+                    ivLocal.Count,
+                    ArrayOrOriginalNull(outputLocal, pbOutput),
+                    outputLocal.Count,
                     out outputLength,
                     flags);
             }

--- a/src/BCrypt/BCrypt.cs
+++ b/src/BCrypt/BCrypt.cs
@@ -289,7 +289,7 @@ namespace PInvoke
             SafeKeyHandle hKey,
             byte* pbInput,
             int cbInput,
-            byte* pPaddingInfo,
+            void* pPaddingInfo,
             byte* pbIV,
             int cbIV,
             byte* pbOutput,

--- a/src/BCrypt/BCrypt.cs
+++ b/src/BCrypt/BCrypt.cs
@@ -144,6 +144,58 @@ namespace PInvoke
             BCryptEncryptFlags dwFlags);
 
         /// <summary>
+        /// Encrypts a block of data.
+        /// </summary>
+        /// <param name="hKey">
+        /// The handle of the key to use to encrypt the data. This handle is obtained from one of the key creation functions, such as <see cref="BCryptGenerateSymmetricKey(SafeAlgorithmHandle, byte[], byte[], BCryptGenerateSymmetricKeyFlags)"/>, <see cref="BCryptGenerateKeyPair(SafeAlgorithmHandle, int)"/>, or <see cref="BCryptImportKey(SafeAlgorithmHandle, string, byte[], SafeKeyHandle, byte[], BCryptImportKeyFlags)"/>.
+        /// </param>
+        /// <param name="pbInput">
+        /// The address of a buffer that contains the plaintext to be encrypted. The cbInput parameter contains the size of the plaintext to encrypt.
+        /// </param>
+        /// <param name="cbInput">
+        /// The number of bytes in the pbInput buffer to encrypt.
+        /// </param>
+        /// <param name="pPaddingInfo">
+        /// A pointer to a structure that contains padding information. This parameter is only used with asymmetric keys and authenticated encryption modes. If an authenticated encryption mode is used, this parameter must point to a BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO structure. If asymmetric keys are used, the type of structure this parameter points to is determined by the value of the dwFlags parameter. Otherwise, the parameter must be set to NULL.
+        /// </param>
+        /// <param name="pbIV">
+        /// The address of a buffer that contains the initialization vector (IV) to use during encryption. The cbIV parameter contains the size of this buffer. This function will modify the contents of this buffer. If you need to reuse the IV later, make sure you make a copy of this buffer before calling this function.
+        /// This parameter is optional and can be NULL if no IV is used.
+        /// The required size of the IV can be obtained by calling the <see cref="BCryptGetProperty(SafeHandle, string, BCryptGetPropertyFlags)"/> function to get the BCRYPT_BLOCK_LENGTH property.This will provide the size of a block for the algorithm, which is also the size of the IV.
+        /// </param>
+        /// <param name="cbIV">The size, in bytes, of the pbIV buffer.</param>
+        /// <param name="pbOutput">
+        /// The address of the buffer that receives the ciphertext produced by this function. The <paramref name="cbOutput"/> parameter contains the size of this buffer. For more information, see Remarks.
+        /// If this parameter is NULL, the <see cref="BCryptEncrypt(SafeKeyHandle, byte[], IntPtr, byte[], BCryptEncryptFlags)"/> function calculates the size needed for the ciphertext of the data passed in the <paramref name="pbInput"/> parameter. In this case, the location pointed to by the <paramref name="pcbResult"/> parameter contains this size, and the function returns <see cref="NTStatus.STATUS_SUCCESS"/>.The <paramref name="pPaddingInfo"/> parameter is not modified.
+        /// If the values of both the <paramref name="pbOutput"/> and <paramref name="pbInput"/> parameters are NULL, an error is returned unless an authenticated encryption algorithm is in use.In the latter case, the call is treated as an authenticated encryption call with zero length data, and the authentication tag is returned in the <paramref name="pPaddingInfo"/> parameter.
+        /// </param>
+        /// <param name="cbOutput">
+        /// The size, in bytes, of the <paramref name="pbOutput"/> buffer. This parameter is ignored if the <paramref name="pbOutput"/> parameter is NULL.
+        /// </param>
+        /// <param name="pcbResult">
+        /// A pointer to a ULONG variable that receives the number of bytes copied to the <paramref name="pbOutput"/> buffer. If <paramref name="pbOutput"/> is NULL, this receives the size, in bytes, required for the ciphertext.
+        /// </param>
+        /// <param name="dwFlags">
+        /// A set of flags that modify the behavior of this function. The allowed set of flags depends on the type of key specified by the hKey parameter.
+        /// </param>
+        /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
+        /// <remarks>
+        /// The <paramref name="pbInput"/> and <paramref name="pbOutput"/> parameters can point to the same buffer. In this case, this function will perform the encryption in place. It is possible that the encrypted data size will be larger than the unencrypted data size, so the buffer must be large enough to hold the encrypted data.
+        /// </remarks>
+        [DllImport(nameof(BCrypt), SetLastError = true)]
+        public static unsafe extern NTStatus BCryptEncrypt(
+            SafeKeyHandle hKey,
+            byte* pbInput,
+            int cbInput,
+            void* pPaddingInfo,
+            byte* pbIV,
+            int cbIV,
+            byte* pbOutput,
+            int cbOutput,
+            out int pcbResult,
+            BCryptEncryptFlags dwFlags);
+
+        /// <summary>
         /// Decrypts a block of data.
         /// </summary>
         /// <param name="hKey">
@@ -190,6 +242,57 @@ namespace PInvoke
             [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 5)] byte[] pbIV,
             int cbIV,
             [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 8)] byte[] pbOutput,
+            int cbOutput,
+            out int pcbResult,
+            BCryptEncryptFlags dwFlags);
+
+        /// <summary>
+        /// Decrypts a block of data.
+        /// </summary>
+        /// <param name="hKey">
+        /// The handle of the key to use to decrypt the data. This handle is obtained from one of the key creation functions, such as <see cref="BCryptGenerateSymmetricKey(SafeAlgorithmHandle, byte[], byte[], BCryptGenerateSymmetricKeyFlags)"/>, <see cref="BCryptGenerateKeyPair(SafeAlgorithmHandle, int)"/>, or <see cref="BCryptImportKey(SafeAlgorithmHandle, string, byte[], SafeKeyHandle, byte[], BCryptImportKeyFlags)"/>.
+        /// </param>
+        /// <param name="pbInput">
+        /// The address of a buffer that contains the ciphertext to be decrypted. The <paramref name="cbInput"/> parameter contains the size of the ciphertext to decrypt. For more information, see Remarks.
+        /// </param>
+        /// <param name="cbInput">
+        /// The number of bytes in the <paramref name="pbInput"/> buffer to decrypt.
+        /// </param>
+        /// <param name="pPaddingInfo">
+        /// A pointer to a structure that contains padding information. This parameter is only used with asymmetric keys and authenticated encryption modes. If an authenticated encryption mode is used, this parameter must point to a BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO structure. If asymmetric keys are used, the type of structure this parameter points to is determined by the value of the <paramref name="dwFlags"/> parameter. Otherwise, the parameter must be set to NULL.
+        /// </param>
+        /// <param name="pbIV">
+        /// The address of a buffer that contains the initialization vector (IV) to use during decryption. The <paramref name="cbIV"/> parameter contains the size of this buffer. This function will modify the contents of this buffer. If you need to reuse the IV later, make sure you make a copy of this buffer before calling this function.
+        /// This parameter is optional and can be NULL if no IV is used.
+        /// The required size of the IV can be obtained by calling the <see cref="BCryptGetProperty(SafeHandle, string, BCryptGetPropertyFlags)"/> function to get the <see cref="PropertyNames.BCRYPT_BLOCK_LENGTH"/> property. This will provide the size of a block for the algorithm, which is also the size of the IV.
+        /// </param>
+        /// <param name="cbIV">
+        /// The size, in bytes, of the <paramref name="pbIV"/> buffer.
+        /// </param>
+        /// <param name="pbOutput">
+        /// The address of a buffer to receive the plaintext produced by this function. The cbOutput parameter contains the size of this buffer. For more information, see Remarks.
+        /// If this parameter is NULL, the <see cref="BCryptDecrypt(SafeKeyHandle, byte[], IntPtr, byte[], BCryptEncryptFlags)"/> function calculates the size required for the plaintext of the encrypted data passed in the <paramref name="pbInput"/> parameter.In this case, the location pointed to by the <paramref name="pcbResult"/> parameter contains this size, and the function returns <see cref="NTStatus.STATUS_SUCCESS"/>.
+        /// If the values of both the <paramref name="pbOutput"/> and <paramref name="pbInput" /> parameters are NULL, an error is returned unless an authenticated encryption algorithm is in use.In the latter case, the call is treated as an authenticated encryption call with zero length data, and the authentication tag, passed in the <paramref name="pPaddingInfo"/> parameter, is verified.
+        /// </param>
+        /// <param name="cbOutput">
+        /// The size, in bytes, of the <paramref name="pbOutput"/> buffer. This parameter is ignored if the <paramref name="pbOutput"/> parameter is NULL.
+        /// </param>
+        /// <param name="pcbResult">
+        /// A pointer to a ULONG variable to receive the number of bytes copied to the <paramref name="pbOutput"/> buffer. If <paramref name="pbOutput"/> is NULL, this receives the size, in bytes, required for the plaintext.
+        /// </param>
+        /// <param name="dwFlags">
+        /// A set of flags that modify the behavior of this function. The allowed set of flags depends on the type of key specified by the <paramref name="hKey"/> parameter.
+        /// </param>
+        /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
+        [DllImport(nameof(BCrypt), SetLastError = true)]
+        public static unsafe extern NTStatus BCryptDecrypt(
+            SafeKeyHandle hKey,
+            byte* pbInput,
+            int cbInput,
+            byte* pPaddingInfo,
+            byte* pbIV,
+            int cbIV,
+            byte* pbOutput,
             int cbOutput,
             out int pcbResult,
             BCryptEncryptFlags dwFlags);


### PR DESCRIPTION
Add P/Invoke overloads for encryption/decryption that accept pointers so that callers can pass in offsets to byte arrays, saving on memory allocation and copying.
Also add helper methods that take `ArraySegment<byte>` so that the special memory handling required can be centralized.

Note the `EnsureNotNull` and `ArrayOrOriginalNull` helper methods may be more useful than just for BCrypt. We may want to find a good place for them to go for anyone who wants to expose array pointers as ArraySegments to make it easier on callers while still allowing nulls.
