### PR TITLE
Fix code generation for shared + platform files, and #directives

### DIFF
--- a/src/CodeGeneration/OfferIntPtrOverloadGenerator.cs
+++ b/src/CodeGeneration/OfferIntPtrOverloadGenerator.cs
@@ -49,7 +49,8 @@ namespace PInvoke
                     .WithParameterList(TransformParameterList(method.ParameterList))
                     .WithModifiers(RemoveModifier(method.Modifiers, SyntaxKind.ExternKeyword))
                     .WithAttributeLists(SyntaxFactory.List<AttributeListSyntax>())
-                    .WithLeadingTrivia(method.GetLeadingTrivia())
+                    .WithLeadingTrivia(method.GetLeadingTrivia().Where(t => !t.IsDirective))
+                    .WithTrailingTrivia(method.GetTrailingTrivia().Where(t => !t.IsDirective))
                     .WithBody(CallNativePointerOverload(method))
                     .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.None));
                 generatedType = generatedType.AddMembers(intPtrOverload);

--- a/src/CodeGeneration/OfferIntPtrOverloadGenerator.cs
+++ b/src/CodeGeneration/OfferIntPtrOverloadGenerator.cs
@@ -32,7 +32,7 @@ namespace PInvoke
         }
 
         /// <inheritdoc />
-        public Task<IReadOnlyList<MemberDeclarationSyntax>> GenerateAsync(MemberDeclarationSyntax applyTo, Document document, IProgressAndErrors progress, CancellationToken cancellationToken)
+        public Task<IReadOnlyList<MemberDeclarationSyntax>> GenerateAsync(MemberDeclarationSyntax applyTo, Document document, IProgress<Diagnostic> progress, CancellationToken cancellationToken)
         {
             var type = (ClassDeclarationSyntax)applyTo;
             var result = new List<MemberDeclarationSyntax>();

--- a/src/CodeGeneration/OfferIntPtrOverloadGenerator.cs
+++ b/src/CodeGeneration/OfferIntPtrOverloadGenerator.cs
@@ -138,7 +138,7 @@ namespace PInvoke
 
             IdentifierNameSyntax resultVariableName = null;
             StatementSyntax invocationStatement;
-            if (nativePointerOverload.ReturnType != null)
+            if (nativePointerOverload.ReturnType != null && (nativePointerOverload.ReturnType as PredefinedTypeSyntax)?.Keyword.Kind() != SyntaxKind.VoidKeyword)
             {
                 resultVariableName = SyntaxFactory.IdentifierName("result"); // TODO: ensure this is unique.
                 invocationStatement = SyntaxFactory.LocalDeclarationStatement(

--- a/src/CodeGeneration/project.json
+++ b/src/CodeGeneration/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "CodeGeneration.Roslyn": {
-      "version": "0.1.28-alpha",
+      "version": "0.1.43-alpha",
       "suppressParent": "none"
     },
     "Nerdbank.GitVersioning": {

--- a/src/CodeGenerationAttributes.Net40/project.json
+++ b/src/CodeGenerationAttributes.Net40/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "CodeGeneration.Roslyn": {
-      "version": "0.1.28-alpha",
+      "version": "0.1.43-alpha",
       "suppressParent": "none"
     },
     "Nerdbank.GitVersioning": {

--- a/src/CodeGenerationAttributes/project.json
+++ b/src/CodeGenerationAttributes/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "CodeGeneration.Roslyn": {
-      "version": "0.1.28-alpha",
+      "version": "0.1.43-alpha",
       "suppressParent": "none"
     },
     "Nerdbank.GitVersioning": {


### PR DESCRIPTION
When `#if` directives are present, they'd get (partially) copied into generated code, leading to compiler errors.
Also as @jmelosegui predicted, when a library has a (shared) libname.cs file and a (platform) libname.cs file, code generation would break the build. 

This PR fixes both issues (one commit per issue).
