### PR TITLE
Throw exception based on NTStatus->HRESULT instead of on NTStatus->Win32ErrorCode

### DIFF
--- a/src/Kernel32.Shared/Kernel32Extensions.cs
+++ b/src/Kernel32.Shared/Kernel32Extensions.cs
@@ -6,18 +6,6 @@ namespace PInvoke
     public static class Kernel32Extensions
     {
         /// <summary>
-        /// Throws an exception if a P/Invoke failed.
-        /// </summary>
-        /// <param name="status">The result of the P/Invoke call.</param>
-        public static void ThrowOnError(this NTStatus status)
-        {
-            if ((int)status < 0)
-            {
-                status.ToWin32ErrorCode().ThrowOnError();
-            }
-        }
-
-        /// <summary>
         /// Throws an exception when an error occurs.
         /// </summary>
         /// <param name="errorCode">The result of the P/Invoke call.</param>

--- a/src/Windows.Core/NTStatusFacilities.cs
+++ b/src/Windows.Core/NTStatusFacilities.cs
@@ -8,6 +8,7 @@ namespace PInvoke
     /// </summary>
     internal static class NTStatusFacilities
     {
+        internal const uint NTStatusFacility = 0x10000000;
         internal const uint HidErrorCode = (uint)0x11 << 16;
     }
 }

--- a/src/Windows.Core/PInvokeExtensions.cs
+++ b/src/Windows.Core/PInvokeExtensions.cs
@@ -4,6 +4,7 @@
 namespace PInvoke
 {
     using System;
+    using System.Runtime.InteropServices;
 
     /// <summary>
     /// Extension methods for commonly defined types.
@@ -18,6 +19,30 @@ namespace PInvoke
         public static NTStatus ToNTStatus(int hresult)
         {
             return (NTStatus)((hresult & 0xC0007FFF) | ((int)NTStatus.FACILITY_FILTER_MANAGER << 16) | 0x40000000);
+        }
+
+        /// <summary>
+        /// Converts an NTStatus to an HRESULT.
+        /// </summary>
+        /// <param name="status">The <see cref="NTStatus"/> to convert.</param>
+        /// <returns>The HRESULT.</returns>
+        public static int ToHResult(this NTStatus status)
+        {
+            // From winerror.h
+            // #define HRESULT_FROM_NT(x)      ((HRESULT) ((x) | FACILITY_NT_BIT))
+            return (int)status | (int)NTStatusFacilities.NTStatusFacility;
+        }
+
+        /// <summary>
+        /// Throws an exception if a P/Invoke failed.
+        /// </summary>
+        /// <param name="status">The result of the P/Invoke call.</param>
+        public static void ThrowOnError(this NTStatus status)
+        {
+            if ((int)status < 0)
+            {
+                Marshal.ThrowExceptionForHR(status.ToHResult());
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Converting NTStatus to Win32 error codes is incomplete, and the recommendation generally seems to be to convert to HRESULT instead.

The impetus for this change is that in throwing exceptions for NTStatus errors, I was getting exceptions for the inability to convert the particular NTStatus value to an equivalent Win32 error. So in general the approach of throwing Win32Exception for NTStatus returning methods seems faulty. This change switches it to throw using Marshal.ThrowExceptionForHR instead after converting the NTStatus to an HRESULT, which is more straightforward.
