### PR TITLE
Fix IntPtr overload code gen when native pointers are ref/out parameters

### DIFF
--- a/src/CodeGeneration.Debugging/CodeGeneration.Debugging.csproj
+++ b/src/CodeGeneration.Debugging/CodeGeneration.Debugging.csproj
@@ -49,6 +49,12 @@
   <ItemGroup>
     <None Include="App.config" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\CodeGeneration\CodeGeneration.csproj">
+      <Project>{c1815471-02af-4bb9-8d83-652adbaff5b6}</Project>
+      <Name>CodeGeneration</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
The new generated code for the method is below. Note the care taken to handle `out` and `ref` parameters.

``` csharp
public static unsafe int StrongNameGetPublicKey(string szKeyContainer, System.IntPtr pbKeyBlob, int cbKeyBlob, out System.IntPtr ppbPublicKeyBlob, out int pcbPublicKeyBlob)
{
    byte* pbKeyBlobLocal = (byte*)pbKeyBlob.ToPointer();
    byte* ppbPublicKeyBlobLocal;
    int result = StrongNameGetPublicKey(szKeyContainer, pbKeyBlobLocal, cbKeyBlob, out ppbPublicKeyBlobLocal, out pcbPublicKeyBlob);
    ppbPublicKeyBlob = new System.IntPtr(ppbPublicKeyBlobLocal);
    return result;
}
```

Remind me again why the code gen generates method bodies rather than just generating another `[DllImport]` overload?
