### PR TITLE
Generate IntPtr overloads for BCrypt native pointer methods

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,11 @@ anything else found in native header files for these reasons:
  * Prefer `SafeHandle`-derived types to `IntPtr` when dealing with handles.
    Mark P/Invoke methods that destroy handles private because they will necessarily take `IntPtr`
    and the pattern for users should be to `Dispose` of your `SafeHandle`.
- * Prefer `IntPtr` over unsafe pointers. But be sure the xml doc comments for the parameter specify the expected type.
+ * Prefer native pointers over `IntPtr`. We have automatic code generation in place during the build
+   to create `IntPtr` overloads of these methods.
+ * When a native method accepts a pointer to a byte array, consider creating two P/Invoke overloads:
+   one that takes `byte[]` and one that takes `byte*`. The former being more convenient for most callers,
+   while the latter is more efficient when callers may want to point to some offset into the array.
  * Prefer `enum` types over `int` or `uint` flags. Generally, name flags enums as `METHODNAMEFlags`, for example
    `CreateFileFlags` for the flags that are passed to `CreateFile`.
 

--- a/src/AdvApi32.Desktop/AdvApi32+ServiceTriggerInfo.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServiceTriggerInfo.cs
@@ -12,7 +12,7 @@ namespace PInvoke
     public static partial class AdvApi32
     {
         /// <summary>
-        /// Contains trigger event information for a service. This structure is used by the <see cref="ChangeServiceConfig2"/> and QueryServiceConfig2 functions.
+        /// Contains trigger event information for a service. This structure is used by the <see cref="ChangeServiceConfig2(SafeServiceHandle, ServiceInfoLevel, void*)"/> and QueryServiceConfig2 functions.
         /// </summary>
         [StructLayout(LayoutKind.Sequential)]
         public struct ServiceTriggerInfo

--- a/src/AdvApi32.Desktop/AdvApi32.Desktop.csproj
+++ b/src/AdvApi32.Desktop/AdvApi32.Desktop.csproj
@@ -25,6 +25,15 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\CodeGenerationAttributes.Net40\CodeGenerationAttributes.Net40.csproj">
+      <Project>{6a77281b-c503-44ea-90c1-0e9868d06cd0}</Project>
+      <Name>CodeGenerationAttributes.Net40</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\CodeGeneration\CodeGeneration.csproj">
+      <Project>{C1815471-02AF-4BB9-8D83-652ADBAFF5B6}</Project>
+      <Name>CodeGeneration</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
     <ProjectReference Include="..\Kernel32.Desktop\Kernel32.Desktop.csproj">
       <Project>{18BA8C60-9A63-4EEA-BB5C-C9899D86F5B8}</Project>
       <Name>Kernel32.Desktop</Name>

--- a/src/AdvApi32.Shared/AdvApi32+TOKEN_ELEVATION_TYPE.cs
+++ b/src/AdvApi32.Shared/AdvApi32+TOKEN_ELEVATION_TYPE.cs
@@ -9,7 +9,7 @@ namespace PInvoke
     public partial class AdvApi32
     {
         /// <summary>
-        /// Indicates the elevation type of token being queried by the <see cref="GetTokenInformation"/> function.
+        /// Indicates the elevation type of token being queried by the <see cref="GetTokenInformation(Kernel32.SafeObjectHandle, TOKEN_INFORMATION_CLASS, void*, int, out int)"/> function.
         /// </summary>
         public enum TOKEN_ELEVATION_TYPE
         {

--- a/src/AdvApi32.Shared/AdvApi32.Helpers.cs
+++ b/src/AdvApi32.Shared/AdvApi32.Helpers.cs
@@ -150,14 +150,14 @@ namespace PInvoke
             }
         }
 
-        /// <summary>Get the elevation type of a token via <see cref="GetTokenInformation" />.</summary>
+        /// <summary>Get the elevation type of a token via <see cref="GetTokenInformation(SafeObjectHandle, TOKEN_INFORMATION_CLASS, void*, int, out int)" />.</summary>
         /// <param name="TokenHandle">
         ///     A handle to an access token from which information is retrieved. The handle must have
         ///     TOKEN_QUERY access.
         /// </param>
         /// <returns>The token elevation type</returns>
         /// <exception cref="ArgumentNullException"><paramref name="TokenHandle" /> is NULL.</exception>
-        /// <exception cref="Win32Exception">If the call to <see cref="GetTokenInformation" /> fails.</exception>
+        /// <exception cref="Win32Exception">If the call to <see cref="GetTokenInformation(SafeObjectHandle, TOKEN_INFORMATION_CLASS, void*, int, out int)" /> fails.</exception>
         public static TOKEN_ELEVATION_TYPE GetTokenElevationType(SafeObjectHandle TokenHandle)
         {
             if (TokenHandle == null)

--- a/src/AdvApi32.Shared/AdvApi32.Shared.projitems
+++ b/src/AdvApi32.Shared/AdvApi32.Shared.projitems
@@ -33,7 +33,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)AdvApi32+TokenAccessRights.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AdvApi32+TOKEN_ELEVATION_TYPE.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AdvApi32+TOKEN_INFORMATION_CLASS.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)AdvApi32.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)AdvApi32.cs">
+      <Generator>MSBuild:GenerateCodeFromAttributes</Generator>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)AdvApi32.Helpers.cs" />
   </ItemGroup>
 </Project>

--- a/src/AdvApi32.Shared/AdvApi32.cs
+++ b/src/AdvApi32.Shared/AdvApi32.cs
@@ -41,7 +41,7 @@ namespace PInvoke
 
         /// <summary>
         /// Changes the configuration parameters of a service.
-        /// To change the optional configuration parameters, use the <see cref="ChangeServiceConfig2"/> function.
+        /// To change the optional configuration parameters, use the <see cref="ChangeServiceConfig2(SafeServiceHandle, ServiceInfoLevel, void*)"/> function.
         /// </summary>
         /// <param name="hService">
         /// A handle to the service.

--- a/src/AdvApi32.Shared/AdvApi32.cs
+++ b/src/AdvApi32.Shared/AdvApi32.cs
@@ -11,7 +11,7 @@ namespace PInvoke
     /// Exported functions from the AdvApi32.dll Windows library
     /// that are available to Desktop and Store apps.
     /// </content>
-    [OfferIntPtrOverload]
+    [OfferIntPtrOverloads]
     public static partial class AdvApi32
     {
         /// <summary>

--- a/src/AdvApi32.Shared/AdvApi32.cs
+++ b/src/AdvApi32.Shared/AdvApi32.cs
@@ -11,6 +11,7 @@ namespace PInvoke
     /// Exported functions from the AdvApi32.dll Windows library
     /// that are available to Desktop and Store apps.
     /// </content>
+    [OfferIntPtrOverload]
     public static partial class AdvApi32
     {
         /// <summary>

--- a/src/AdvApi32/AdvApi32.csproj
+++ b/src/AdvApi32/AdvApi32.csproj
@@ -29,6 +29,16 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\CodeGenerationAttributes\CodeGenerationAttributes.csproj">
+      <Project>{1387e009-7086-4572-ac8d-ce4242adec77}</Project>
+      <Name>CodeGenerationAttributes</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\CodeGeneration\CodeGeneration.csproj">
+      <Project>{C1815471-02AF-4BB9-8D83-652ADBAFF5B6}</Project>
+      <Name>CodeGeneration</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
     <ProjectReference Include="..\Kernel32\Kernel32.csproj">
       <Project>{1fdc092a-d3e8-4cc4-b896-17e0a213f723}</Project>
       <Name>Kernel32</Name>

--- a/src/BCrypt.Tests/BCrypt.cs
+++ b/src/BCrypt.Tests/BCrypt.cs
@@ -290,8 +290,9 @@ public class BCrypt
                     authInfo.pbTag = new IntPtr(pTagBuffer);
                     authInfo.cbTag = tagBuffer.Length;
 
+                    // Mix up calling the IntPtr and native pointer overloads so we test both.
                     int cipherTextLength;
-                    BCryptEncrypt(key, plainText, plainText.Length, &authInfo, null, 0, null, 0, out cipherTextLength, BCryptEncryptFlags.None).ThrowOnError();
+                    BCryptEncrypt(key, plainText, plainText.Length, new IntPtr(&authInfo), null, 0, null, 0, out cipherTextLength, BCryptEncryptFlags.None).ThrowOnError();
                     cipherText = new byte[cipherTextLength];
                     BCryptEncrypt(key, plainText, plainText.Length, &authInfo, null, 0, cipherText, cipherText.Length, out cipherTextLength, BCryptEncryptFlags.None).ThrowOnError();
                 }

--- a/src/BCrypt/BCrypt.Helpers.cs
+++ b/src/BCrypt/BCrypt.Helpers.cs
@@ -562,7 +562,7 @@ namespace PInvoke
         /// The signature produced by this function.
         /// </returns>
         /// <remarks>
-        /// To later verify that the signature is valid, call the <see cref="BCryptVerifySignature"/> function with an identical key and an identical hash of the original data.
+        /// To later verify that the signature is valid, call the <see cref="BCryptVerifySignature(SafeKeyHandle, void*, byte[], int, byte[], int, BCryptSignHashFlags)"/> function with an identical key and an identical hash of the original data.
         /// </remarks>
         public static unsafe ArraySegment<byte> BCryptSignHash(
             SafeKeyHandle key,

--- a/src/BCrypt/BCrypt.cs
+++ b/src/BCrypt/BCrypt.cs
@@ -11,7 +11,7 @@ namespace PInvoke
     /// <summary>
     /// Exported functions from the BCrypt.dll Windows library.
     /// </summary>
-    [OfferIntPtrOverload]
+    [OfferIntPtrOverloads]
     public static partial class BCrypt
     {
         /// <summary>

--- a/src/BCrypt/BCrypt.cs
+++ b/src/BCrypt/BCrypt.cs
@@ -11,6 +11,7 @@ namespace PInvoke
     /// <summary>
     /// Exported functions from the BCrypt.dll Windows library.
     /// </summary>
+    [OfferIntPtrOverload]
     public static partial class BCrypt
     {
         /// <summary>
@@ -371,7 +372,7 @@ namespace PInvoke
         /// </param>
         /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
         /// <remarks>
-        /// To later verify that the signature is valid, call the <see cref="BCryptVerifySignature"/> function with an identical key and an identical hash of the original data.
+        /// To later verify that the signature is valid, call the <see cref="BCryptVerifySignature(SafeKeyHandle, void*, byte[], int, byte[], int, BCryptSignHashFlags)"/> function with an identical key and an identical hash of the original data.
         /// </remarks>
         [DllImport(nameof(BCrypt), SetLastError = true)]
         public static unsafe extern NTStatus BCryptSignHash(

--- a/src/BCrypt/BCrypt.csproj
+++ b/src/BCrypt/BCrypt.csproj
@@ -70,7 +70,9 @@
     <Compile Include="BCrypt+SafeKeyHandle.cs" />
     <Compile Include="BCrypt+SafeSecretHandle.cs" />
     <Compile Include="BCrypt+SymmetricKeyBlobTypes.cs" />
-    <Compile Include="BCrypt.cs" />
+    <Compile Include="BCrypt.cs">
+      <Generator>MSBuild:GenerateCodeFromAttributes</Generator>
+    </Compile>
     <Compile Include="BCrypt.Helpers.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -78,6 +80,16 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\CodeGenerationAttributes\CodeGenerationAttributes.csproj">
+      <Project>{1387e009-7086-4572-ac8d-ce4242adec77}</Project>
+      <Name>CodeGenerationAttributes</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\CodeGeneration\CodeGeneration.csproj">
+      <Project>{C1815471-02AF-4BB9-8D83-652ADBAFF5B6}</Project>
+      <Name>CodeGeneration</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
     <ProjectReference Include="..\Kernel32\Kernel32.csproj">
       <Project>{1fdc092a-d3e8-4cc4-b896-17e0a213f723}</Project>
       <Name>Kernel32</Name>

--- a/src/CodeGeneration.Debugging/App.config
+++ b/src/CodeGeneration.Debugging/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+    </startup>
+</configuration>

--- a/src/CodeGeneration.Debugging/CodeGeneration.Debugging.csproj
+++ b/src/CodeGeneration.Debugging/CodeGeneration.Debugging.csproj
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{95305207-62AE-4019-83EC-079008625219}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>CodeGeneration.Debugging</RootNamespace>
+    <AssemblyName>CodeGeneration.Debugging</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/CodeGeneration.Debugging/Program.cs
+++ b/src/CodeGeneration.Debugging/Program.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CodeGeneration.Debugging
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            // This app is a dummy. But when it is debugged within VS, it builds the Tests
+            // allowing VS to debug into the build/code generation process.
+        }
+    }
+}

--- a/src/CodeGeneration.Debugging/Properties/AssemblyInfo.cs
+++ b/src/CodeGeneration.Debugging/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("CodeGeneration.Debugging")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("CodeGeneration.Debugging")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("95305207-62ae-4019-83ec-079008625219")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/CodeGeneration/CodeGeneration.csproj
+++ b/src/CodeGeneration/CodeGeneration.csproj
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), EnlistmentInfo.props))\EnlistmentInfo.props" Condition=" '$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), EnlistmentInfo.props))' != '' " />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C1815471-02AF-4BB9-8D83-652ADBAFF5B6}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>PInvoke</RootNamespace>
+    <AssemblyName>CodeGeneration</AssemblyName>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="OfferIntPtrOverloadGenerator.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), EnlistmentInfo.targets))\EnlistmentInfo.targets" Condition=" '$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), EnlistmentInfo.targets))' != '' " />
+</Project>

--- a/src/CodeGeneration/OfferIntPtrOverloadGenerator.cs
+++ b/src/CodeGeneration/OfferIntPtrOverloadGenerator.cs
@@ -1,0 +1,127 @@
+﻿// Copyright (c) to owners found in https://github.com/AArnott/pinvoke/blob/master/COPYRIGHT.md. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+
+namespace PInvoke
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using CodeGeneration.Roslyn;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+    /// <summary>
+    /// Generates an <see cref="IntPtr"/> overload of a method that accepts native pointers.
+    /// </summary>
+    public class OfferIntPtrOverloadGenerator : ICodeGenerator
+    {
+        private static readonly TypeSyntax VoidStar = SyntaxFactory.ParseTypeName("void*");
+
+        private static readonly TypeSyntax IntPtrTypeSyntax = SyntaxFactory.ParseTypeName("System.IntPtr");
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OfferIntPtrOverloadGenerator"/> class.
+        /// </summary>
+        /// <param name="data">Generator attribute data.</param>
+        public OfferIntPtrOverloadGenerator(AttributeData data)
+        {
+        }
+
+        /// <inheritdoc />
+        public Task<IReadOnlyList<MemberDeclarationSyntax>> GenerateAsync(MemberDeclarationSyntax applyTo, Document document, IProgressAndErrors progress, CancellationToken cancellationToken)
+        {
+            var type = (ClassDeclarationSyntax)applyTo;
+            var result = new List<MemberDeclarationSyntax>();
+            var generatedType = type
+                .WithMembers(SyntaxFactory.List<MemberDeclarationSyntax>());
+            var methodsWithNativePointers =
+                from method in type.Members.OfType<MethodDeclarationSyntax>()
+                where WhereIsPointerParameter(method.ParameterList.Parameters).Any()
+                select method;
+
+            foreach (var method in methodsWithNativePointers)
+            {
+                var intPtrOverload = method
+                    .WithParameterList(TransformParameterList(method.ParameterList))
+                    .WithModifiers(RemoveModifier(method.Modifiers, SyntaxKind.ExternKeyword))
+                    .WithAttributeLists(SyntaxFactory.List<AttributeListSyntax>())
+                    .WithLeadingTrivia(method.GetLeadingTrivia())
+                    .WithBody(CallNativePointerOverload(method))
+                    .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.None));
+                generatedType = generatedType.AddMembers(intPtrOverload);
+            }
+
+            result.Add(generatedType);
+            return Task.FromResult<IReadOnlyList<MemberDeclarationSyntax>>(result);
+        }
+
+        private static IEnumerable<ParameterSyntax> WhereIsPointerParameter(IEnumerable<ParameterSyntax> parameters)
+        {
+            return from p in parameters
+                   where p.Type is PointerTypeSyntax
+                   select p;
+        }
+
+        private static ParameterListSyntax TransformParameterList(ParameterListSyntax list)
+        {
+            var resultingList = list.ReplaceNodes(
+                WhereIsPointerParameter(list.Parameters),
+                (n1, n2) => n2.WithType(IntPtrTypeSyntax));
+            return resultingList;
+        }
+
+        private static SyntaxTokenList RemoveModifier(SyntaxTokenList list, params SyntaxKind[] modifiers)
+        {
+            return SyntaxFactory.TokenList(list.Where(t => Array.IndexOf(modifiers, t.Kind()) < 0));
+        }
+
+        private static ArgumentSyntax IntPtrOverloadParameterToArgument(ParameterSyntax p)
+        {
+            var refOrOut = p.Modifiers.FirstOrDefault(m => m.IsKind(SyntaxKind.RefKeyword) || m.IsKind(SyntaxKind.OutKeyword));
+            ExpressionSyntax argRef = SyntaxFactory.IdentifierName(p.Identifier);
+            if (p.Type is PointerTypeSyntax)
+            {
+                argRef =
+                    SyntaxFactory.InvocationExpression(
+                        SyntaxFactory.MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            argRef,
+                            SyntaxFactory.IdentifierName(nameof(IntPtr.ToPointer))),
+                        SyntaxFactory.ArgumentList());
+                if (!p.Type.WithoutTrivia().IsEquivalentTo(VoidStar))
+                {
+                    argRef = SyntaxFactory.CastExpression(p.Type, argRef);
+                }
+            }
+
+            return SyntaxFactory.Argument(argRef)
+                .WithRefOrOutKeyword(refOrOut);
+        }
+
+        private static BlockSyntax CallNativePointerOverload(MethodDeclarationSyntax nativePointerOverload)
+        {
+            var invocationExpression = SyntaxFactory.InvocationExpression(
+                SyntaxFactory.IdentifierName(nativePointerOverload.Identifier.ValueText),
+                SyntaxFactory.ArgumentList(
+                    SyntaxFactory.SeparatedList(
+                        from p in nativePointerOverload.ParameterList.Parameters
+                        select IntPtrOverloadParameterToArgument(p))));
+
+            StatementSyntax statement;
+            if (nativePointerOverload.ReturnType != null)
+            {
+                statement = SyntaxFactory.ReturnStatement(invocationExpression);
+            }
+            else
+            {
+                statement = SyntaxFactory.ExpressionStatement(invocationExpression);
+            }
+
+            return SyntaxFactory.Block(statement);
+        }
+    }
+}

--- a/src/CodeGeneration/project.json
+++ b/src/CodeGeneration/project.json
@@ -1,0 +1,24 @@
+﻿{
+  "dependencies": {
+    "CodeGeneration.Roslyn": {
+      "version": "0.1.28-alpha",
+      "suppressParent": "none"
+    },
+    "Nerdbank.GitVersioning": {
+      "version": "1.1.61-rc",
+      "suppressParent": "none"
+    },
+    "Nuproj.Common": {
+      "version": "0.10.27-beta-g2363d7cd98",
+      "suppressParent": "none"
+    },
+    "StyleCop.Analyzers": "1.0.0-rc2"
+  },
+  "frameworks": {
+    ".NETFramework,Version=v4.6": { }
+  },
+  "runtimes": {
+    "win-anycpu": { },
+    "win": { }
+  }
+}

--- a/src/CodeGenerationAttributes.Net40/CodeGenerationAttributes.Net40.csproj
+++ b/src/CodeGenerationAttributes.Net40/CodeGenerationAttributes.Net40.csproj
@@ -25,15 +25,15 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\CodeGenerationAttributes\OfferIntPtrOverloadAttribute.cs">
-      <Link>OfferIntPtrOverloadAttribute.cs</Link>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\CodeGenerationAttributes\OfferIntPtrOverloadsAttribute.cs">
+      <Link>OfferIntPtrOverloadsAttribute.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), EnlistmentInfo.targets))\EnlistmentInfo.targets" Condition=" '$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), EnlistmentInfo.targets))' != '' " />

--- a/src/CodeGenerationAttributes.Net40/CodeGenerationAttributes.Net40.csproj
+++ b/src/CodeGenerationAttributes.Net40/CodeGenerationAttributes.Net40.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="14.0">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
   </PropertyGroup>
@@ -8,11 +8,11 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>$guid5$</ProjectGuid>
+    <ProjectGuid>{6A77281B-C503-44EA-90C1-0E9868D06CD0}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PInvoke</RootNamespace>
-    <AssemblyName>PInvoke.LIBNAME</AssemblyName>
+    <AssemblyName>CodeGenerationAttributes.Net40</AssemblyName>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -25,33 +25,16 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\CodeGenerationAttributes.Net40\CodeGenerationAttributes.Net40.csproj">
-      <Project>{6a77281b-c503-44ea-90c1-0e9868d06cd0}</Project>
-      <Name>CodeGenerationAttributes.Net40</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\CodeGeneration\CodeGeneration.csproj">
-      <Project>{C1815471-02AF-4BB9-8D83-652ADBAFF5B6}</Project>
-      <Name>CodeGeneration</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-    </ProjectReference>
-    <ProjectReference Include="..\Windows.Core\Windows.Core.csproj">
-      <Project>{b08c3c79-4cdd-4d37-933c-07d3452fd5f1}</Project>
-      <Name>Windows.Core</Name>
-    </ProjectReference>
+    <Compile Include="..\CodeGenerationAttributes\OfferIntPtrOverloadAttribute.cs">
+      <Link>OfferIntPtrOverloadAttribute.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="LIBNAME.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Folder Include="Properties\" />
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="LIBNAME.exports.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-  <Import Project="..\LIBNAME.Shared\LIBNAME.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), EnlistmentInfo.targets))\EnlistmentInfo.targets" Condition=" '$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), EnlistmentInfo.targets))' != '' " />
 </Project>

--- a/src/CodeGenerationAttributes.Net40/project.json
+++ b/src/CodeGenerationAttributes.Net40/project.json
@@ -1,0 +1,24 @@
+﻿{
+  "dependencies": {
+    "CodeGeneration.Roslyn": {
+      "version": "0.1.28-alpha",
+      "suppressParent": "none"
+    },
+    "Nerdbank.GitVersioning": {
+      "version": "1.1.61-rc",
+      "suppressParent": "none"
+    },
+    "Nuproj.Common": {
+      "version": "0.10.27-beta-g2363d7cd98",
+      "suppressParent": "none"
+    },
+    "StyleCop.Analyzers": "1.0.0-rc2"
+  },
+  "frameworks": {
+    ".NETFramework,Version=v4.0": { }
+  },
+  "runtimes": {
+    "win-anycpu": { },
+    "win": { }
+  }
+}

--- a/src/CodeGenerationAttributes/CodeGenerationAttributes.csproj
+++ b/src/CodeGenerationAttributes/CodeGenerationAttributes.csproj
@@ -28,7 +28,7 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="OfferIntPtrOverloadAttribute.cs" />
+    <Compile Include="OfferIntPtrOverloadsAttribute.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/src/CodeGenerationAttributes/CodeGenerationAttributes.csproj
+++ b/src/CodeGenerationAttributes/CodeGenerationAttributes.csproj
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile92</TargetFrameworkProfile>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), EnlistmentInfo.props))\EnlistmentInfo.props" Condition=" '$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), EnlistmentInfo.props))' != '' " />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>10.0</MinimumVisualStudioVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{1387E009-7086-4572-AC8D-CE4242ADEC77}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>PInvoke</RootNamespace>
+    <AssemblyName>CodeGenerationAttributes</AssemblyName>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- A reference to the entire .NET Framework is automatically included -->
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="OfferIntPtrOverloadAttribute.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), EnlistmentInfo.targets))\EnlistmentInfo.targets" Condition=" '$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), EnlistmentInfo.targets))' != '' " />
+</Project>

--- a/src/CodeGenerationAttributes/OfferIntPtrOverloadAttribute.cs
+++ b/src/CodeGenerationAttributes/OfferIntPtrOverloadAttribute.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) to owners found in https://github.com/AArnott/pinvoke/blob/master/COPYRIGHT.md. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+
+namespace PInvoke
+{
+    using System;
+    using System.Diagnostics;
+    using CodeGeneration.Roslyn;
+
+    /// <summary>
+    /// Causes generation of an overload of the method that accepts
+    /// <see cref="IntPtr"/> parameters instead of native pointers.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    [CodeGenerationAttribute("PInvoke.OfferIntPtrOverloadGenerator, CodeGeneration, Version=0.1.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a")]
+    [Conditional("CodeGeneration")]
+    public class OfferIntPtrOverloadAttribute : Attribute
+    {
+    }
+}

--- a/src/CodeGenerationAttributes/OfferIntPtrOverloadsAttribute.cs
+++ b/src/CodeGenerationAttributes/OfferIntPtrOverloadsAttribute.cs
@@ -14,7 +14,7 @@ namespace PInvoke
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     [CodeGenerationAttribute("PInvoke.OfferIntPtrOverloadGenerator, CodeGeneration, Version=0.1.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a")]
     [Conditional("CodeGeneration")]
-    public class OfferIntPtrOverloadAttribute : Attribute
+    public class OfferIntPtrOverloadsAttribute : Attribute
     {
     }
 }

--- a/src/CodeGenerationAttributes/project.json
+++ b/src/CodeGenerationAttributes/project.json
@@ -1,0 +1,24 @@
+﻿{
+  "dependencies": {
+    "CodeGeneration.Roslyn": {
+      "version": "0.1.28-alpha",
+      "suppressParent": "none"
+    },
+    "Nerdbank.GitVersioning": {
+      "version": "1.1.61-rc",
+      "suppressParent": "none"
+    },
+    "Nuproj.Common": {
+      "version": "0.10.27-beta-g2363d7cd98",
+      "suppressParent": "none"
+    },
+    "StyleCop.Analyzers": "1.0.0-rc2"
+  },
+  "frameworks": {
+    ".NETPortable,Version=v4.0,Profile=Profile92": { }
+  },
+  "runtimes": {
+    "win-anycpu": { },
+    "win": { }
+  }
+}

--- a/src/EnlistmentInfo.targets
+++ b/src/EnlistmentInfo.targets
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json"/>
+    <GeneratorAssemblySearchPaths Include="$(MSBuildThisFileDirectory)..\bin\$(Configuration)\Desktop\" />
   </ItemGroup>
 
   <Import Project="NuProj.Extra.targets" Condition=" '$(MSBuildProjectExtension)' == '.nuproj' "/>

--- a/src/PInvoke.sln
+++ b/src/PInvoke.sln
@@ -121,6 +121,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CodeGen", "CodeGen", "{BC58
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeGeneration.Debugging", "CodeGeneration.Debugging\CodeGeneration.Debugging.csproj", "{95305207-62AE-4019-83EC-079008625219}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeGenerationAttributes.Net40", "CodeGenerationAttributes.Net40\CodeGenerationAttributes.Net40.csproj", "{6A77281B-C503-44EA-90C1-0E9868D06CD0}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		AdvApi32.Shared\AdvApi32.Shared.projitems*{3fcbf2e0-1330-454c-8a17-af14eba6b244}*SharedItemsImports = 4
@@ -309,6 +311,10 @@ Global
 		{95305207-62AE-4019-83EC-079008625219}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{95305207-62AE-4019-83EC-079008625219}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{95305207-62AE-4019-83EC-079008625219}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A77281B-C503-44EA-90C1-0E9868D06CD0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A77281B-C503-44EA-90C1-0E9868D06CD0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A77281B-C503-44EA-90C1-0E9868D06CD0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A77281B-C503-44EA-90C1-0E9868D06CD0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -317,5 +323,6 @@ Global
 		{C1815471-02AF-4BB9-8D83-652ADBAFF5B6} = {BC58E358-D202-41B7-BDC3-38E084F36F0B}
 		{1387E009-7086-4572-AC8D-CE4242ADEC77} = {BC58E358-D202-41B7-BDC3-38E084F36F0B}
 		{95305207-62AE-4019-83EC-079008625219} = {BC58E358-D202-41B7-BDC3-38E084F36F0B}
+		{6A77281B-C503-44EA-90C1-0E9868D06CD0} = {BC58E358-D202-41B7-BDC3-38E084F36F0B}
 	EndGlobalSection
 EndGlobal

--- a/src/PInvoke.sln
+++ b/src/PInvoke.sln
@@ -113,6 +113,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AdvApi32", "AdvApi32\AdvApi
 EndProject
 Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "PInvoke.Win32", "PInvoke.Win32\PInvoke.Win32.nuproj", "{65008241-13FE-4DA1-A197-28795195B6C2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeGeneration", "CodeGeneration\CodeGeneration.csproj", "{C1815471-02AF-4BB9-8D83-652ADBAFF5B6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeGenerationAttributes", "CodeGenerationAttributes\CodeGenerationAttributes.csproj", "{1387E009-7086-4572-AC8D-CE4242ADEC77}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CodeGen", "CodeGen", "{BC58E358-D202-41B7-BDC3-38E084F36F0B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeGeneration.Debugging", "CodeGeneration.Debugging\CodeGeneration.Debugging.csproj", "{95305207-62AE-4019-83EC-079008625219}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		AdvApi32.Shared\AdvApi32.Shared.projitems*{3fcbf2e0-1330-454c-8a17-af14eba6b244}*SharedItemsImports = 4
@@ -289,8 +297,25 @@ Global
 		{65008241-13FE-4DA1-A197-28795195B6C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{65008241-13FE-4DA1-A197-28795195B6C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{65008241-13FE-4DA1-A197-28795195B6C2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C1815471-02AF-4BB9-8D83-652ADBAFF5B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C1815471-02AF-4BB9-8D83-652ADBAFF5B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C1815471-02AF-4BB9-8D83-652ADBAFF5B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C1815471-02AF-4BB9-8D83-652ADBAFF5B6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1387E009-7086-4572-AC8D-CE4242ADEC77}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1387E009-7086-4572-AC8D-CE4242ADEC77}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1387E009-7086-4572-AC8D-CE4242ADEC77}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1387E009-7086-4572-AC8D-CE4242ADEC77}.Release|Any CPU.Build.0 = Release|Any CPU
+		{95305207-62AE-4019-83EC-079008625219}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{95305207-62AE-4019-83EC-079008625219}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{95305207-62AE-4019-83EC-079008625219}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{95305207-62AE-4019-83EC-079008625219}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{C1815471-02AF-4BB9-8D83-652ADBAFF5B6} = {BC58E358-D202-41B7-BDC3-38E084F36F0B}
+		{1387E009-7086-4572-AC8D-CE4242ADEC77} = {BC58E358-D202-41B7-BDC3-38E084F36F0B}
+		{95305207-62AE-4019-83EC-079008625219} = {BC58E358-D202-41B7-BDC3-38E084F36F0B}
 	EndGlobalSection
 EndGlobal

--- a/templates/LIBNAME.Shared/LIBNAME.Shared.projitems
+++ b/templates/LIBNAME.Shared/LIBNAME.Shared.projitems
@@ -10,6 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)LIBNAME.Helpers.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)LIBNAME.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)LIBNAME.cs">
+      <Generator>MSBuild:GenerateCodeFromAttributes</Generator>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/templates/LIBNAME.Shared/LIBNAME.cs
+++ b/templates/LIBNAME.Shared/LIBNAME.cs
@@ -10,7 +10,7 @@ namespace PInvoke
     /// Exported functions from the LIBNAME.dll Windows library
     /// that are available to Desktop and Store apps.
     /// </summary>
-    [OfferIntPtrOverload]
+    [OfferIntPtrOverloads]
     public static partial class LIBNAME
     {
     }

--- a/templates/LIBNAME.Shared/LIBNAME.cs
+++ b/templates/LIBNAME.Shared/LIBNAME.cs
@@ -10,6 +10,7 @@ namespace PInvoke
     /// Exported functions from the LIBNAME.dll Windows library
     /// that are available to Desktop and Store apps.
     /// </summary>
+    [OfferIntPtrOverload]
     public static partial class LIBNAME
     {
     }

--- a/templates/LIBNAME/LIBNAME.csproj
+++ b/templates/LIBNAME/LIBNAME.csproj
@@ -29,6 +29,16 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\CodeGenerationAttributes\CodeGenerationAttributes.csproj">
+      <Project>{1387e009-7086-4572-ac8d-ce4242adec77}</Project>
+      <Name>CodeGenerationAttributes</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\CodeGeneration\CodeGeneration.csproj">
+      <Project>{C1815471-02AF-4BB9-8D83-652ADBAFF5B6}</Project>
+      <Name>CodeGeneration</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
     <ProjectReference Include="..\Windows.Core\Windows.Core.csproj">
       <Project>{b08c3c79-4cdd-4d37-933c-07d3452fd5f1}</Project>
       <Name>Windows.Core</Name>


### PR DESCRIPTION
Introduces code generation that automatically adds `IntPtr` overloads of methods with native pointers.

This will close #95 when merged to master. I'm merging to a staging branch for now so we can review it without also re-reviewing the changes to bcrypt and advapi32 that removed the intptr overloads.

**Design**

We rely on the new CodeGeneration.Roslyn nuget package for the framework in which we generate code. This frees us from much of the grunt work of code generation such as .targets and MSBuild Task authoring, locked files, etc. We can adjust the code generation code in VS and build the solution without any reloading and it immediately takes effect. We can even hit F5 and debug the code generation itself which of course can turn in handy. 
All extra dependencies (on the nuget package and assemblies defining attributes and code generation) evaporate during the build. No references remain so the end user is not impacted.

The IntPtr overloads are generated into files that are created in the intermediate output directory. They are added to `@(Compile)` so the same assembly and same type that contains the native pointer method also contains the IntPtr overload. This generated code is available at design-time, so you can Go to Definition on it, find it in the member jump list at the top of the document, etc.
