### PR TITLE
Fix NTStatus exception messages to include enum name

### DIFF
--- a/src/Kernel32.Desktop/Kernel32Extensions.cs
+++ b/src/Kernel32.Desktop/Kernel32Extensions.cs
@@ -14,7 +14,7 @@ namespace PInvoke
         /// Gets the text associated with an <see cref="NTStatus"/>.
         /// </summary>
         /// <param name="status">The error code.</param>
-        /// <returns>The error message.</returns>
+        /// <returns>The error message. Or <c>null</c> if no message could be found.</returns>
         public static string GetMessage(this NTStatus status)
         {
             using (var ntdll = LoadLibrary("ntdll.dll"))
@@ -32,7 +32,7 @@ namespace PInvoke
                 }
             }
 
-            return $"Unknown NT_STATUS error (0x{status:x8})";
+            return null;
         }
     }
 }

--- a/src/Kernel32.Shared/Kernel32Extensions.cs
+++ b/src/Kernel32.Shared/Kernel32Extensions.cs
@@ -19,7 +19,7 @@ namespace PInvoke
         /// Gets the text associated with a <see cref="Win32ErrorCode"/>.
         /// </summary>
         /// <param name="error">The error code.</param>
-        /// <returns>The error message.</returns>
+        /// <returns>The error message. Or <c>null</c> if no message could be found.</returns>
         public static unsafe string GetMessage(this Win32ErrorCode error)
         {
             return FormatMessage(
@@ -28,7 +28,7 @@ namespace PInvoke
                 (int)error,
                 0,
                 null,
-                MaxAllowedBufferSize) ?? $"Unknown Win32 error (0x{(int)error:x8})";
+                MaxAllowedBufferSize);
         }
 
         /// <summary>

--- a/src/Kernel32.Shared/NTStatusException.cs
+++ b/src/Kernel32.Shared/NTStatusException.cs
@@ -20,7 +20,7 @@ namespace PInvoke
         /// </summary>
         /// <param name="statusCode">The status code identifying the error.</param>
         public NTStatusException(NTStatus statusCode)
-            : this(statusCode, null)
+            : this(statusCode, null, null)
         {
         }
 
@@ -30,9 +30,8 @@ namespace PInvoke
         /// <param name="statusCode">The status code identifying the error.</param>
         /// <param name="message">The exception message (which may be null to use the default).</param>
         public NTStatusException(NTStatus statusCode, string message)
-            : base(message ?? GetMessage(statusCode))
+            : this(statusCode, message, null)
         {
-            this.StatusCode = statusCode;
         }
 
         /// <summary>
@@ -82,11 +81,16 @@ namespace PInvoke
         /// <returns>The description of the error.</returns>
         private static string GetMessage(NTStatus status)
         {
+            string statusAsString = Enum.GetName(typeof(NTStatus.Code), status.AsUInt32) ?? $"0x{(int)status:x8}";
+            string insert = $"NT_STATUS error: {statusAsString}";
+            string message = null;
 #if DESKTOP
-            return status.GetMessage();
-#else
-            return $"Unknown NT_STATUS error (0x{status:x8})";
+            message = status.GetMessage();
 #endif
+
+            return message != null
+                ? $"{message} ({insert})"
+                : insert;
         }
     }
 }

--- a/src/Kernel32.Shared/NTStatusException.cs
+++ b/src/Kernel32.Shared/NTStatusException.cs
@@ -81,8 +81,12 @@ namespace PInvoke
         /// <returns>The description of the error.</returns>
         private static string GetMessage(NTStatus status)
         {
-            string statusAsString = Enum.GetName(typeof(NTStatus.Code), status.AsUInt32) ?? $"0x{(int)status:x8}";
-            string insert = $"NT_STATUS error: {statusAsString}";
+            string hexCode = $"0x{(int)status:X8}";
+            string namedCode = Enum.GetName(typeof(NTStatus.Code), status.AsUInt32);
+            string statusAsString = namedCode != null
+                ? $"{namedCode} ({hexCode})"
+                : hexCode;
+            string insert = $"NT_STATUS {GetSeverityString(status)}: {statusAsString}";
             string message = null;
 #if DESKTOP
             message = status.GetMessage();
@@ -91,6 +95,23 @@ namespace PInvoke
             return message != null
                 ? $"{message} ({insert})"
                 : insert;
+        }
+
+        private static string GetSeverityString(NTStatus status)
+        {
+            switch (status.Severity)
+            {
+                case NTStatus.SeverityCode.STATUS_SEVERITY_SUCCESS:
+                    return "success";
+                case NTStatus.SeverityCode.STATUS_SEVERITY_INFORMATIONAL:
+                    return "information";
+                case NTStatus.SeverityCode.STATUS_SEVERITY_WARNING:
+                    return "warning";
+                case NTStatus.SeverityCode.STATUS_SEVERITY_ERROR:
+                    return "error";
+                default:
+                    return string.Empty;
+            }
         }
     }
 }

--- a/src/Kernel32.Shared/NTStatusException.cs
+++ b/src/Kernel32.Shared/NTStatusException.cs
@@ -43,7 +43,7 @@ namespace PInvoke
         public NTStatusException(NTStatus statusCode, string message, Exception inner)
             : base(message ?? GetMessage(statusCode), inner)
         {
-            this.StatusCode = statusCode;
+            this.NativeErrorCode = statusCode;
         }
 
 #if DESKTOP
@@ -56,20 +56,20 @@ namespace PInvoke
         protected NTStatusException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            this.StatusCode = info.GetUInt32(nameof(this.StatusCode));
+            this.NativeErrorCode = info.GetUInt32(nameof(this.NativeErrorCode));
         }
 #endif
 
         /// <summary>
         /// Gets the <see cref="NTStatus"/> code that identifies the error condition.
         /// </summary>
-        public NTStatus StatusCode { get; }
+        public NTStatus NativeErrorCode { get; }
 
 #if DESKTOP
         /// <inheritdoc />
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
-            info.AddValue(nameof(this.StatusCode), this.StatusCode.AsUInt32);
+            info.AddValue(nameof(this.NativeErrorCode), this.NativeErrorCode.AsUInt32);
             base.GetObjectData(info, context);
         }
 #endif

--- a/src/Kernel32.Shared/Win32Exception.cs
+++ b/src/Kernel32.Shared/Win32Exception.cs
@@ -48,7 +48,7 @@ namespace PInvoke
 #if DESKTOP
             : base((int)error)
 #else
-            : this(error, error.GetMessage())
+            : this(error, error.GetMessage() ?? $"Unknown Win32 error (0x{(int)error:x8})")
 #endif
         {
         }

--- a/src/Kernel32.Tests.Shared/Kernel32ExtensionsTests.cs
+++ b/src/Kernel32.Tests.Shared/Kernel32ExtensionsTests.cs
@@ -41,9 +41,9 @@ public partial class Kernel32ExtensionsTests
         catch (NTStatusException ex)
         {
 #if DESKTOP
-            Assert.Equal("The remote procedure call failed", ex.Message);
+            Assert.Equal("The remote procedure call failed (NT_STATUS error: RPC_NT_CALL_FAILED)", ex.Message);
 #else
-            Assert.Equal("Unknown NT_STATUS error (0xc002001b)", ex.Message);
+            Assert.Equal("NT_STATUS error: RPC_NT_CALL_FAILED", ex.Message);
 #endif
         }
     }

--- a/src/Kernel32.Tests.Shared/Kernel32ExtensionsTests.cs
+++ b/src/Kernel32.Tests.Shared/Kernel32ExtensionsTests.cs
@@ -41,9 +41,9 @@ public partial class Kernel32ExtensionsTests
         catch (NTStatusException ex)
         {
 #if DESKTOP
-            Assert.Equal("The remote procedure call failed (NT_STATUS error: RPC_NT_CALL_FAILED)", ex.Message);
+            Assert.Equal("The remote procedure call failed (NT_STATUS error: RPC_NT_CALL_FAILED (0xC002001B))", ex.Message);
 #else
-            Assert.Equal("NT_STATUS error: RPC_NT_CALL_FAILED", ex.Message);
+            Assert.Equal("NT_STATUS error: RPC_NT_CALL_FAILED (0xC002001B)", ex.Message);
 #endif
         }
     }

--- a/src/Kernel32.Tests.Shared/NTStatusExceptionTests.cs
+++ b/src/Kernel32.Tests.Shared/NTStatusExceptionTests.cs
@@ -10,11 +10,11 @@ using static PInvoke.Kernel32;
 public partial class NTStatusExceptionTests
 {
     [Fact]
-    public void NTStatusException_StatusCode()
+    public void NTStatusException_NativeErrorCode()
     {
         NTStatus error = NTStatus.Code.EPT_NT_INVALID_ENTRY;
         var ex = new NTStatusException(error);
-        Assert.Equal(error, ex.StatusCode);
+        Assert.Equal(error, ex.NativeErrorCode);
     }
 
     [Fact]
@@ -78,7 +78,7 @@ public partial class NTStatusExceptionTests
     {
         NTStatus error = NTStatus.Code.EPT_NT_INVALID_ENTRY;
         var ex = new NTStatusException(error, "msg");
-        Assert.Equal(error, ex.StatusCode);
+        Assert.Equal(error, ex.NativeErrorCode);
         Assert.Equal("msg", ex.Message);
     }
 }

--- a/src/Kernel32.Tests.Shared/NTStatusExceptionTests.cs
+++ b/src/Kernel32.Tests.Shared/NTStatusExceptionTests.cs
@@ -10,7 +10,7 @@ using static PInvoke.Kernel32;
 public partial class NTStatusExceptionTests
 {
     [Fact]
-    public void NTStatusException_NativeErrorCode()
+    public void NTStatusException_StatusCode()
     {
         NTStatus error = NTStatus.Code.EPT_NT_INVALID_ENTRY;
         var ex = new NTStatusException(error);
@@ -23,9 +23,9 @@ public partial class NTStatusExceptionTests
         NTStatus error = NTStatus.Code.EPT_NT_INVALID_ENTRY;
         var ex = new NTStatusException(error);
 #if DESKTOP
-        Assert.Equal("The entry is invalid", ex.Message);
+        Assert.Equal("The entry is invalid (NT_STATUS error: EPT_NT_INVALID_ENTRY)", ex.Message);
 #else
-        Assert.Equal("Unknown NT_STATUS error (0xc0020034)", ex.Message);
+        Assert.Equal("NT_STATUS error: EPT_NT_INVALID_ENTRY", ex.Message);
 #endif
     }
 
@@ -34,7 +34,7 @@ public partial class NTStatusExceptionTests
     {
         NTStatus error = 0x11111111;
         var ex = new NTStatusException(error);
-        Assert.Equal("Unknown NT_STATUS error (0x11111111)", ex.Message);
+        Assert.Equal("NT_STATUS error: 0x11111111", ex.Message);
     }
 
     [Fact]

--- a/src/Kernel32.Tests.Shared/NTStatusExceptionTests.cs
+++ b/src/Kernel32.Tests.Shared/NTStatusExceptionTests.cs
@@ -18,23 +18,59 @@ public partial class NTStatusExceptionTests
     }
 
     [Fact]
-    public void NTStatusException_Message()
+    public void NTStatusException_Error_Message()
     {
         NTStatus error = NTStatus.Code.EPT_NT_INVALID_ENTRY;
         var ex = new NTStatusException(error);
 #if DESKTOP
-        Assert.Equal("The entry is invalid (NT_STATUS error: EPT_NT_INVALID_ENTRY)", ex.Message);
+        Assert.Equal("The entry is invalid (NT_STATUS error: EPT_NT_INVALID_ENTRY (0xC0020034))", ex.Message);
 #else
-        Assert.Equal("NT_STATUS error: EPT_NT_INVALID_ENTRY", ex.Message);
+        Assert.Equal("NT_STATUS error: EPT_NT_INVALID_ENTRY (0xC0020034)", ex.Message);
+#endif
+    }
+
+    [Fact]
+    public void NTStatusException_Warning_Message()
+    {
+        NTStatus error = NTStatus.Code.STATUS_BUFFER_OVERFLOW;
+        var ex = new NTStatusException(error);
+#if DESKTOP
+        Assert.Equal("{Buffer Overflow}\r\nThe data was too large to fit into the specified buffer (NT_STATUS warning: STATUS_BUFFER_OVERFLOW (0x80000005))", ex.Message);
+#else
+        Assert.Equal("NT_STATUS warning: STATUS_BUFFER_OVERFLOW (0x80000005)", ex.Message);
+#endif
+    }
+
+    [Fact]
+    public void NTStatusException_Informational_Message()
+    {
+        NTStatus error = NTStatus.Code.STATUS_WAKE_SYSTEM;
+        var ex = new NTStatusException(error);
+#if DESKTOP
+        Assert.Equal("The system has awoken (NT_STATUS information: STATUS_WAKE_SYSTEM (0x40000294))", ex.Message);
+#else
+        Assert.Equal("NT_STATUS information: STATUS_WAKE_SYSTEM (0x40000294)", ex.Message);
+#endif
+    }
+
+    [Fact]
+    public void NTStatusException_Success_Message()
+    {
+        NTStatus error = NTStatus.Code.STATUS_PENDING;
+        var ex = new NTStatusException(error);
+#if DESKTOP
+        Assert.Equal("The operation that was requested is pending completion (NT_STATUS success: STATUS_PENDING (0x00000103))", ex.Message);
+#else
+        Assert.Equal("NT_STATUS success: STATUS_PENDING (0x00000103)", ex.Message);
 #endif
     }
 
     [Fact]
     public void NTStatusException_MessageNotFound()
     {
-        NTStatus error = 0x11111111;
+        NTStatus error = 0xC1111111;
         var ex = new NTStatusException(error);
-        Assert.Equal("NT_STATUS error: 0x11111111", ex.Message);
+        Assert.Equal("NT_STATUS error: 0xC1111111", ex.Message);
     }
 
     [Fact]

--- a/src/Kernel32.Tests/Kernel32ExtensionsTests.cs
+++ b/src/Kernel32.Tests/Kernel32ExtensionsTests.cs
@@ -27,7 +27,7 @@ public partial class Kernel32ExtensionsTests
         ms.Position = 0;
         var deserializedException = (NTStatusException)formatter.Deserialize(ms);
         Assert.Equal(exception.Message, deserializedException.Message);
-        Assert.Equal(exception.StatusCode, deserializedException.StatusCode);
+        Assert.Equal(exception.NativeErrorCode, deserializedException.NativeErrorCode);
     }
 
     [Fact]


### PR DESCRIPTION
On WinRT profiles, this is the only clue we can provide beyond the number itself.

On desktop, you get:
`[message] (enumName (hex value))`

On WinRT you get:
`enumName (hex value)`
