### PR TITLE
SetupAPI api work

### DIFF
--- a/src/SetupApi.Desktop/SetupApi+DeviceInterfaceDataFlags.cs
+++ b/src/SetupApi.Desktop/SetupApi+DeviceInterfaceDataFlags.cs
@@ -12,7 +12,7 @@ namespace PInvoke
     public partial class SetupApi
     {
         /// <summary>
-        /// The flags present in <see cref="DeviceInterfaceData" /> structure.
+        /// The flags present in <see cref="SP_DEVICE_INTERFACE_DATA" /> structure.
         /// </summary>
         [SuppressMessage("ReSharper", "InconsistentNaming", Justification = "Original API names are used for consistency")]
         [Flags]

--- a/src/SetupApi.Desktop/SetupApi+SP_DEVICE_INTERFACE_DATA.cs
+++ b/src/SetupApi.Desktop/SetupApi+SP_DEVICE_INTERFACE_DATA.cs
@@ -7,7 +7,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="DeviceInterfaceData"/> nested struct.
+    /// Contains the <see cref="SP_DEVICE_INTERFACE_DATA"/> nested struct.
     /// </content>
     public partial class SetupApi
     {
@@ -15,10 +15,10 @@ namespace PInvoke
         /// Defines a device interface in a device information set.
         /// </summary>
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
-        public struct DeviceInterfaceData
+        public struct SP_DEVICE_INTERFACE_DATA
         {
             /// <summary>
-            /// The size, in bytes, of the <see cref="DeviceInterfaceData" /> structure. <see cref="Create" /> set this value
+            /// The size, in bytes, of the <see cref="SP_DEVICE_INTERFACE_DATA" /> structure. <see cref="Create" /> set this value
             /// automatically
             /// to the correct value.
             /// </summary>
@@ -42,10 +42,10 @@ namespace PInvoke
             /// <summary>
             /// Create an instance with <see cref="Size" /> set to the correct value.
             /// </summary>
-            /// <returns>An instance of <see cref="DeviceInterfaceData" /> with it's <see cref="Size" /> member set.</returns>
-            public static DeviceInterfaceData Create()
+            /// <returns>An instance of <see cref="SP_DEVICE_INTERFACE_DATA" /> with it's <see cref="Size" /> member set.</returns>
+            public static SP_DEVICE_INTERFACE_DATA Create()
             {
-                var result = default(DeviceInterfaceData);
+                var result = default(SP_DEVICE_INTERFACE_DATA);
                 result.Size = Marshal.SizeOf(result);
                 return result;
             }

--- a/src/SetupApi.Desktop/SetupApi+SP_DEVICE_INTERFACE_DETAIL_DATA.cs
+++ b/src/SetupApi.Desktop/SetupApi+SP_DEVICE_INTERFACE_DETAIL_DATA.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) to owners found in https://github.com/AArnott/pinvoke/blob/master/COPYRIGHT.md. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+
+namespace PInvoke
+{
+    using System;
+    using System.Runtime.InteropServices;
+
+    /// <content>
+    /// Contains the <see cref="SP_DEVICE_INTERFACE_DETAIL_DATA"/> nested type.
+    /// </content>
+    public partial class SetupApi
+    {
+        /// <summary>
+        /// An SP_DEVICE_INTERFACE_DETAIL_DATA structure contains the path for a device interface.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        public unsafe struct SP_DEVICE_INTERFACE_DETAIL_DATA
+        {
+            /// <summary>
+            /// The size, in bytes, of the <see cref="SP_DEVICE_INTERFACE_DETAIL_DATA"/> structure.
+            /// </summary>
+            /// <remarks>
+            /// This member always contains the size of the fixed part of the data structure, not a size reflecting the
+            /// variable-length string at the end.
+            /// </remarks>
+            public int cbSize;
+
+            /// <summary>
+            /// A NULL-terminated string that contains the device interface path. This path can be passed to Win32 functions such as CreateFile.
+            /// </summary>
+            public fixed char DevicePath[1];
+
+            /// <summary>
+            /// Gets the value that should be set to the <see cref="cbSize"/> field.
+            /// </summary>
+            /// <remarks>
+            /// The structure size take into account an Int32 and a character.
+            /// The character can be 1 or 2 octets depending on ANSI / Unicode,
+            /// leading to a total struct size of 5 or 6 bytes.
+            /// But on 64-bit OS, we report 8 bytes due to memory alignment.
+            /// </remarks>
+            public static int ReportableStructSize => IntPtr.Size == 4 ? 4 + Marshal.SystemDefaultCharSize : 8;
+
+            /// <summary>
+            /// Gets the full string pointed to by <see cref="DevicePath"/>.
+            /// </summary>
+            /// <param name="pSelf">
+            /// Note that this must be the original struct that was initialized by native memory.
+            /// It cannot be copied first as interop will not copy any more than the first character.
+            /// </param>
+            /// <returns>The full string.</returns>
+            /// <remarks>
+            /// This is a static method rather than an instance method to try to avoid the easy
+            /// mistake of calling the method on an instance that was copied.
+            /// </remarks>
+            public static string GetDevicePath(SP_DEVICE_INTERFACE_DETAIL_DATA* pSelf)
+            {
+                return Marshal.PtrToStringAuto(new IntPtr(pSelf->DevicePath));
+            }
+        }
+    }
+}

--- a/src/SetupApi.Desktop/SetupApi+SP_DEVICE_INTERFACE_DETAIL_DATA.cs
+++ b/src/SetupApi.Desktop/SetupApi+SP_DEVICE_INTERFACE_DETAIL_DATA.cs
@@ -14,7 +14,7 @@ namespace PInvoke
         /// <summary>
         /// An SP_DEVICE_INTERFACE_DETAIL_DATA structure contains the path for a device interface.
         /// </summary>
-        [StructLayout(LayoutKind.Sequential)]
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
         public unsafe struct SP_DEVICE_INTERFACE_DETAIL_DATA
         {
             /// <summary>

--- a/src/SetupApi.Desktop/SetupApi+SP_DEVINFO_DATA.cs
+++ b/src/SetupApi.Desktop/SetupApi+SP_DEVINFO_DATA.cs
@@ -8,7 +8,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="DeviceInfoData" /> nested struct.
+    /// Contains the <see cref="SP_DEVINFO_DATA" /> nested struct.
     /// </content>
     public partial class SetupApi
     {
@@ -20,7 +20,7 @@ namespace PInvoke
             "SA1401:Fields must be private",
             Justification = "Used in DllImport Marshaling.")]
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
-        public class DeviceInfoData
+        public class SP_DEVINFO_DATA
         {
             /// <summary>
             /// The GUID of the device's setup class.
@@ -30,7 +30,7 @@ namespace PInvoke
             /// <summary>
             /// An opaque handle to the device instance (also known as a handle to the devnode).
             /// <para>
-            /// Some functions, such as SetupDiXxx functions, take the whole <see cref="DeviceInfoData" /> structure as input to
+            /// Some functions, such as SetupDiXxx functions, take the whole <see cref="SP_DEVINFO_DATA" /> structure as input to
             /// identify a device in a device information set.Other functions, such as CM_Xxx functions like CM_Get_DevNode_Status,
             /// take this DevInst handle as input.
             /// </para>
@@ -43,16 +43,16 @@ namespace PInvoke
             public IntPtr Reserved;
 
             /// <summary>
-            /// The size, in bytes, of the <see cref="DeviceInfoData" /> structure. The constructor set this value automatically
+            /// The size, in bytes, of the <see cref="SP_DEVINFO_DATA" /> structure. The constructor set this value automatically
             /// to the correct size.
             /// </summary>
             public int Size;
 
             /// <summary>
-            /// Initializes a new instance of the <see cref="DeviceInfoData" /> class with <see cref="Size" /> set to the correct
+            /// Initializes a new instance of the <see cref="SP_DEVINFO_DATA" /> class with <see cref="Size" /> set to the correct
             /// value.
             /// </summary>
-            public DeviceInfoData()
+            public SP_DEVINFO_DATA()
             {
                 this.Size = Marshal.SizeOf(this);
             }

--- a/src/SetupApi.Desktop/SetupApi+SafeDeviceInfoSetHandle.cs
+++ b/src/SetupApi.Desktop/SetupApi+SafeDeviceInfoSetHandle.cs
@@ -14,7 +14,7 @@ namespace PInvoke
     {
         /// <summary>
         /// Represents a preparsed data handle created by
-        /// <see cref="SetupDiEnumDeviceInterfaces(SafeDeviceInfoSetHandle,DeviceInfoData,ref Guid,int,ref DeviceInterfaceData)"/>
+        /// <see cref="SetupDiEnumDeviceInterfaces(SafeDeviceInfoSetHandle,SP_DEVINFO_DATA,ref Guid,int,ref SP_DEVICE_INTERFACE_DATA)"/>
         /// that can be closed with <see cref="SetupDiDestroyDeviceInfoList"/>.
         /// </summary>
         public class SafeDeviceInfoSetHandle : SafeHandle

--- a/src/SetupApi.Desktop/SetupApi.Desktop.csproj
+++ b/src/SetupApi.Desktop/SetupApi.Desktop.csproj
@@ -38,8 +38,8 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="SetupApi+DeviceInfoData.cs" />
-    <Compile Include="SetupApi+DeviceInterfaceData.cs" />
+    <Compile Include="SetupApi+SP_DEVINFO_DATA.cs" />
+    <Compile Include="SetupApi+SP_DEVICE_INTERFACE_DATA.cs" />
     <Compile Include="SetupApi+DeviceInterfaceDataFlags.cs" />
     <Compile Include="SetupApi+GetClassDevsFlags.cs" />
     <Compile Include="SetupApi+SafeDeviceInfoSetHandle.cs" />

--- a/src/SetupApi.Desktop/SetupApi.Desktop.csproj
+++ b/src/SetupApi.Desktop/SetupApi.Desktop.csproj
@@ -38,6 +38,7 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="SetupApi+SP_DEVICE_INTERFACE_DETAIL_DATA.cs" />
     <Compile Include="SetupApi+SP_DEVINFO_DATA.cs" />
     <Compile Include="SetupApi+SP_DEVICE_INTERFACE_DATA.cs" />
     <Compile Include="SetupApi+DeviceInterfaceDataFlags.cs" />

--- a/src/SetupApi.Desktop/SetupApi.Helpers.cs
+++ b/src/SetupApi.Desktop/SetupApi.Helpers.cs
@@ -45,15 +45,15 @@ namespace PInvoke
             return result;
         }
 
-        public static IEnumerable<DeviceInterfaceData> SetupDiEnumDeviceInterfaces(
+        public static IEnumerable<SP_DEVICE_INTERFACE_DATA> SetupDiEnumDeviceInterfaces(
             SafeDeviceInfoSetHandle lpDeviceInfoSet,
-            DeviceInfoData deviceInfoData,
+            SP_DEVINFO_DATA deviceInfoData,
             Guid interfaceClassGuid)
         {
             int index = 0;
             while (true)
             {
-                var data = DeviceInterfaceData.Create();
+                var data = SP_DEVICE_INTERFACE_DATA.Create();
 
                 var result = SetupDiEnumDeviceInterfaces(
                     lpDeviceInfoSet,
@@ -80,8 +80,8 @@ namespace PInvoke
 
         public static string SetupDiGetDeviceInterfaceDetail(
             SafeDeviceInfoSetHandle deviceInfoSet,
-            DeviceInterfaceData interfaceData,
-            DeviceInfoData deviceInfoData)
+            SP_DEVICE_INTERFACE_DATA interfaceData,
+            SP_DEVINFO_DATA deviceInfoData)
         {
             var requiredSize = new NullableUInt32();
 

--- a/src/SetupApi.Desktop/SetupApi.cs
+++ b/src/SetupApi.Desktop/SetupApi.cs
@@ -68,7 +68,7 @@ namespace PInvoke
         /// return information. This handle is typically returned by <see cref="SetupDiGetClassDevs(NullableGuid,string,IntPtr,GetClassDevsFlags)" />.
         /// </param>
         /// <param name="deviceInfoData">
-        /// A pointer to an <see cref="DeviceInfoData" /> structure that specifies a device
+        /// A pointer to an <see cref="SP_DEVINFO_DATA" /> structure that specifies a device
         /// information element in DeviceInfoSet. This parameter is optional and can be <see langword="null" />. If this parameter
         /// is specified, SetupDiEnumDeviceInterfaces constrains the enumeration to the interfaces that are supported by the
         /// specified device. If this parameter is <see langword="null" />, repeated calls to SetupDiEnumDeviceInterfaces return
@@ -87,10 +87,10 @@ namespace PInvoke
         /// </param>
         /// <param name="deviceInterfaceData">
         /// A pointer to a caller-allocated buffer that contains, on successful return, a
-        /// completed <see cref="DeviceInterfaceData" /> structure that identifies an interface that meets the search parameters.
+        /// completed <see cref="SP_DEVICE_INTERFACE_DATA" /> structure that identifies an interface that meets the search parameters.
         /// The caller
-        /// must set <see cref="DeviceInterfaceData.Size" /> before calling this function either manually or via
-        /// <see cref="DeviceInterfaceData.Create" />.
+        /// must set <see cref="SP_DEVICE_INTERFACE_DATA.Size" /> before calling this function either manually or via
+        /// <see cref="SP_DEVICE_INTERFACE_DATA.Create" />.
         /// </param>
         /// <returns>
         /// Returns <see langword="true" /> if the function completed without error. If the function completed with an
@@ -100,10 +100,10 @@ namespace PInvoke
         [DllImport(nameof(SetupApi), SetLastError = true)]
         public static extern bool SetupDiEnumDeviceInterfaces(
             SafeDeviceInfoSetHandle deviceInfoSet,
-            DeviceInfoData deviceInfoData,
+            SP_DEVINFO_DATA deviceInfoData,
             ref Guid interfaceClassGuid,
             int memberIndex,
-            ref DeviceInterfaceData deviceInterfaceData);
+            ref SP_DEVICE_INTERFACE_DATA deviceInterfaceData);
 
         /// <summary>
         /// Returns details about a device interface.
@@ -113,9 +113,9 @@ namespace PInvoke
         /// return information. This handle is typically returned by <see cref="SetupDiGetClassDevs(NullableGuid,string,IntPtr,GetClassDevsFlags)" />.
         /// </param>
         /// <param name="deviceInterfaceData">
-        /// A pointer to an <see cref="DeviceInterfaceData" /> structure that specifies the
+        /// A pointer to an <see cref="SP_DEVICE_INTERFACE_DATA" /> structure that specifies the
         /// interface in DeviceInfoSet for which to retrieve details. A pointer of this type is typically returned by
-        /// <see cref="SetupDiEnumDeviceInterfaces(SafeDeviceInfoSetHandle,DeviceInfoData,ref Guid,int,ref DeviceInterfaceData)" />.
+        /// <see cref="SetupDiEnumDeviceInterfaces(SafeDeviceInfoSetHandle,SP_DEVINFO_DATA,ref Guid,int,ref SP_DEVICE_INTERFACE_DATA)" />.
         /// </param>
         /// <param name="deviceInterfaceDetailData">
         /// A pointer to an SP_DEVICE_INTERFACE_DETAIL_DATA structure to receive
@@ -137,7 +137,7 @@ namespace PInvoke
         /// </param>
         /// <param name="deviceInfoData">
         /// A pointer to a buffer that receives information about the device that supports the requested interface. The caller
-        /// must set <see cref="DeviceInfoData.Size" /> before calling this function.
+        /// must set <see cref="SP_DEVINFO_DATA.Size" /> before calling this function.
         /// <para>This parameter is optional and can be <see langword="null" />.</para>
         /// </param>
         /// <returns>
@@ -148,24 +148,24 @@ namespace PInvoke
         [DllImport(nameof(SetupApi), SetLastError = true, CharSet = CharSet.Unicode)]
         public static extern bool SetupDiGetDeviceInterfaceDetail(
             SafeDeviceInfoSetHandle deviceInfoSet,
-            ref DeviceInterfaceData deviceInterfaceData,
+            ref SP_DEVICE_INTERFACE_DATA deviceInterfaceData,
             IntPtr deviceInterfaceDetailData,
             int deviceInterfaceDetailDataSize,
             NullableUInt32 requiredSize,
-            DeviceInfoData deviceInfoData);
+            SP_DEVINFO_DATA deviceInfoData);
 
         /// <summary>
-        /// Returns a <see cref="DeviceInfoData" /> structure that specifies a device information element in a device information
+        /// Returns a <see cref="SP_DEVINFO_DATA" /> structure that specifies a device information element in a device information
         /// set.
         /// </summary>
         /// <param name="deviceInfoSet">
-        /// A handle to the device information set for which to return an <see cref="DeviceInfoData" />
+        /// A handle to the device information set for which to return an <see cref="SP_DEVINFO_DATA" />
         /// structure that represents a device information element.
         /// </param>
         /// <param name="memberIndex">A zero-based index of the device information element to retrieve.</param>
         /// <param name="deviceInfoData">
-        /// A pointer to an <see cref="DeviceInfoData"/> structure to receive information about an enumerated
-        /// device information element. The caller must set <see cref="DeviceInfoData.Size" /> before calling this function.
+        /// A pointer to an <see cref="SP_DEVINFO_DATA"/> structure to receive information about an enumerated
+        /// device information element. The caller must set <see cref="SP_DEVINFO_DATA.Size" /> before calling this function.
         /// </param>
         /// <returns>
         /// Returns <see langword="true" /> if the function completed without error. If the function completed with an
@@ -176,7 +176,7 @@ namespace PInvoke
         public static extern bool SetupDiEnumDeviceInfo(
             SafeDeviceInfoSetHandle deviceInfoSet,
             int memberIndex,
-            DeviceInfoData deviceInfoData);
+            SP_DEVINFO_DATA deviceInfoData);
 
         /// <summary>
         /// Deletes a device information set and frees all associated memory.

--- a/src/SetupApi.Desktop/SetupApi.cs
+++ b/src/SetupApi.Desktop/SetupApi.cs
@@ -121,9 +121,7 @@ namespace PInvoke
         /// A pointer to an SP_DEVICE_INTERFACE_DETAIL_DATA structure to receive
         /// information about the specified interface. This parameter is optional and can be <see langword="null" />. This
         /// parameter must be <see langword="null" /> if <paramref name="deviceInterfaceDetailDataSize"/> is zero. If this parameter is specified, the
-        /// caller must set <paramref name="deviceInterfaceDetailData"/>.cbSize to sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA) before calling this
-        /// function. The cbSize member always contains the size of the fixed part of the data structure, not a size reflecting the
-        /// variable-length string at the end.
+        /// caller must set <paramref name="deviceInterfaceDetailData"/>.cbSize to <see cref="SP_DEVICE_INTERFACE_DETAIL_DATA.ReportableStructSize"/>.
         /// </param>
         /// <param name="deviceInterfaceDetailDataSize">
         /// The size of the <paramref name="deviceInterfaceDetailData" /> buffer.
@@ -131,7 +129,7 @@ namespace PInvoke
         /// </param>
         /// <param name="requiredSize">
         /// A pointer to a variable of type <see cref="uint" /> that receives the required size of the
-        /// DeviceInterfaceDetailData buffer. This size includes the size of the fixed part of the structure plus the number of
+        /// <paramref name="deviceInterfaceDetailData"/> buffer. This size includes the size of the fixed part of the structure plus the number of
         /// bytes required for the variable-length device path string. This parameter is optional and can be
         /// <see langword="null" />.
         /// </param>
@@ -146,12 +144,12 @@ namespace PInvoke
         /// <see cref="Marshal.GetLastWin32Error" />.
         /// </returns>
         [DllImport(nameof(SetupApi), SetLastError = true, CharSet = CharSet.Unicode)]
-        public static extern bool SetupDiGetDeviceInterfaceDetail(
+        public static extern unsafe bool SetupDiGetDeviceInterfaceDetail(
             SafeDeviceInfoSetHandle deviceInfoSet,
             ref SP_DEVICE_INTERFACE_DATA deviceInterfaceData,
-            IntPtr deviceInterfaceDetailData,
+            SP_DEVICE_INTERFACE_DETAIL_DATA* deviceInterfaceDetailData,
             int deviceInterfaceDetailDataSize,
-            NullableUInt32 requiredSize,
+            int* requiredSize,
             SP_DEVINFO_DATA deviceInfoData);
 
         /// <summary>


### PR DESCRIPTION
Rename types to match native names
Define and use SP_DEVICE_INTERFACE_DETAIL_DATA

I haven't been able to test these changes. @vbfox, I believe you have a scenario that uses this. Would you mind reviewing and testing?
