### PR TITLE
Rename NTStatus to NTSTATUS

### DIFF
--- a/src/AdvApi32.Desktop/AdvApi32.cs
+++ b/src/AdvApi32.Desktop/AdvApi32.cs
@@ -113,6 +113,6 @@ namespace PInvoke
         /// The return value is the Windows error code that corresponds to the Status parameter. If there is no corresponding Windows error code, the return value is <see cref="Win32ErrorCode.ERROR_MR_MID_NOT_FOUND"/>.
         /// </returns>
         [DllImport(nameof(AdvApi32))]
-        public static extern Win32ErrorCode LsaNtStatusToWinError(NTStatus Status);
+        public static extern Win32ErrorCode LsaNtStatusToWinError(NTSTATUS Status);
     }
 }

--- a/src/AdvApi32.Tests/AdvApi32.cs
+++ b/src/AdvApi32.Tests/AdvApi32.cs
@@ -11,6 +11,6 @@ public class AdvApi32
     [Fact]
     public void LsaNtStatusToWinError_UsesTable()
     {
-        Assert.Equal(Win32ErrorCode.ERROR_NOACCESS, LsaNtStatusToWinError(NTStatus.Code.STATUS_ACCESS_VIOLATION));
+        Assert.Equal(Win32ErrorCode.ERROR_NOACCESS, LsaNtStatusToWinError(NTSTATUS.Code.STATUS_ACCESS_VIOLATION));
     }
 }

--- a/src/BCrypt.Tests/BCrypt.cs
+++ b/src/BCrypt.Tests/BCrypt.cs
@@ -126,7 +126,7 @@ public class BCrypt
             using (var key = BCryptGenerateSymmetricKey(provider, keyMaterial))
             {
                 // Verify that without padding, an error is returned.
-                Assert.Equal<NTStatus>(NTStatus.Code.STATUS_INVALID_BUFFER_SIZE, BCryptEncrypt(key, plainText, plainText.Length, null, null, 0, null, 0, out cipherTextLength, BCryptEncryptFlags.None));
+                Assert.Equal<NTSTATUS>(NTSTATUS.Code.STATUS_INVALID_BUFFER_SIZE, BCryptEncrypt(key, plainText, plainText.Length, null, null, 0, null, 0, out cipherTextLength, BCryptEncryptFlags.None));
 
                 // Now do our own padding (zeros).
                 blockSize = BCryptGetProperty<int>(provider, PropertyNames.BCRYPT_BLOCK_LENGTH);
@@ -166,7 +166,7 @@ public class BCrypt
             using (var key = BCryptGenerateSymmetricKey(provider, keyMaterial))
             {
                 // Verify that without padding, an error is returned.
-                Assert.Equal<NTStatus>(NTStatus.Code.STATUS_INVALID_BUFFER_SIZE, BCryptEncrypt(key, plainText, plainText.Length, null, null, 0, null, 0, out cipherTextLength, BCryptEncryptFlags.None));
+                Assert.Equal<NTSTATUS>(NTSTATUS.Code.STATUS_INVALID_BUFFER_SIZE, BCryptEncrypt(key, plainText, plainText.Length, null, null, 0, null, 0, out cipherTextLength, BCryptEncryptFlags.None));
 
                 // Now do our own padding (zeros).
                 blockSize = BCryptGetProperty<int>(provider, PropertyNames.BCRYPT_BLOCK_LENGTH);
@@ -357,11 +357,11 @@ public class BCrypt
                 BCryptFinalizeKeyPair(keyPair).ThrowOnError();
                 byte[] hashData = SHA1.Create().ComputeHash(new byte[] { 0x1 });
                 byte[] signature = BCryptSignHash(keyPair, hashData).ToArray();
-                NTStatus status = BCryptVerifySignature(keyPair, null, hashData, hashData.Length, signature, signature.Length);
-                Assert.Equal<NTStatus>(NTStatus.Code.STATUS_SUCCESS, status);
+                NTSTATUS status = BCryptVerifySignature(keyPair, null, hashData, hashData.Length, signature, signature.Length);
+                Assert.Equal<NTSTATUS>(NTSTATUS.Code.STATUS_SUCCESS, status);
                 signature[0] = unchecked((byte)(signature[0] + 1));
                 status = BCryptVerifySignature(keyPair, null, hashData, hashData.Length, signature, signature.Length);
-                Assert.Equal<NTStatus>(NTStatus.Code.STATUS_INVALID_SIGNATURE, status);
+                Assert.Equal<NTSTATUS>(NTSTATUS.Code.STATUS_INVALID_SIGNATURE, status);
             }
         }
     }

--- a/src/BCrypt/BCrypt+SafeAlgorithmHandle.cs
+++ b/src/BCrypt/BCrypt+SafeAlgorithmHandle.cs
@@ -35,7 +35,7 @@ namespace PInvoke
             /// <inheritdoc />
             protected override bool ReleaseHandle()
             {
-                return BCryptCloseAlgorithmProvider(this.handle, 0) == NTStatus.Code.STATUS_SUCCESS;
+                return BCryptCloseAlgorithmProvider(this.handle, 0) == NTSTATUS.Code.STATUS_SUCCESS;
             }
         }
     }

--- a/src/BCrypt/BCrypt+SafeHashHandle.cs
+++ b/src/BCrypt/BCrypt+SafeHashHandle.cs
@@ -35,7 +35,7 @@ namespace PInvoke
             /// <inheritdoc />
             protected override bool ReleaseHandle()
             {
-                return BCryptDestroyHash(this.handle) == NTStatus.Code.STATUS_SUCCESS;
+                return BCryptDestroyHash(this.handle) == NTSTATUS.Code.STATUS_SUCCESS;
             }
         }
     }

--- a/src/BCrypt/BCrypt+SafeKeyHandle.cs
+++ b/src/BCrypt/BCrypt+SafeKeyHandle.cs
@@ -35,7 +35,7 @@ namespace PInvoke
             /// <inheritdoc />
             protected override bool ReleaseHandle()
             {
-                return BCryptDestroyKey(this.handle) == NTStatus.Code.STATUS_SUCCESS;
+                return BCryptDestroyKey(this.handle) == NTSTATUS.Code.STATUS_SUCCESS;
             }
         }
     }

--- a/src/BCrypt/BCrypt+SafeSecretHandle.cs
+++ b/src/BCrypt/BCrypt+SafeSecretHandle.cs
@@ -35,7 +35,7 @@ namespace PInvoke
             /// <inheritdoc />
             protected override bool ReleaseHandle()
             {
-                return BCryptDestroySecret(this.handle) == NTStatus.Code.STATUS_SUCCESS;
+                return BCryptDestroySecret(this.handle) == NTSTATUS.Code.STATUS_SUCCESS;
             }
         }
     }

--- a/src/BCrypt/BCrypt.Helpers.cs
+++ b/src/BCrypt/BCrypt.Helpers.cs
@@ -352,7 +352,7 @@ namespace PInvoke
         /// </param>
         /// <param name="output">
         /// The address of the buffer that receives the ciphertext produced by this function. For more information, see Remarks.
-        /// If this parameter is NULL, the <see cref="BCryptEncrypt(SafeKeyHandle, byte[], void*, byte[], BCryptEncryptFlags)"/> function calculates the size needed for the ciphertext of the data passed in the <paramref name="input"/> parameter. In this case, the location pointed to by the <paramref name="outputLength"/> parameter contains this size, and the function returns <see cref="NTStatus.Code.STATUS_SUCCESS"/>.The <paramref name="paddingInfo"/> parameter is not modified.
+        /// If this parameter is NULL, the <see cref="BCryptEncrypt(SafeKeyHandle, byte[], void*, byte[], BCryptEncryptFlags)"/> function calculates the size needed for the ciphertext of the data passed in the <paramref name="input"/> parameter. In this case, the location pointed to by the <paramref name="outputLength"/> parameter contains this size, and the function returns <see cref="NTSTATUS.Code.STATUS_SUCCESS"/>.The <paramref name="paddingInfo"/> parameter is not modified.
         /// If the values of both the <paramref name="output"/> and <paramref name="input"/> parameters are NULL, an error is returned unless an authenticated encryption algorithm is in use.In the latter case, the call is treated as an authenticated encryption call with zero length data, and the authentication tag is returned in the <paramref name="paddingInfo"/> parameter.
         /// </param>
         /// <param name="outputLength">
@@ -362,7 +362,7 @@ namespace PInvoke
         /// A set of flags that modify the behavior of this function. The allowed set of flags depends on the type of key specified by the hKey parameter.
         /// </param>
         /// <returns>The encrypted ciphertext.</returns>
-        public static unsafe NTStatus BCryptEncrypt(
+        public static unsafe NTSTATUS BCryptEncrypt(
             SafeKeyHandle key,
             ArraySegment<byte>? input,
             void* paddingInfo,
@@ -478,7 +478,7 @@ namespace PInvoke
         /// </param>
         /// <param name="output">
         /// The address of a buffer to receive the plaintext produced by this function. The cbOutput parameter contains the size of this buffer. For more information, see Remarks.
-        /// If this parameter is NULL, the <see cref="BCryptDecrypt(SafeKeyHandle, byte[], void*, byte[], BCryptEncryptFlags)"/> function calculates the size required for the plaintext of the encrypted data passed in the <paramref name="input"/> parameter.In this case, the location pointed to by the <paramref name="outputLength"/> parameter contains this size, and the function returns <see cref="NTStatus.Code.STATUS_SUCCESS"/>.
+        /// If this parameter is NULL, the <see cref="BCryptDecrypt(SafeKeyHandle, byte[], void*, byte[], BCryptEncryptFlags)"/> function calculates the size required for the plaintext of the encrypted data passed in the <paramref name="input"/> parameter.In this case, the location pointed to by the <paramref name="outputLength"/> parameter contains this size, and the function returns <see cref="NTSTATUS.Code.STATUS_SUCCESS"/>.
         /// If the values of both the <paramref name="output"/> and <paramref name="input" /> parameters are NULL, an error is returned unless an authenticated encryption algorithm is in use.In the latter case, the call is treated as an authenticated encryption call with zero length data, and the authentication tag, passed in the <paramref name="paddingInfo"/> parameter, is verified.
         /// </param>
         /// <param name="outputLength">
@@ -488,7 +488,7 @@ namespace PInvoke
         /// A set of flags that modify the behavior of this function. The allowed set of flags depends on the type of key specified by the <paramref name="key"/> parameter.
         /// </param>
         /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
-        public static unsafe NTStatus BCryptDecrypt(
+        public static unsafe NTSTATUS BCryptDecrypt(
             SafeKeyHandle key,
             ArraySegment<byte>? input,
             void* paddingInfo,
@@ -627,7 +627,7 @@ namespace PInvoke
             void* paddingInfo = null,
             BCryptSignHashFlags flags = BCryptSignHashFlags.None)
         {
-            NTStatus status = BCryptVerifySignature(
+            NTSTATUS status = BCryptVerifySignature(
                 key,
                 paddingInfo,
                 hash,
@@ -636,7 +636,7 @@ namespace PInvoke
                 signature.Length,
                 flags);
 
-            if (status == NTStatus.Code.STATUS_INVALID_SIGNATURE)
+            if (status == NTSTATUS.Code.STATUS_INVALID_SIGNATURE)
             {
                 return false;
             }

--- a/src/BCrypt/BCrypt.cs
+++ b/src/BCrypt/BCrypt.cs
@@ -48,7 +48,7 @@ namespace PInvoke
         /// Returns a status code that indicates the success or failure of the function.
         /// </returns>
         [DllImport(nameof(BCrypt), SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
-        public static extern NTStatus BCryptOpenAlgorithmProvider(
+        public static extern NTSTATUS BCryptOpenAlgorithmProvider(
             out SafeAlgorithmHandle phAlgorithm,
             string pszAlgId,
             string pszImplementation,
@@ -83,7 +83,7 @@ namespace PInvoke
         /// <param name="dwFlags">Flags that modify the behavior of the function.</param>
         /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
         [DllImport(nameof(BCrypt), SetLastError = true)]
-        public static extern NTStatus BCryptCreateHash(
+        public static extern NTSTATUS BCryptCreateHash(
             SafeAlgorithmHandle hAlgorithm,
             out SafeHashHandle phHash,
             byte[] pbHashObject,
@@ -115,7 +115,7 @@ namespace PInvoke
         /// <param name="cbIV">The size, in bytes, of the pbIV buffer.</param>
         /// <param name="pbOutput">
         /// The address of the buffer that receives the ciphertext produced by this function. The <paramref name="cbOutput"/> parameter contains the size of this buffer. For more information, see Remarks.
-        /// If this parameter is NULL, the <see cref="BCryptEncrypt(SafeKeyHandle, byte[], void*, byte[], BCryptEncryptFlags)"/> function calculates the size needed for the ciphertext of the data passed in the <paramref name="pbInput"/> parameter. In this case, the location pointed to by the <paramref name="pcbResult"/> parameter contains this size, and the function returns <see cref="NTStatus.Code.STATUS_SUCCESS"/>.The <paramref name="pPaddingInfo"/> parameter is not modified.
+        /// If this parameter is NULL, the <see cref="BCryptEncrypt(SafeKeyHandle, byte[], void*, byte[], BCryptEncryptFlags)"/> function calculates the size needed for the ciphertext of the data passed in the <paramref name="pbInput"/> parameter. In this case, the location pointed to by the <paramref name="pcbResult"/> parameter contains this size, and the function returns <see cref="NTSTATUS.Code.STATUS_SUCCESS"/>.The <paramref name="pPaddingInfo"/> parameter is not modified.
         /// If the values of both the <paramref name="pbOutput"/> and <paramref name="pbInput"/> parameters are NULL, an error is returned unless an authenticated encryption algorithm is in use.In the latter case, the call is treated as an authenticated encryption call with zero length data, and the authentication tag is returned in the <paramref name="pPaddingInfo"/> parameter.
         /// </param>
         /// <param name="cbOutput">
@@ -132,7 +132,7 @@ namespace PInvoke
         /// The <paramref name="pbInput"/> and <paramref name="pbOutput"/> parameters can point to the same buffer. In this case, this function will perform the encryption in place. It is possible that the encrypted data size will be larger than the unencrypted data size, so the buffer must be large enough to hold the encrypted data.
         /// </remarks>
         [DllImport(nameof(BCrypt), SetLastError = true)]
-        public static unsafe extern NTStatus BCryptEncrypt(
+        public static unsafe extern NTSTATUS BCryptEncrypt(
             SafeKeyHandle hKey,
             byte[] pbInput,
             int cbInput,
@@ -167,7 +167,7 @@ namespace PInvoke
         /// <param name="cbIV">The size, in bytes, of the pbIV buffer.</param>
         /// <param name="pbOutput">
         /// The address of the buffer that receives the ciphertext produced by this function. The <paramref name="cbOutput"/> parameter contains the size of this buffer. For more information, see Remarks.
-        /// If this parameter is NULL, the <see cref="BCryptEncrypt(SafeKeyHandle, byte[], void*, byte[], BCryptEncryptFlags)"/> function calculates the size needed for the ciphertext of the data passed in the <paramref name="pbInput"/> parameter. In this case, the location pointed to by the <paramref name="pcbResult"/> parameter contains this size, and the function returns <see cref="NTStatus.Code.STATUS_SUCCESS"/>.The <paramref name="pPaddingInfo"/> parameter is not modified.
+        /// If this parameter is NULL, the <see cref="BCryptEncrypt(SafeKeyHandle, byte[], void*, byte[], BCryptEncryptFlags)"/> function calculates the size needed for the ciphertext of the data passed in the <paramref name="pbInput"/> parameter. In this case, the location pointed to by the <paramref name="pcbResult"/> parameter contains this size, and the function returns <see cref="NTSTATUS.Code.STATUS_SUCCESS"/>.The <paramref name="pPaddingInfo"/> parameter is not modified.
         /// If the values of both the <paramref name="pbOutput"/> and <paramref name="pbInput"/> parameters are NULL, an error is returned unless an authenticated encryption algorithm is in use.In the latter case, the call is treated as an authenticated encryption call with zero length data, and the authentication tag is returned in the <paramref name="pPaddingInfo"/> parameter.
         /// </param>
         /// <param name="cbOutput">
@@ -184,7 +184,7 @@ namespace PInvoke
         /// The <paramref name="pbInput"/> and <paramref name="pbOutput"/> parameters can point to the same buffer. In this case, this function will perform the encryption in place. It is possible that the encrypted data size will be larger than the unencrypted data size, so the buffer must be large enough to hold the encrypted data.
         /// </remarks>
         [DllImport(nameof(BCrypt), SetLastError = true)]
-        public static unsafe extern NTStatus BCryptEncrypt(
+        public static unsafe extern NTSTATUS BCryptEncrypt(
             SafeKeyHandle hKey,
             byte* pbInput,
             int cbInput,
@@ -221,7 +221,7 @@ namespace PInvoke
         /// </param>
         /// <param name="pbOutput">
         /// The address of a buffer to receive the plaintext produced by this function. The cbOutput parameter contains the size of this buffer. For more information, see Remarks.
-        /// If this parameter is NULL, the <see cref="BCryptDecrypt(SafeKeyHandle, byte[], void*, byte[], BCryptEncryptFlags)"/> function calculates the size required for the plaintext of the encrypted data passed in the <paramref name="pbInput"/> parameter.In this case, the location pointed to by the <paramref name="pcbResult"/> parameter contains this size, and the function returns <see cref="NTStatus.Code.STATUS_SUCCESS"/>.
+        /// If this parameter is NULL, the <see cref="BCryptDecrypt(SafeKeyHandle, byte[], void*, byte[], BCryptEncryptFlags)"/> function calculates the size required for the plaintext of the encrypted data passed in the <paramref name="pbInput"/> parameter.In this case, the location pointed to by the <paramref name="pcbResult"/> parameter contains this size, and the function returns <see cref="NTSTATUS.Code.STATUS_SUCCESS"/>.
         /// If the values of both the <paramref name="pbOutput"/> and <paramref name="pbInput" /> parameters are NULL, an error is returned unless an authenticated encryption algorithm is in use.In the latter case, the call is treated as an authenticated encryption call with zero length data, and the authentication tag, passed in the <paramref name="pPaddingInfo"/> parameter, is verified.
         /// </param>
         /// <param name="cbOutput">
@@ -235,7 +235,7 @@ namespace PInvoke
         /// </param>
         /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
         [DllImport(nameof(BCrypt), SetLastError = true)]
-        public static unsafe extern NTStatus BCryptDecrypt(
+        public static unsafe extern NTSTATUS BCryptDecrypt(
             SafeKeyHandle hKey,
             byte[] pbInput,
             int cbInput,
@@ -272,7 +272,7 @@ namespace PInvoke
         /// </param>
         /// <param name="pbOutput">
         /// The address of a buffer to receive the plaintext produced by this function. The cbOutput parameter contains the size of this buffer. For more information, see Remarks.
-        /// If this parameter is NULL, the <see cref="BCryptDecrypt(SafeKeyHandle, byte[], void*, byte[], BCryptEncryptFlags)"/> function calculates the size required for the plaintext of the encrypted data passed in the <paramref name="pbInput"/> parameter.In this case, the location pointed to by the <paramref name="pcbResult"/> parameter contains this size, and the function returns <see cref="NTStatus.Code.STATUS_SUCCESS"/>.
+        /// If this parameter is NULL, the <see cref="BCryptDecrypt(SafeKeyHandle, byte[], void*, byte[], BCryptEncryptFlags)"/> function calculates the size required for the plaintext of the encrypted data passed in the <paramref name="pbInput"/> parameter.In this case, the location pointed to by the <paramref name="pcbResult"/> parameter contains this size, and the function returns <see cref="NTSTATUS.Code.STATUS_SUCCESS"/>.
         /// If the values of both the <paramref name="pbOutput"/> and <paramref name="pbInput" /> parameters are NULL, an error is returned unless an authenticated encryption algorithm is in use.In the latter case, the call is treated as an authenticated encryption call with zero length data, and the authentication tag, passed in the <paramref name="pPaddingInfo"/> parameter, is verified.
         /// </param>
         /// <param name="cbOutput">
@@ -286,7 +286,7 @@ namespace PInvoke
         /// </param>
         /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
         [DllImport(nameof(BCrypt), SetLastError = true)]
-        public static unsafe extern NTStatus BCryptDecrypt(
+        public static unsafe extern NTSTATUS BCryptDecrypt(
             SafeKeyHandle hKey,
             byte* pbInput,
             int cbInput,
@@ -315,7 +315,7 @@ namespace PInvoke
         /// After the <see cref="BCryptFinishHash(SafeHashHandle, byte[], int, BCryptFinishHashFlags)"/> function has been called for a specified handle, that handle cannot be reused.
         /// </remarks>
         [DllImport(nameof(BCrypt), SetLastError = true)]
-        public static extern NTStatus BCryptHashData(
+        public static extern NTSTATUS BCryptHashData(
             SafeHashHandle hHash,
             byte[] pbInput,
             int cbInput,
@@ -337,7 +337,7 @@ namespace PInvoke
         /// <param name="dwFlags">A set of flags that modify the behavior of this function.</param>
         /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
         [DllImport(nameof(BCrypt), SetLastError = true)]
-        public static extern NTStatus BCryptFinishHash(
+        public static extern NTSTATUS BCryptFinishHash(
             SafeHashHandle hHash,
             [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] byte[] pbOutput,
             int cbOutput,
@@ -375,7 +375,7 @@ namespace PInvoke
         /// To later verify that the signature is valid, call the <see cref="BCryptVerifySignature(SafeKeyHandle, void*, byte[], int, byte[], int, BCryptSignHashFlags)"/> function with an identical key and an identical hash of the original data.
         /// </remarks>
         [DllImport(nameof(BCrypt), SetLastError = true)]
-        public static unsafe extern NTStatus BCryptSignHash(
+        public static unsafe extern NTSTATUS BCryptSignHash(
             SafeKeyHandle hKey,
             void* pPaddingInfo,
             byte[] pbInput,
@@ -413,10 +413,10 @@ namespace PInvoke
         /// </param>
         /// <returns>
         /// Returns a status code that indicates the success or failure of the function.
-        /// In particular, an invalid signature will produce a <see cref="NTStatus.Code.STATUS_INVALID_SIGNATURE"/> result.
+        /// In particular, an invalid signature will produce a <see cref="NTSTATUS.Code.STATUS_INVALID_SIGNATURE"/> result.
         /// </returns>
         [DllImport(nameof(BCrypt), SetLastError = true)]
-        public static unsafe extern NTStatus BCryptVerifySignature(
+        public static unsafe extern NTSTATUS BCryptVerifySignature(
             SafeKeyHandle hKey,
             void* pPaddingInfo,
             byte[] pbHash,
@@ -439,7 +439,7 @@ namespace PInvoke
         /// BCryptFinalizeKeyPair function is called.
         /// </remarks>
         [DllImport(nameof(BCrypt), SetLastError = true, ExactSpelling = true)]
-        public static extern NTStatus BCryptGenerateKeyPair(
+        public static extern NTSTATUS BCryptGenerateKeyPair(
             SafeAlgorithmHandle hAlgorithm,
             out SafeKeyHandle phKey,
             int dwLength,
@@ -473,7 +473,7 @@ namespace PInvoke
         /// <param name="flags">A set of flags that modify the behavior of this function. No flags are currently defined, so this parameter should be zero.</param>
         /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
         [DllImport(nameof(BCrypt), SetLastError = true)]
-        public static extern NTStatus BCryptGenerateSymmetricKey(
+        public static extern NTSTATUS BCryptGenerateSymmetricKey(
             SafeAlgorithmHandle hAlgorithm,
             out SafeKeyHandle phKey,
             byte[] pbKeyObject,
@@ -494,7 +494,7 @@ namespace PInvoke
         /// can no longer be used for this key.
         /// </remarks>
         [DllImport(nameof(BCrypt), SetLastError = true, ExactSpelling = true)]
-        public static extern NTStatus BCryptFinalizeKeyPair(
+        public static extern NTSTATUS BCryptFinalizeKeyPair(
             SafeKeyHandle hKey,
             BCryptFinalizeKeyPairFlags dwFlags = BCryptFinalizeKeyPairFlags.None);
 
@@ -535,7 +535,7 @@ namespace PInvoke
         /// <param name="dwFlags">A set of flags that modify the behavior of this function.</param>
         /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
         [DllImport(nameof(BCrypt), SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
-        public static extern NTStatus BCryptImportKey(
+        public static extern NTSTATUS BCryptImportKey(
             SafeAlgorithmHandle hAlgorithm,
             SafeKeyHandle hImportKey,
             [MarshalAs(UnmanagedType.LPWStr)] string pszBlobType,
@@ -558,7 +558,7 @@ namespace PInvoke
         /// <param name="dwFlags">A set of flags that modify the behavior of this function. This can be zero or the following value: BCRYPT_NO_KEY_VALIDATION</param>
         /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
         [DllImport(nameof(BCrypt), SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
-        public static extern NTStatus BCryptImportKeyPair(
+        public static extern NTSTATUS BCryptImportKeyPair(
             SafeAlgorithmHandle hAlgorithm,
             SafeKeyHandle hImportKey,
             [MarshalAs(UnmanagedType.LPWStr)] string pszBlobType,
@@ -595,7 +595,7 @@ namespace PInvoke
         /// <param name="dwFlags">A set of flags that modify the behavior of this function. </param>
         /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
         [DllImport(nameof(BCrypt), SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
-        public static extern NTStatus BCryptExportKey(
+        public static extern NTSTATUS BCryptExportKey(
             SafeKeyHandle hKey,
             SafeKeyHandle hExportKey,
             [MarshalAs(UnmanagedType.LPWStr)] string pszBlobType,
@@ -623,7 +623,7 @@ namespace PInvoke
         /// <param name="flags">A set of flags that modify the behavior of this function. No flags are defined for this function.</param>
         /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
         [DllImport(nameof(BCrypt), SetLastError = true, ExactSpelling = true)]
-        public static extern NTStatus BCryptSecretAgreement(
+        public static extern NTSTATUS BCryptSecretAgreement(
             SafeKeyHandle privateKey,
             SafeKeyHandle publicKey,
             out SafeSecretHandle secret,
@@ -665,7 +665,7 @@ namespace PInvoke
         /// Returns a status code that indicates the success or failure of the function.
         /// </returns>
         [DllImport(nameof(BCrypt), SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
-        public static extern NTStatus BCryptDeriveKey(
+        public static extern NTSTATUS BCryptDeriveKey(
             SafeSecretHandle sharedSecret,
             string keyDerivationFunction,
             [In] ref BCryptBufferDesc kdfParameters,
@@ -686,7 +686,7 @@ namespace PInvoke
         /// <param name="dwFlags">A set of flags that modify the behavior of this function. No flags are defined for this function.</param>
         /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
         [DllImport(nameof(BCrypt), SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
-        public static extern unsafe NTStatus BCryptSetProperty(
+        public static extern unsafe NTSTATUS BCryptSetProperty(
             SafeHandle hObject,
             string pszProperty,
             byte* pbInput,
@@ -705,7 +705,7 @@ namespace PInvoke
         /// <param name="dwFlags">A set of flags that modify the behavior of this function. No flags are defined for this function.</param>
         /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
         [DllImport(nameof(BCrypt), SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
-        public static extern NTStatus BCryptSetProperty(
+        public static extern NTSTATUS BCryptSetProperty(
             SafeHandle hObject,
             string pszProperty,
             [In, MarshalAs(UnmanagedType.LPArray)] byte[] pbInput,
@@ -724,7 +724,7 @@ namespace PInvoke
         /// <param name="dwFlags">A set of flags that modify the behavior of this function. No flags are defined for this function.</param>
         /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
         [DllImport(nameof(BCrypt), SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
-        public static extern NTStatus BCryptSetProperty(
+        public static extern NTSTATUS BCryptSetProperty(
             SafeHandle hObject,
             string pszProperty,
             string pbInput,
@@ -742,7 +742,7 @@ namespace PInvoke
         /// <param name="flags">A set of flags that modify the behavior of this function. No flags are defined for this function.</param>
         /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
         [DllImport(nameof(BCrypt), SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
-        public static extern NTStatus BCryptGetProperty(
+        public static extern NTSTATUS BCryptGetProperty(
             SafeHandle hObject,
             string property,
             [Out, MarshalAs(UnmanagedType.LPArray)] byte[] output,
@@ -765,7 +765,7 @@ namespace PInvoke
         /// <param name="flags">A set of flags that modify the behavior of this function. </param>
         /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
         [DllImport(nameof(BCrypt), SetLastError = true)]
-        public static extern NTStatus BCryptGenRandom(
+        public static extern NTSTATUS BCryptGenRandom(
             SafeAlgorithmHandle hAlgorithm,
             byte[] pbBuffer,
             int cbBuffer,
@@ -778,7 +778,7 @@ namespace PInvoke
         /// <param name="flags">A set of flags that modify the behavior of this function. No flags are defined for this function.</param>
         /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
         [DllImport(nameof(BCrypt), SetLastError = true, ExactSpelling = true)]
-        private static extern NTStatus BCryptCloseAlgorithmProvider(
+        private static extern NTSTATUS BCryptCloseAlgorithmProvider(
             IntPtr algorithmHandle,
             BCryptCloseAlgorithmProviderFlags flags = BCryptCloseAlgorithmProviderFlags.None);
 
@@ -788,7 +788,7 @@ namespace PInvoke
         /// <param name="hHash">The handle of the hash or MAC object to destroy. This handle is obtained by using the <see cref="BCryptCreateHash(SafeAlgorithmHandle, out SafeHashHandle, byte[], int, byte[], int, BCryptCreateHashFlags)"/> function.</param>
         /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
         [DllImport(nameof(BCrypt), SetLastError = true)]
-        private static extern NTStatus BCryptDestroyHash(IntPtr hHash);
+        private static extern NTSTATUS BCryptDestroyHash(IntPtr hHash);
 
         /// <summary>
         /// Destroys a key.
@@ -796,7 +796,7 @@ namespace PInvoke
         /// <param name="hKey">The handle of the key to destroy.</param>
         /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
         [DllImport(nameof(BCrypt), SetLastError = true, ExactSpelling = true)]
-        private static extern NTStatus BCryptDestroyKey(
+        private static extern NTSTATUS BCryptDestroyKey(
             IntPtr hKey);
 
         /// <summary>
@@ -805,7 +805,7 @@ namespace PInvoke
         /// <param name="hSecret">The handle of the secret to destroy.</param>
         /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
         [DllImport(nameof(BCrypt), SetLastError = true, ExactSpelling = true)]
-        private static extern NTStatus BCryptDestroySecret(
+        private static extern NTSTATUS BCryptDestroySecret(
             IntPtr hSecret);
     }
 }

--- a/src/Hid.Shared/Hid.Helpers.cs
+++ b/src/Hid.Shared/Hid.Helpers.cs
@@ -50,10 +50,10 @@ namespace PInvoke
             var result = HidP_GetCaps(preparsedData, ref hidCaps);
             switch (result.Value)
             {
-                case NTStatus.Code.HIDP_STATUS_SUCCESS:
+                case NTSTATUS.Code.HIDP_STATUS_SUCCESS:
                     return hidCaps;
 
-                case NTStatus.Code.HIDP_STATUS_INVALID_PREPARSED_DATA:
+                case NTSTATUS.Code.HIDP_STATUS_INVALID_PREPARSED_DATA:
                     throw new ArgumentException("The specified preparsed data is invalid.", nameof(preparsedData));
 
                 default:

--- a/src/Hid.Shared/Hid.cs
+++ b/src/Hid.Shared/Hid.cs
@@ -154,11 +154,11 @@ namespace PInvoke
         /// <see cref="HidpCaps" /> structure.
         /// </param>
         /// <returns>
-        /// <see cref="NTStatus.Code.HIDP_STATUS_SUCCESS" /> on success or <see cref="NTStatus.Code.HIDP_STATUS_INVALID_PREPARSED_DATA" /> if rhe
+        /// <see cref="NTSTATUS.Code.HIDP_STATUS_SUCCESS" /> on success or <see cref="NTSTATUS.Code.HIDP_STATUS_INVALID_PREPARSED_DATA" /> if rhe
         /// specified preparsed data is invalid.
         /// </returns>
         [DllImport(nameof(Hid), SetLastError = true)]
-        public static extern NTStatus HidP_GetCaps(SafePreparsedDataHandle preparsedData, ref HidpCaps capabilities);
+        public static extern NTSTATUS HidP_GetCaps(SafePreparsedDataHandle preparsedData, ref HidpCaps capabilities);
 
         /// <summary>
         /// Releases the resources that the HID class driver allocated to hold a top-level collection's preparsed data.

--- a/src/Kernel32.Desktop/Kernel32Extensions.cs
+++ b/src/Kernel32.Desktop/Kernel32Extensions.cs
@@ -11,11 +11,11 @@ namespace PInvoke
     public static partial class Kernel32Extensions
     {
         /// <summary>
-        /// Gets the text associated with an <see cref="NTStatus"/>.
+        /// Gets the text associated with an <see cref="NTSTATUS"/>.
         /// </summary>
         /// <param name="status">The error code.</param>
         /// <returns>The error message. Or <c>null</c> if no message could be found.</returns>
-        public static string GetMessage(this NTStatus status)
+        public static string GetMessage(this NTSTATUS status)
         {
             using (var ntdll = LoadLibrary("ntdll.dll"))
             {

--- a/src/Kernel32.Shared/Kernel32Extensions.cs
+++ b/src/Kernel32.Shared/Kernel32Extensions.cs
@@ -48,9 +48,9 @@ namespace PInvoke
         /// Throws an exception if a P/Invoke failed.
         /// </summary>
         /// <param name="status">The result of the P/Invoke call.</param>
-        public static void ThrowOnError(this NTStatus status)
+        public static void ThrowOnError(this NTSTATUS status)
         {
-            if (status.Severity == NTStatus.SeverityCode.STATUS_SEVERITY_ERROR)
+            if (status.Severity == NTSTATUS.SeverityCode.STATUS_SEVERITY_ERROR)
             {
                 throw new NTStatusException(status);
             }

--- a/src/Kernel32.Shared/NTStatusException.cs
+++ b/src/Kernel32.Shared/NTStatusException.cs
@@ -8,7 +8,7 @@ namespace PInvoke
     using static PInvoke.Kernel32;
 
     /// <summary>
-    /// An exception thrown for a failure described by a <see cref="NTStatus"/>.
+    /// An exception thrown for a failure described by a <see cref="NTSTATUS"/>.
     /// </summary>
 #if DESKTOP
     [Serializable]
@@ -19,7 +19,7 @@ namespace PInvoke
         /// Initializes a new instance of the <see cref="NTStatusException"/> class.
         /// </summary>
         /// <param name="statusCode">The status code identifying the error.</param>
-        public NTStatusException(NTStatus statusCode)
+        public NTStatusException(NTSTATUS statusCode)
             : this(statusCode, null, null)
         {
         }
@@ -29,7 +29,7 @@ namespace PInvoke
         /// </summary>
         /// <param name="statusCode">The status code identifying the error.</param>
         /// <param name="message">The exception message (which may be null to use the default).</param>
-        public NTStatusException(NTStatus statusCode, string message)
+        public NTStatusException(NTSTATUS statusCode, string message)
             : this(statusCode, message, null)
         {
         }
@@ -40,7 +40,7 @@ namespace PInvoke
         /// <param name="statusCode">The status code identifying the error.</param>
         /// <param name="message">The exception message (which may be null to use the default).</param>
         /// <param name="inner">The inner exception.</param>
-        public NTStatusException(NTStatus statusCode, string message, Exception inner)
+        public NTStatusException(NTSTATUS statusCode, string message, Exception inner)
             : base(message ?? GetMessage(statusCode), inner)
         {
             this.NativeErrorCode = statusCode;
@@ -61,9 +61,9 @@ namespace PInvoke
 #endif
 
         /// <summary>
-        /// Gets the <see cref="NTStatus"/> code that identifies the error condition.
+        /// Gets the <see cref="NTSTATUS"/> code that identifies the error condition.
         /// </summary>
-        public NTStatus NativeErrorCode { get; }
+        public NTSTATUS NativeErrorCode { get; }
 
 #if DESKTOP
         /// <inheritdoc />
@@ -75,14 +75,14 @@ namespace PInvoke
 #endif
 
         /// <summary>
-        /// Gets the message associated with the given <see cref="NTStatus"/>.
+        /// Gets the message associated with the given <see cref="NTSTATUS"/>.
         /// </summary>
-        /// <param name="status">The <see cref="NTStatus"/> for the error.</param>
+        /// <param name="status">The <see cref="NTSTATUS"/> for the error.</param>
         /// <returns>The description of the error.</returns>
-        private static string GetMessage(NTStatus status)
+        private static string GetMessage(NTSTATUS status)
         {
             string hexCode = $"0x{(int)status:X8}";
-            string namedCode = Enum.GetName(typeof(NTStatus.Code), status.AsUInt32);
+            string namedCode = Enum.GetName(typeof(NTSTATUS.Code), status.AsUInt32);
             string statusAsString = namedCode != null
                 ? $"{namedCode} ({hexCode})"
                 : hexCode;
@@ -97,17 +97,17 @@ namespace PInvoke
                 : insert;
         }
 
-        private static string GetSeverityString(NTStatus status)
+        private static string GetSeverityString(NTSTATUS status)
         {
             switch (status.Severity)
             {
-                case NTStatus.SeverityCode.STATUS_SEVERITY_SUCCESS:
+                case NTSTATUS.SeverityCode.STATUS_SEVERITY_SUCCESS:
                     return "success";
-                case NTStatus.SeverityCode.STATUS_SEVERITY_INFORMATIONAL:
+                case NTSTATUS.SeverityCode.STATUS_SEVERITY_INFORMATIONAL:
                     return "information";
-                case NTStatus.SeverityCode.STATUS_SEVERITY_WARNING:
+                case NTSTATUS.SeverityCode.STATUS_SEVERITY_WARNING:
                     return "warning";
-                case NTStatus.SeverityCode.STATUS_SEVERITY_ERROR:
+                case NTSTATUS.SeverityCode.STATUS_SEVERITY_ERROR:
                     return "error";
                 default:
                     return string.Empty;

--- a/src/Kernel32.Tests.Shared/Kernel32ExtensionsTests.cs
+++ b/src/Kernel32.Tests.Shared/Kernel32ExtensionsTests.cs
@@ -28,9 +28,9 @@ public partial class Kernel32ExtensionsTests
     [Fact]
     public void ThrowOnError_NTStatus()
     {
-        NTStatus success = NTStatus.Code.STATUS_SUCCESS;
+        NTSTATUS success = NTSTATUS.Code.STATUS_SUCCESS;
         success.ThrowOnError();
-        NTStatus failure = NTStatus.Code.RPC_NT_CALL_FAILED;
+        NTSTATUS failure = NTSTATUS.Code.RPC_NT_CALL_FAILED;
         Assert.Throws<NTStatusException>(() => failure.ThrowOnError());
 
         try

--- a/src/Kernel32.Tests.Shared/NTStatusExceptionTests.cs
+++ b/src/Kernel32.Tests.Shared/NTStatusExceptionTests.cs
@@ -12,7 +12,7 @@ public partial class NTStatusExceptionTests
     [Fact]
     public void NTStatusException_NativeErrorCode()
     {
-        NTStatus error = NTStatus.Code.EPT_NT_INVALID_ENTRY;
+        NTSTATUS error = NTSTATUS.Code.EPT_NT_INVALID_ENTRY;
         var ex = new NTStatusException(error);
         Assert.Equal(error, ex.NativeErrorCode);
     }
@@ -20,7 +20,7 @@ public partial class NTStatusExceptionTests
     [Fact]
     public void NTStatusException_Error_Message()
     {
-        NTStatus error = NTStatus.Code.EPT_NT_INVALID_ENTRY;
+        NTSTATUS error = NTSTATUS.Code.EPT_NT_INVALID_ENTRY;
         var ex = new NTStatusException(error);
 #if DESKTOP
         Assert.Equal("The entry is invalid (NT_STATUS error: EPT_NT_INVALID_ENTRY (0xC0020034))", ex.Message);
@@ -32,7 +32,7 @@ public partial class NTStatusExceptionTests
     [Fact]
     public void NTStatusException_Warning_Message()
     {
-        NTStatus error = NTStatus.Code.STATUS_BUFFER_OVERFLOW;
+        NTSTATUS error = NTSTATUS.Code.STATUS_BUFFER_OVERFLOW;
         var ex = new NTStatusException(error);
 #if DESKTOP
         Assert.Equal("{Buffer Overflow}\r\nThe data was too large to fit into the specified buffer (NT_STATUS warning: STATUS_BUFFER_OVERFLOW (0x80000005))", ex.Message);
@@ -44,7 +44,7 @@ public partial class NTStatusExceptionTests
     [Fact]
     public void NTStatusException_Informational_Message()
     {
-        NTStatus error = NTStatus.Code.STATUS_WAKE_SYSTEM;
+        NTSTATUS error = NTSTATUS.Code.STATUS_WAKE_SYSTEM;
         var ex = new NTStatusException(error);
 #if DESKTOP
         Assert.Equal("The system has awoken (NT_STATUS information: STATUS_WAKE_SYSTEM (0x40000294))", ex.Message);
@@ -56,7 +56,7 @@ public partial class NTStatusExceptionTests
     [Fact]
     public void NTStatusException_Success_Message()
     {
-        NTStatus error = NTStatus.Code.STATUS_PENDING;
+        NTSTATUS error = NTSTATUS.Code.STATUS_PENDING;
         var ex = new NTStatusException(error);
 #if DESKTOP
         Assert.Equal("The operation that was requested is pending completion (NT_STATUS success: STATUS_PENDING (0x00000103))", ex.Message);
@@ -68,7 +68,7 @@ public partial class NTStatusExceptionTests
     [Fact]
     public void NTStatusException_MessageNotFound()
     {
-        NTStatus error = 0xC1111111;
+        NTSTATUS error = 0xC1111111;
         var ex = new NTStatusException(error);
         Assert.Equal("NT_STATUS error: 0xC1111111", ex.Message);
     }
@@ -76,7 +76,7 @@ public partial class NTStatusExceptionTests
     [Fact]
     public void NTStatusException_CodeAndMessage()
     {
-        NTStatus error = NTStatus.Code.EPT_NT_INVALID_ENTRY;
+        NTSTATUS error = NTSTATUS.Code.EPT_NT_INVALID_ENTRY;
         var ex = new NTStatusException(error, "msg");
         Assert.Equal(error, ex.NativeErrorCode);
         Assert.Equal("msg", ex.Message);

--- a/src/Kernel32.Tests/Kernel32.cs
+++ b/src/Kernel32.Tests/Kernel32.cs
@@ -164,7 +164,7 @@ public partial class Kernel32
             string actual = FormatMessage(
                 FormatMessageFlags.FORMAT_MESSAGE_FROM_HMODULE,
                 ntdll.DangerousGetHandle(),
-                (int)NTStatus.Code.DBG_REPLY_LATER,
+                (int)NTSTATUS.Code.DBG_REPLY_LATER,
                 0,
                 null,
                 500);

--- a/src/Kernel32.Tests/Kernel32ExtensionsTests.cs
+++ b/src/Kernel32.Tests/Kernel32ExtensionsTests.cs
@@ -12,7 +12,7 @@ public partial class Kernel32ExtensionsTests
     [Fact]
     public void GetMessage_NTStatus()
     {
-        NTStatus error = NTStatus.Code.EPT_NT_INVALID_ENTRY;
+        NTSTATUS error = NTSTATUS.Code.EPT_NT_INVALID_ENTRY;
         string message = error.GetMessage();
         Assert.Equal("The entry is invalid", message);
     }
@@ -20,7 +20,7 @@ public partial class Kernel32ExtensionsTests
     [Fact]
     public void NTStatusException_Serializable()
     {
-        var exception = new NTStatusException(NTStatus.Code.STATUS_TPM_AUDITFAIL_SUCCESSFUL, "It works, yo");
+        var exception = new NTStatusException(NTSTATUS.Code.STATUS_TPM_AUDITFAIL_SUCCESSFUL, "It works, yo");
         var formatter = new BinaryFormatter();
         var ms = new MemoryStream();
         formatter.Serialize(ms, exception);

--- a/src/NCrypt/NCrypt.cs
+++ b/src/NCrypt/NCrypt.cs
@@ -194,7 +194,7 @@ namespace PInvoke
         /// </param>
         /// <param name="pbOutput">
         /// The address of the buffer that receives the ciphertext produced by this function. The <paramref name="cbOutput"/> parameter contains the size of this buffer. For more information, see Remarks.
-        /// If this parameter is NULL, this function calculates the size needed for the ciphertext of the data passed in the <paramref name="pbInput"/> parameter. In this case, the location pointed to by the <paramref name="pcbResult"/> parameter contains this size, and the function returns <see cref="NTStatus.Code.STATUS_SUCCESS"/>.The <paramref name="pPaddingInfo"/> parameter is not modified.
+        /// If this parameter is NULL, this function calculates the size needed for the ciphertext of the data passed in the <paramref name="pbInput"/> parameter. In this case, the location pointed to by the <paramref name="pcbResult"/> parameter contains this size, and the function returns <see cref="NTSTATUS.Code.STATUS_SUCCESS"/>.The <paramref name="pPaddingInfo"/> parameter is not modified.
         /// If the values of both the <paramref name="pbOutput"/> and <paramref name="pbInput"/> parameters are NULL, an error is returned unless an authenticated encryption algorithm is in use.In the latter case, the call is treated as an authenticated encryption call with zero length data, and the authentication tag is returned in the <paramref name="pPaddingInfo"/> parameter.
         /// </param>
         /// <param name="cbOutput">
@@ -238,7 +238,7 @@ namespace PInvoke
         /// </param>
         /// <param name="pbOutput">
         /// The address of a buffer to receive the plaintext produced by this function. The cbOutput parameter contains the size of this buffer. For more information, see Remarks.
-        /// If this parameter is NULL, this function calculates the size required for the plaintext of the encrypted data passed in the <paramref name="pbInput"/> parameter.In this case, the location pointed to by the <paramref name="pcbResult"/> parameter contains this size, and the function returns <see cref="NTStatus.Code.STATUS_SUCCESS"/>.
+        /// If this parameter is NULL, this function calculates the size required for the plaintext of the encrypted data passed in the <paramref name="pbInput"/> parameter.In this case, the location pointed to by the <paramref name="pcbResult"/> parameter contains this size, and the function returns <see cref="NTSTATUS.Code.STATUS_SUCCESS"/>.
         /// If the values of both the <paramref name="pbOutput"/> and <paramref name="pbInput" /> parameters are NULL, an error is returned unless an authenticated encryption algorithm is in use.In the latter case, the call is treated as an authenticated encryption call with zero length data, and the authentication tag, passed in the <paramref name="pPaddingInfo"/> parameter, is verified.
         /// </param>
         /// <param name="cbOutput">

--- a/src/NTDll.Desktop/NTDll.cs
+++ b/src/NTDll.Desktop/NTDll.cs
@@ -22,6 +22,6 @@ namespace PInvoke
         /// ERROR_MR_MID_NOT_FOUND is returned when the specified NTSTATUS code does not have a corresponding system error code.
         /// </remarks>
         [DllImport(nameof(NTDll))]
-        public static extern Win32ErrorCode RtlNtStatusToDosError(NTStatus Status);
+        public static extern Win32ErrorCode RtlNtStatusToDosError(NTSTATUS Status);
     }
 }

--- a/src/NTDll.Tests/NTDll.cs
+++ b/src/NTDll.Tests/NTDll.cs
@@ -11,9 +11,9 @@ public class NTDll
     [Fact]
     public void RtlNtStatusToDosError_Test()
     {
-        Assert.Equal(Win32ErrorCode.ERROR_IO_PENDING, RtlNtStatusToDosError(NTStatus.Code.STATUS_PENDING));
-        Assert.Equal(Win32ErrorCode.ERROR_SUCCESS, RtlNtStatusToDosError(NTStatus.Code.STATUS_SUCCESS));
-        Assert.Equal(Win32ErrorCode.ERROR_OBJECT_ALREADY_EXISTS, RtlNtStatusToDosError(NTStatus.Code.STATUS_DUPLICATE_OBJECTID));
+        Assert.Equal(Win32ErrorCode.ERROR_IO_PENDING, RtlNtStatusToDosError(NTSTATUS.Code.STATUS_PENDING));
+        Assert.Equal(Win32ErrorCode.ERROR_SUCCESS, RtlNtStatusToDosError(NTSTATUS.Code.STATUS_SUCCESS));
+        Assert.Equal(Win32ErrorCode.ERROR_OBJECT_ALREADY_EXISTS, RtlNtStatusToDosError(NTSTATUS.Code.STATUS_DUPLICATE_OBJECTID));
 
         // You'd think these would be more or less obviously correct return values, but this API
         // actually does a pitiful job of producing valid return values.

--- a/src/Windows.Core.Tests/NTStatusTests.cs
+++ b/src/Windows.Core.Tests/NTStatusTests.cs
@@ -13,38 +13,38 @@ public class NTStatusTests
     {
         // It's imperative that the struct be exactly the size of an Int32
         // since we use it in interop.
-        Assert.Equal(sizeof(int), Marshal.SizeOf(typeof(NTStatus)));
+        Assert.Equal(sizeof(int), Marshal.SizeOf(typeof(NTSTATUS)));
     }
 
     [Fact]
     public void Ctor_Int32()
     {
-        Assert.Equal(3, ((NTStatus)3).AsInt32);
+        Assert.Equal(3, ((NTSTATUS)3).AsInt32);
     }
 
     [Fact]
     public void Ctor_UInt32()
     {
-        Assert.Equal(3, new NTStatus((uint)3).AsInt32);
+        Assert.Equal(3, new NTSTATUS((uint)3).AsInt32);
     }
 
     [Fact]
     public void DefaultIs0()
     {
-        Assert.Equal(0, default(NTStatus).AsInt32);
+        Assert.Equal(0, default(NTSTATUS).AsInt32);
     }
 
     [Fact]
     public void PopularValuesPredefined()
     {
-        Assert.Equal(0u, (uint)NTStatus.Code.STATUS_SUCCESS);
+        Assert.Equal(0u, (uint)NTSTATUS.Code.STATUS_SUCCESS);
     }
 
     [Fact]
     public void AsUInt32()
     {
         uint expectedValue = 5;
-        NTStatus status = expectedValue;
+        NTSTATUS status = expectedValue;
         uint actualValue = status.AsUInt32;
         Assert.Equal(expectedValue, actualValue);
     }
@@ -53,7 +53,7 @@ public class NTStatusTests
     public void ImplicitCast_Int32()
     {
         int originalValue = 0x5;
-        NTStatus status = originalValue;
+        NTSTATUS status = originalValue;
         Assert.Equal(originalValue, status.AsInt32);
     }
 
@@ -61,7 +61,7 @@ public class NTStatusTests
     public void ImplicitCast_UInt32()
     {
         uint originalValue = 0x5;
-        NTStatus status = originalValue;
+        NTSTATUS status = originalValue;
         uint backToUInt = status;
         Assert.Equal(originalValue, backToUInt);
     }
@@ -70,7 +70,7 @@ public class NTStatusTests
     public void ExplicitCast_Int32()
     {
         int originalValue = 0x5;
-        NTStatus status = (NTStatus)originalValue;
+        NTSTATUS status = (NTSTATUS)originalValue;
         Assert.Equal(originalValue, (int)status);
     }
 
@@ -78,23 +78,23 @@ public class NTStatusTests
     public void ExplicitCast_UInt32()
     {
         uint originalValue = 0x5;
-        NTStatus status = (NTStatus)originalValue;
+        NTSTATUS status = (NTSTATUS)originalValue;
         Assert.Equal(originalValue, (uint)status);
     }
 
     [Fact]
     public void ToString_FormatsNumberAsDecimalOrName()
     {
-        NTStatus status = 0x80000000;
+        NTSTATUS status = 0x80000000;
         Assert.Equal("2147483648", status.ToString());
-        status = NTStatus.Code.DBG_CONTINUE;
+        status = NTSTATUS.Code.DBG_CONTINUE;
         Assert.Equal("DBG_CONTINUE", status.ToString());
     }
 
     [Fact]
     public void ToString_IsFormattable()
     {
-        NTStatus status = 0x10;
+        NTSTATUS status = 0x10;
         Assert.Equal("0010", $"{status:x4}");
         Assert.Equal("00000010", $"{status:x8}");
     }
@@ -102,16 +102,16 @@ public class NTStatusTests
     [Fact]
     public void GetHashCodeReturnsValue()
     {
-        Assert.Equal(3, ((NTStatus)3).GetHashCode());
-        Assert.Equal(4, ((NTStatus)4).GetHashCode());
+        Assert.Equal(3, ((NTSTATUS)3).GetHashCode());
+        Assert.Equal(4, ((NTSTATUS)4).GetHashCode());
     }
 
     [Fact]
     public void EqualityChecks()
     {
-        NTStatus hr3 = 3;
-        NTStatus hr5 = 5;
-        IEquatable<NTStatus> hr3Equatable = hr3;
+        NTSTATUS hr3 = 3;
+        NTSTATUS hr5 = 5;
+        IEquatable<NTSTATUS> hr3Equatable = hr3;
 
         Assert.Equal(hr3, hr3);
         Assert.True(hr3.Equals(hr3));
@@ -125,9 +125,9 @@ public class NTStatusTests
     [Fact]
     public void EqualOperators()
     {
-        NTStatus hr3 = 3;
-        NTStatus hr3b = 3;
-        NTStatus hr5 = 5;
+        NTSTATUS hr3 = 3;
+        NTSTATUS hr3b = 3;
+        NTSTATUS hr5 = 5;
 
         Assert.True(hr3 != hr5);
         Assert.True(hr3 == hr3b);
@@ -138,24 +138,24 @@ public class NTStatusTests
     [Fact]
     public void Severity()
     {
-        Assert.Equal((NTStatus.SeverityCode)0xc0000000, new NTStatus(0xffffffff).Severity);
+        Assert.Equal((NTSTATUS.SeverityCode)0xc0000000, new NTSTATUS(0xffffffff).Severity);
     }
 
     [Fact]
     public void CustomerCode()
     {
-        Assert.Equal(0x20000000u, new NTStatus(0xffffffff).CustomerCode);
+        Assert.Equal(0x20000000u, new NTSTATUS(0xffffffff).CustomerCode);
     }
 
     [Fact]
     public void Facility()
     {
-        Assert.Equal((NTStatus.FacilityCode)0xfff0000, new NTStatus(0xffffffff).Facility);
+        Assert.Equal((NTSTATUS.FacilityCode)0xfff0000, new NTSTATUS(0xffffffff).Facility);
     }
 
     [Fact]
     public void Code()
     {
-        Assert.Equal<uint>(0xffff, new NTStatus(0xffffffff).FacilityStatus);
+        Assert.Equal<uint>(0xffff, new NTSTATUS(0xffffffff).FacilityStatus);
     }
 }

--- a/src/Windows.Core.Tests/PInvokeExtensionsTests.cs
+++ b/src/Windows.Core.Tests/PInvokeExtensionsTests.cs
@@ -11,7 +11,7 @@ public class PInvokeExtensionsTests
     [Fact]
     public void ToHResult_FromNTStatus()
     {
-        NTStatus duplicate = NTStatus.Code.STATUS_DUPLICATE_OBJECTID;
+        NTSTATUS duplicate = NTSTATUS.Code.STATUS_DUPLICATE_OBJECTID;
         Assert.Equal(0xD000022A, duplicate.ToHResult());
     }
 

--- a/src/Windows.Core/NTStatus+Code.cs
+++ b/src/Windows.Core/NTStatus+Code.cs
@@ -8,10 +8,10 @@ namespace PInvoke
     /// <content>
     /// Contains the <see cref="Code"/> nested type.
     /// </content>
-    public partial struct NTStatus
+    public partial struct NTSTATUS
     {
         /// <summary>
-        /// Common <see cref="NTStatus"/> constants.
+        /// Common <see cref="NTSTATUS"/> constants.
         /// </summary>
         public enum Code : uint
         {

--- a/src/Windows.Core/NTStatus+FacilityCode.cs
+++ b/src/Windows.Core/NTStatus+FacilityCode.cs
@@ -6,10 +6,10 @@ namespace PInvoke
     /// <content>
     /// The <see cref="FacilityCode"/> nested type.
     /// </content>
-    public partial struct NTStatus
+    public partial struct NTSTATUS
     {
         /// <summary>
-        /// The <see cref="NTStatus"/> facility codes.
+        /// The <see cref="NTSTATUS"/> facility codes.
         /// </summary>
         public enum FacilityCode
         {

--- a/src/Windows.Core/NTStatus+SeverityCode.cs
+++ b/src/Windows.Core/NTStatus+SeverityCode.cs
@@ -6,10 +6,10 @@ namespace PInvoke
     /// <content>
     /// The <see cref="SeverityCode"/> nested type.
     /// </content>
-    public partial struct NTStatus
+    public partial struct NTSTATUS
     {
         /// <summary>
-        /// The <see cref="NTStatus"/> severity codes.
+        /// The <see cref="NTSTATUS"/> severity codes.
         /// </summary>
         public enum SeverityCode : uint
         {

--- a/src/Windows.Core/NTStatus.cs
+++ b/src/Windows.Core/NTStatus.cs
@@ -34,7 +34,7 @@ namespace PInvoke
     /// </remarks>
     [DebuggerDisplay("{Value}")]
     [StructLayout(LayoutKind.Sequential)]
-    public partial struct NTStatus : IComparable, IComparable<NTStatus>, IEquatable<NTStatus>, IFormattable
+    public partial struct NTSTATUS : IComparable, IComparable<NTSTATUS>, IEquatable<NTSTATUS>, IFormattable
     {
         /// <summary>
         /// The mask of the bits that describe the <see cref="Severity"/>.
@@ -81,28 +81,28 @@ namespace PInvoke
         private const int FacilityStatusShift = 0;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="NTStatus"/> struct.
+        /// Initializes a new instance of the <see cref="NTSTATUS"/> struct.
         /// </summary>
         /// <param name="status">The value of the NTStatus.</param>
-        public NTStatus(uint status)
+        public NTSTATUS(uint status)
             : this((Code)status)
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="NTStatus"/> struct.
+        /// Initializes a new instance of the <see cref="NTSTATUS"/> struct.
         /// </summary>
         /// <param name="status">The value of the NTStatus.</param>
-        public NTStatus(int status)
+        public NTSTATUS(int status)
             : this((Code)status)
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="NTStatus"/> struct.
+        /// Initializes a new instance of the <see cref="NTSTATUS"/> struct.
         /// </summary>
         /// <param name="status">The value of the NTStatus.</param>
-        public NTStatus(Code status)
+        public NTSTATUS(Code status)
         {
             this.Value = status;
         }
@@ -144,55 +144,55 @@ namespace PInvoke
         public uint FacilityStatus => this.AsUInt32 & FacilityStatusMask;
 
         /// <summary>
-        /// Converts an <see cref="int"/> into an <see cref="NTStatus"/>.
+        /// Converts an <see cref="int"/> into an <see cref="NTSTATUS"/>.
         /// </summary>
         /// <param name="status">The value of the NT_STATUS.</param>
-        public static implicit operator NTStatus(int status) => new NTStatus(status);
+        public static implicit operator NTSTATUS(int status) => new NTSTATUS(status);
 
         /// <summary>
-        /// Converts an <see cref="NTStatus"/> into an <see cref="int"/>.
+        /// Converts an <see cref="NTSTATUS"/> into an <see cref="int"/>.
         /// </summary>
         /// <param name="status">The value of the NT_STATUS.</param>
-        public static explicit operator int(NTStatus status) => status.AsInt32;
+        public static explicit operator int(NTSTATUS status) => status.AsInt32;
 
         /// <summary>
-        /// Converts an <see cref="uint"/> into an <see cref="NTStatus"/>.
+        /// Converts an <see cref="uint"/> into an <see cref="NTSTATUS"/>.
         /// </summary>
         /// <param name="status">The value of the NT_STATUS.</param>
-        public static implicit operator NTStatus(uint status) => new NTStatus(status);
+        public static implicit operator NTSTATUS(uint status) => new NTSTATUS(status);
 
         /// <summary>
-        /// Converts an <see cref="NTStatus"/> into an <see cref="uint"/>.
+        /// Converts an <see cref="NTSTATUS"/> into an <see cref="uint"/>.
         /// </summary>
         /// <param name="status">The value of the NT_STATUS.</param>
-        public static implicit operator uint(NTStatus status) => status.AsUInt32;
+        public static implicit operator uint(NTSTATUS status) => status.AsUInt32;
 
         /// <summary>
-        /// Converts a <see cref="Code"/> enum to its structural <see cref="NTStatus"/> representation.
+        /// Converts a <see cref="Code"/> enum to its structural <see cref="NTSTATUS"/> representation.
         /// </summary>
         /// <param name="status">The value to convert.</param>
-        public static implicit operator NTStatus(Code status) => new NTStatus(status);
+        public static implicit operator NTSTATUS(Code status) => new NTSTATUS(status);
 
         /// <summary>
-        /// Converts an <see cref="NTStatus"/> to its <see cref="Code"/> enum representation.
+        /// Converts an <see cref="NTSTATUS"/> to its <see cref="Code"/> enum representation.
         /// </summary>
         /// <param name="status">The value to convert.</param>
-        public static implicit operator Code(NTStatus status) => status.Value;
+        public static implicit operator Code(NTSTATUS status) => status.Value;
 
         /// <inheritdoc />
         public override int GetHashCode() => (int)this.Value;
 
         /// <inheritdoc />
-        public bool Equals(NTStatus other) => this.Value == other.Value;
+        public bool Equals(NTSTATUS other) => this.Value == other.Value;
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => obj is NTStatus && this.Equals((NTStatus)obj);
+        public override bool Equals(object obj) => obj is NTSTATUS && this.Equals((NTSTATUS)obj);
 
         /// <inheritdoc />
         public int CompareTo(object obj) => ((IComparable)this.Value).CompareTo(obj);
 
         /// <inheritdoc />
-        public int CompareTo(NTStatus other) => this.Value.CompareTo(other.Value);
+        public int CompareTo(NTSTATUS other) => this.Value.CompareTo(other.Value);
 
         /// <inheritdoc />
         public override string ToString() => this.Value.ToString();

--- a/src/Windows.Core/PInvokeExtensions.cs
+++ b/src/Windows.Core/PInvokeExtensions.cs
@@ -13,11 +13,11 @@ namespace PInvoke
     public static class PInvokeExtensions
     {
         /// <summary>
-        /// Converts an <see cref="NTStatus"/> to an <see cref="HResult"/>.
+        /// Converts an <see cref="NTSTATUS"/> to an <see cref="HResult"/>.
         /// </summary>
-        /// <param name="status">The <see cref="NTStatus"/> to convert.</param>
+        /// <param name="status">The <see cref="NTSTATUS"/> to convert.</param>
         /// <returns>The <see cref="HResult"/>.</returns>
-        public static HResult ToHResult(this NTStatus status)
+        public static HResult ToHResult(this NTSTATUS status)
         {
             // From winerror.h
             // #define HRESULT_FROM_NT(x)      ((HRESULT) ((x) | FACILITY_NT_BIT))

--- a/src/Windows.Core/Windows.Core.csproj
+++ b/src/Windows.Core/Windows.Core.csproj
@@ -43,12 +43,12 @@
     <Compile Include="IMAGE_SECTION_HEADER+CharacteristicsType.cs" />
     <Compile Include="IMAGE_SECTION_HEADER.cs" />
     <Compile Include="LIST_ENTRY.cs" />
-    <Compile Include="NTStatus+Code.cs" />
-    <Compile Include="NTStatus+SeverityCode.cs" />
-    <Compile Include="NTStatus+FacilityCode.cs" />
+    <Compile Include="NTSTATUS+Code.cs" />
+    <Compile Include="NTSTATUS+SeverityCode.cs" />
+    <Compile Include="NTSTATUS+FacilityCode.cs" />
     <Compile Include="NullableUInt32.cs" />
     <Compile Include="NullableGuid.cs" />
-    <Compile Include="NTStatus.cs" />
+    <Compile Include="NTSTATUS.cs" />
     <Compile Include="PInvokeExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Win32ErrorCode.cs" />


### PR DESCRIPTION
Per our guidance doc that we should preserve type names when native code defines them.
