### PR TITLE
Fix versioning of projects after NuGet v3.3

### DIFF
--- a/src/AdvApi32.Desktop/project.json
+++ b/src/AdvApi32.Desktop/project.json
@@ -1,7 +1,6 @@
 ﻿{
   "supports": { },
   "dependencies": {
-    "NuProj.Common": "0.10.10-beta-g13363167e1"
   },
   "frameworks": {
     ".NETFramework,Version=v4.0": { }

--- a/src/AdvApi32/project.json
+++ b/src/AdvApi32/project.json
@@ -1,7 +1,6 @@
 ﻿{
   "supports": { },
   "dependencies": {
-    "NuProj.Common": "0.10.10-beta-g13363167e1"
   },
   "frameworks": {
     ".NETPortable,Version=v4.0,Profile=Profile92": { }

--- a/src/BCrypt/project.json
+++ b/src/BCrypt/project.json
@@ -1,7 +1,6 @@
 ﻿{
   "supports": {},
   "dependencies": {
-    "NuProj.Common": "0.10.10-beta-g13363167e1"
   },
   "frameworks": {
     ".NETPortable,Version=v4.0,Profile=Profile92": {}

--- a/src/DbgHelp/project.json
+++ b/src/DbgHelp/project.json
@@ -1,7 +1,6 @@
 ﻿{
   "supports": { },
   "dependencies": {
-    "NuProj.Common": "0.10.10-beta-g13363167e1"
   },
   "frameworks": {
     ".NETPortable,Version=v4.0,Profile=Profile92": { }

--- a/src/Gdi32.Desktop/project.json
+++ b/src/Gdi32.Desktop/project.json
@@ -1,7 +1,6 @@
 ﻿{
   "supports": {},
   "dependencies": {
-    "NuProj.Common": "0.10.10-beta-g13363167e1"
   },
   "frameworks": {
     ".NETFramework,Version=v4.0": { }

--- a/src/Hid.Desktop/project.json
+++ b/src/Hid.Desktop/project.json
@@ -1,7 +1,6 @@
 ﻿{
   "supports": { },
   "dependencies": {
-    "NuProj.Common": "0.10.10-beta-g13363167e1"
   },
   "frameworks": {
     ".NETFramework,Version=v4.0": { }

--- a/src/Hid/project.json
+++ b/src/Hid/project.json
@@ -1,7 +1,6 @@
 ﻿{
   "supports": { },
   "dependencies": {
-    "NuProj.Common": "0.10.10-beta-g13363167e1"
   },
   "frameworks": {
     ".NETPortable,Version=v4.0,Profile=Profile92": { }

--- a/src/ImageHlp/project.json
+++ b/src/ImageHlp/project.json
@@ -1,7 +1,6 @@
 ﻿{
   "supports": { },
   "dependencies": {
-    "NuProj.Common": "0.10.10-beta-g13363167e1"
   },
   "frameworks": {
     ".NETFramework,Version=v4.0": { }

--- a/src/Kernel32.Desktop/project.json
+++ b/src/Kernel32.Desktop/project.json
@@ -1,7 +1,6 @@
 ﻿{
   "supports": { },
   "dependencies": {
-    "NuProj.Common": "0.10.10-beta-g13363167e1"
   },
   "frameworks": {
     ".NETFramework,Version=v4.0": { }

--- a/src/Kernel32/project.json
+++ b/src/Kernel32/project.json
@@ -1,7 +1,6 @@
 ﻿{
   "supports": { },
   "dependencies": {
-    "NuProj.Common": "0.10.10-beta-g13363167e1"
   },
   "frameworks": {
     ".NETPortable,Version=v4.0,Profile=Profile92": { }

--- a/src/NCrypt/project.json
+++ b/src/NCrypt/project.json
@@ -1,7 +1,6 @@
 ﻿{
   "supports": { },
   "dependencies": {
-    "NuProj.Common": "0.10.10-beta-g13363167e1"
   },
   "frameworks": {
     ".NETPortable,Version=v4.0,Profile=Profile92": { }

--- a/src/Psapi/project.json
+++ b/src/Psapi/project.json
@@ -1,7 +1,6 @@
 ﻿{
   "supports": { },
   "dependencies": {
-    "NuProj.Common": "0.10.10-beta-g13363167e1"
   },
   "frameworks": {
     ".NETFramework,Version=v4.0": { }

--- a/src/SetupApi.Desktop/project.json
+++ b/src/SetupApi.Desktop/project.json
@@ -1,7 +1,6 @@
 ﻿{
   "supports": { },
   "dependencies": {
-    "NuProj.Common": "0.10.10-beta-g13363167e1"
   },
   "frameworks": {
     ".NETFramework,Version=v4.0": { }

--- a/src/User32.Desktop/project.json
+++ b/src/User32.Desktop/project.json
@@ -1,7 +1,6 @@
 ﻿{
   "supports": {},
   "dependencies": {
-    "NuProj.Common": "0.10.10-beta-g13363167e1"
   },
   "frameworks": {
     ".NETFramework,Version=v4.0": { }

--- a/src/Windows.Core/project.json
+++ b/src/Windows.Core/project.json
@@ -1,7 +1,10 @@
 {
   "supports": { },
   "dependencies": {
-    "Nerdbank.GitVersioning": "1.1.52-rc",
+    "Nerdbank.GitVersioning": {
+      "version": "1.1.52-rc",
+      "suppressParent": "none"
+    },
     "Nuproj": "0.10.10-beta-g13363167e1",
     "Nuproj.Common": {
       "version": "0.10.10-beta-g13363167e1",

--- a/src/Windows.Core/project.json
+++ b/src/Windows.Core/project.json
@@ -3,7 +3,10 @@
   "dependencies": {
     "Nerdbank.GitVersioning": "1.1.52-rc",
     "Nuproj": "0.10.10-beta-g13363167e1",
-    "Nuproj.Common": "0.10.10-beta-g13363167e1",
+    "Nuproj.Common": {
+      "version": "0.10.10-beta-g13363167e1",
+      "suppressParent": "none"
+    },
     "StyleCop.Analyzers": "1.0.0-beta016"
   },
   "frameworks": {


### PR DESCRIPTION
Re-fix #98 in a much more concise way, and apply the same fix to Nerdbank.GitVersioning dependency which also stopped propagating, leading to no version stamping on assemblies besides Windows.Core.

See https://github.com/NuGet/Home/wiki/%5BSpec%5D-Managing-dependency-package-assets for info on this breaking change to NuGet.
