### PR TITLE
AdvApi32: Define native pointer methods instead of IntPtr

### DIFF
--- a/src/AdvApi32.Desktop/AdvApi32+ServiceStateQuery.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServiceStateQuery.cs
@@ -11,7 +11,7 @@ namespace PInvoke
     public partial class AdvApi32
     {
         /// <summary>
-        /// Represents the state of the services to be enumerated (<see cref="EnumServicesStatus(SafeServiceHandle,ServiceType,ServiceStateQuery,IntPtr,int,ref int,ref int,ref int)"/> or EnumServicesStatusEx).
+        /// Represents the state of the services to be enumerated (<see cref="EnumServicesStatus(SafeServiceHandle,ServiceType,ServiceStateQuery,byte*,int,ref int,ref int,ref int)"/> or EnumServicesStatusEx).
         /// </summary>
         [Flags]
         public enum ServiceStateQuery

--- a/src/AdvApi32.Desktop/AdvApi32+ServiceTrigger.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServiceTrigger.cs
@@ -29,7 +29,7 @@ namespace PInvoke
 
             /// <summary>
             /// Points to a GUID that identifies the trigger event subtype. The value
-            /// of this member depends on the value of the dwTriggerType member.
+            /// of this member depends on the value of the <see cref="dwTriggerType"/> member.
             /// </summary>
             public IntPtr pTriggerSubtype;
 

--- a/src/AdvApi32.Desktop/AdvApi32+ServiceTriggerInfo.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServiceTriggerInfo.cs
@@ -27,7 +27,7 @@ namespace PInvoke
             /// A pointer to an array of <see cref="ServiceTrigger"/> structures that specify the trigger events for the service.
             /// If the cTriggers member is 0, this member is not used.
             /// </summary>
-            public IntPtr pTriggers;
+            public ServiceTrigger[] pTriggers;
 
             /// <summary>
             /// This member is reserved and must be NULL.

--- a/src/AdvApi32.Desktop/AdvApi32.Helpers.cs
+++ b/src/AdvApi32.Desktop/AdvApi32.Helpers.cs
@@ -77,6 +77,7 @@ namespace PInvoke
                     {
                         result[i] = (ENUM_SERVICE_STATUS)Marshal.PtrToStructure(new IntPtr(position), typeof(ENUM_SERVICE_STATUS));
                         position += structSize;
+                        Marshal.DestroyStructure(new IntPtr(position), typeof(ENUM_SERVICE_STATUS));
                     }
 
                     return result;

--- a/src/AdvApi32.Desktop/AdvApi32.Helpers.cs
+++ b/src/AdvApi32.Desktop/AdvApi32.Helpers.cs
@@ -77,7 +77,6 @@ namespace PInvoke
                     {
                         result[i] = (ENUM_SERVICE_STATUS)Marshal.PtrToStructure(new IntPtr(position), typeof(ENUM_SERVICE_STATUS));
                         position += structSize;
-                        Marshal.DestroyStructure(new IntPtr(position), typeof(ENUM_SERVICE_STATUS));
                     }
 
                     return result;

--- a/src/AdvApi32.Desktop/AdvApi32.cs
+++ b/src/AdvApi32.Desktop/AdvApi32.cs
@@ -68,14 +68,14 @@ namespace PInvoke
         /// A pointer to a buffer that contains an array of <see cref="ENUM_SERVICE_STATUS"/> structures that receive the name and service status information for each service in the database.
         /// The buffer must be large enough to hold the structures, plus the strings to which their members point.
         /// The maximum size of this array is 256K bytes.
-        /// To determine the required size, specify NULL for this parameter and 0 for the cbBufSize parameter.
-        /// The function will fail and GetLastError will return <see cref="Win32ErrorCode.ERROR_INSUFFICIENT_BUFFER"/>.
-        /// The pcbBytesNeeded parameter will receive the required size.
+        /// To determine the required size, specify NULL for this parameter and 0 for the <paramref name="cbBufSize" /> parameter.
+        /// The function will fail and <see cref="GetLastError"/> will return <see cref="Win32ErrorCode.ERROR_INSUFFICIENT_BUFFER"/>.
+        /// The <paramref name="pcbBytesNeeded"/> parameter will receive the required size.
         /// Windows Server 2003 and Windows XP:  The maximum size of this array is 64K bytes.
         /// This limit was increased as of Windows Server 2003 with SP1 and Windows XP with SP2.
         /// </param>
         /// <param name="cbBufSize">
-        /// The size of the buffer pointed to by the lpServices parameter, in bytes.
+        /// The size of the buffer pointed to by the <paramref name="lpServices"/> parameter, in bytes.
         /// </param>
         /// <param name="pcbBytesNeeded">
         /// A pointer to a variable that receives the number of bytes needed to return the remaining service entries, if the buffer is too small.
@@ -86,12 +86,12 @@ namespace PInvoke
         /// <param name="lpResumeHandle">
         /// A pointer to a variable that, on input, specifies the starting point of enumeration.
         /// You must set this value to zero the first time this function is called. On output, this value is zero if the function succeeds.
-        /// However, if the function returns zero and the GetLastError function returns <see cref="Win32ErrorCode.ERROR_MORE_DATA"/>,
+        /// However, if the function returns zero and the <see cref="GetLastError"/> function returns <see cref="Win32ErrorCode.ERROR_MORE_DATA"/>,
         /// this value is used to indicate the next service entry to be read when the function is called to retrieve the additional data.
         /// </param>
         /// <returns>
         /// If the function succeeds, the return value is nonzero.
-        /// If the function fails, the return value is zero. To get extended error information, call GetLastError.
+        /// If the function fails, the return value is zero. To get extended error information, call <see cref="GetLastError"/>.
         /// </returns>
         [DllImport(nameof(AdvApi32), SetLastError = true, CharSet = CharSet.Unicode)]
         [return: MarshalAs(UnmanagedType.Bool)]

--- a/src/AdvApi32.Desktop/AdvApi32.cs
+++ b/src/AdvApi32.Desktop/AdvApi32.cs
@@ -18,7 +18,7 @@ namespace PInvoke
         /// Enumerates services in the specified service control manager database.
         /// The name and status of each service are provided.
         /// This function has been superseded by the EnumServicesStatusEx function.
-        /// It returns the same information <see cref="EnumServicesStatus(SafeServiceHandle,ServiceType,ServiceStateQuery,IntPtr,int,ref int,ref int,ref int)"/> returns, plus the process identifier and additional information for the service.
+        /// It returns the same information <see cref="EnumServicesStatus(SafeServiceHandle,ServiceType,ServiceStateQuery,byte*,int,ref int,ref int,ref int)"/> returns, plus the process identifier and additional information for the service.
         /// In addition, EnumServicesStatusEx enables you to enumerate services that belong to a specified group.
         /// </summary>
         /// <param name="hSCManager">
@@ -95,11 +95,11 @@ namespace PInvoke
         /// </returns>
         [DllImport(nameof(AdvApi32), SetLastError = true, CharSet = CharSet.Unicode)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool EnumServicesStatus(
+        public static unsafe extern bool EnumServicesStatus(
             SafeServiceHandle hSCManager,
             ServiceType dwServiceType,
             ServiceStateQuery dwServiceState,
-            IntPtr lpServices,
+            byte* lpServices,
             int cbBufSize,
             ref int pcbBytesNeeded,
             ref int lpServicesReturned,

--- a/src/AdvApi32.Shared/AdvApi32+ServiceFailureActions.cs
+++ b/src/AdvApi32.Shared/AdvApi32+ServiceFailureActions.cs
@@ -47,7 +47,7 @@ namespace PInvoke
             /// A pointer to an array of <see cref="ServiceControlAction"/> structures.
             /// If this value is NULL, the <see cref="cActions"/> and <see cref="dwResetPeriod"/> members are ignored.
             /// </summary>
-            public System.IntPtr lpsaActions;
+            public ServiceControlAction[] lpsaActions;
         }
     }
 }

--- a/src/AdvApi32.Shared/AdvApi32+ServiceFailureActions.cs
+++ b/src/AdvApi32.Shared/AdvApi32+ServiceFailureActions.cs
@@ -21,7 +21,7 @@ namespace PInvoke
 
             /// <summary>
             /// The message to be broadcast to server users before rebooting in response to the <see cref="ServiceControlActionType.SC_ACTION_REBOOT"/> service controller action.
-            /// If this value is NULL, the reboot message is unchanged.If the value is an empty string (""), the reboot message is deleted and no message is broadcast.
+            /// If this value is NULL, the reboot message is unchanged. If the value is an empty string (""), the reboot message is deleted and no message is broadcast.
             /// This member can specify a localized string using the following format:
             /// @[path\]
             /// dllname,-strID
@@ -39,13 +39,13 @@ namespace PInvoke
 
             /// <summary>
             /// The number of elements in the lpsaActions array.
-            /// If this value is 0, but lpsaActions is not NULL, the reset period and array of failure actions are deleted.
+            /// If this value is 0, but <see cref="lpsaActions"/> is not NULL, the reset period and array of failure actions are deleted.
             /// </summary>
             public int cActions;
 
             /// <summary>
             /// A pointer to an array of <see cref="ServiceControlAction"/> structures.
-            /// If this value is NULL, the cActions and dwResetPeriod members are ignored.
+            /// If this value is NULL, the <see cref="cActions"/> and <see cref="dwResetPeriod"/> members are ignored.
             /// </summary>
             public System.IntPtr lpsaActions;
         }

--- a/src/AdvApi32.Shared/AdvApi32.cs
+++ b/src/AdvApi32.Shared/AdvApi32.cs
@@ -216,7 +216,7 @@ namespace PInvoke
         /// </returns>
         [DllImport(api_ms_win_service_management_l2_1_0, SetLastError = true, CharSet = CharSet.Unicode)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool ChangeServiceConfig2(SafeServiceHandle hService, ServiceInfoLevel dwInfoLevel, IntPtr lpInfo);
+        public static unsafe extern bool ChangeServiceConfig2(SafeServiceHandle hService, ServiceInfoLevel dwInfoLevel, void* lpInfo);
 
         /// <summary>
         /// Sends a control code to a service.

--- a/src/AdvApi32.Shared/AdvApi32.cs
+++ b/src/AdvApi32.Shared/AdvApi32.cs
@@ -207,7 +207,7 @@ namespace PInvoke
         /// </param>
         /// <param name="lpInfo">
         /// A pointer to the new value to be set for the configuration information.
-        /// The format of this data depends on the value of the dwInfoLevel parameter.
+        /// The format of this data depends on the value of the <paramref name="dwInfoLevel"/> parameter.
         /// If this value is NULL, the information remains unchanged.
         /// </param>
         /// <returns>
@@ -224,7 +224,7 @@ namespace PInvoke
         /// </summary>
         /// <param name="hService">
         /// A handle to the service. This handle is returned by the <see cref="OpenService"/> or <see cref="CreateService(SafeServiceHandle,string,string,ServiceAccess,ServiceType,ServiceStartType,ServiceErrorControl,string,string,int, string,string,string)"/> function.
-        /// The access rights required for this handle depend on the dwControl code requested.
+        /// The access rights required for this handle depend on the <paramref name="dwControl"/> code requested.
         /// </param>
         /// <param name="dwControl">
         /// This parameter can be one of the following control codes.


### PR DESCRIPTION
Work toward #76

There are no tests defined for this library so I hope I didn't break anything. 
