### PR TITLE
Fix build break due to missing dependencies

### DIFF
--- a/src/AdvApi32.Desktop/project.json
+++ b/src/AdvApi32.Desktop/project.json
@@ -1,6 +1,7 @@
 ﻿{
   "supports": { },
   "dependencies": {
+    "NuProj.Common": "0.10.10-beta-g13363167e1"
   },
   "frameworks": {
     ".NETFramework,Version=v4.0": { }

--- a/src/AdvApi32/project.json
+++ b/src/AdvApi32/project.json
@@ -1,6 +1,7 @@
 ﻿{
   "supports": { },
   "dependencies": {
+    "NuProj.Common": "0.10.10-beta-g13363167e1"
   },
   "frameworks": {
     ".NETPortable,Version=v4.0,Profile=Profile92": { }

--- a/src/BCrypt/project.json
+++ b/src/BCrypt/project.json
@@ -1,6 +1,7 @@
 ﻿{
   "supports": {},
   "dependencies": {
+    "NuProj.Common": "0.10.10-beta-g13363167e1"
   },
   "frameworks": {
     ".NETPortable,Version=v4.0,Profile=Profile92": {}

--- a/src/DbgHelp/project.json
+++ b/src/DbgHelp/project.json
@@ -1,6 +1,7 @@
 ﻿{
   "supports": { },
   "dependencies": {
+    "NuProj.Common": "0.10.10-beta-g13363167e1"
   },
   "frameworks": {
     ".NETPortable,Version=v4.0,Profile=Profile92": { }

--- a/src/Gdi32.Desktop/project.json
+++ b/src/Gdi32.Desktop/project.json
@@ -1,6 +1,7 @@
 ﻿{
   "supports": {},
   "dependencies": {
+    "NuProj.Common": "0.10.10-beta-g13363167e1"
   },
   "frameworks": {
     ".NETFramework,Version=v4.0": { }

--- a/src/Hid.Desktop/project.json
+++ b/src/Hid.Desktop/project.json
@@ -1,6 +1,7 @@
 ﻿{
   "supports": { },
   "dependencies": {
+    "NuProj.Common": "0.10.10-beta-g13363167e1"
   },
   "frameworks": {
     ".NETFramework,Version=v4.0": { }

--- a/src/Hid/project.json
+++ b/src/Hid/project.json
@@ -1,6 +1,7 @@
 ﻿{
   "supports": { },
   "dependencies": {
+    "NuProj.Common": "0.10.10-beta-g13363167e1"
   },
   "frameworks": {
     ".NETPortable,Version=v4.0,Profile=Profile92": { }

--- a/src/ImageHlp/project.json
+++ b/src/ImageHlp/project.json
@@ -1,6 +1,7 @@
 ﻿{
   "supports": { },
   "dependencies": {
+    "NuProj.Common": "0.10.10-beta-g13363167e1"
   },
   "frameworks": {
     ".NETFramework,Version=v4.0": { }

--- a/src/Kernel32.Desktop/project.json
+++ b/src/Kernel32.Desktop/project.json
@@ -1,6 +1,7 @@
 ﻿{
   "supports": { },
   "dependencies": {
+    "NuProj.Common": "0.10.10-beta-g13363167e1"
   },
   "frameworks": {
     ".NETFramework,Version=v4.0": { }

--- a/src/Kernel32/project.json
+++ b/src/Kernel32/project.json
@@ -1,6 +1,7 @@
 ﻿{
   "supports": { },
   "dependencies": {
+    "NuProj.Common": "0.10.10-beta-g13363167e1"
   },
   "frameworks": {
     ".NETPortable,Version=v4.0,Profile=Profile92": { }

--- a/src/NCrypt/project.json
+++ b/src/NCrypt/project.json
@@ -1,6 +1,7 @@
 ﻿{
   "supports": { },
   "dependencies": {
+    "NuProj.Common": "0.10.10-beta-g13363167e1"
   },
   "frameworks": {
     ".NETPortable,Version=v4.0,Profile=Profile92": { }

--- a/src/Psapi/project.json
+++ b/src/Psapi/project.json
@@ -1,6 +1,7 @@
 ﻿{
   "supports": { },
   "dependencies": {
+    "NuProj.Common": "0.10.10-beta-g13363167e1"
   },
   "frameworks": {
     ".NETFramework,Version=v4.0": { }

--- a/src/SetupApi.Desktop/project.json
+++ b/src/SetupApi.Desktop/project.json
@@ -1,6 +1,7 @@
 ﻿{
   "supports": { },
   "dependencies": {
+    "NuProj.Common": "0.10.10-beta-g13363167e1"
   },
   "frameworks": {
     ".NETFramework,Version=v4.0": { }

--- a/src/User32.Desktop/project.json
+++ b/src/User32.Desktop/project.json
@@ -1,6 +1,7 @@
 ﻿{
   "supports": {},
   "dependencies": {
+    "NuProj.Common": "0.10.10-beta-g13363167e1"
   },
   "frameworks": {
     ".NETFramework,Version=v4.0": { }


### PR DESCRIPTION
This break occurs on VS2015 Update 1 RTW. It didn't happen before then.

Fix #98
