### PR TITLE
Excluding CodeGeneration dlls from nuget package referencing them.

### DIFF
--- a/src/AdvApi32.Desktop/AdvApi32.Desktop.csproj
+++ b/src/AdvApi32.Desktop/AdvApi32.Desktop.csproj
@@ -28,10 +28,12 @@
     <ProjectReference Include="..\CodeGenerationAttributes.Net40\CodeGenerationAttributes.Net40.csproj">
       <Project>{6a77281b-c503-44ea-90c1-0e9868d06cd0}</Project>
       <Name>CodeGenerationAttributes.Net40</Name>
+      <ExcludeFromNuPkg>true</ExcludeFromNuPkg>
     </ProjectReference>
     <ProjectReference Include="..\CodeGeneration\CodeGeneration.csproj">
       <Project>{C1815471-02AF-4BB9-8D83-652ADBAFF5B6}</Project>
       <Name>CodeGeneration</Name>
+      <ExcludeFromNuPkg>true</ExcludeFromNuPkg>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
     <ProjectReference Include="..\Kernel32.Desktop\Kernel32.Desktop.csproj">

--- a/src/AdvApi32/AdvApi32.csproj
+++ b/src/AdvApi32/AdvApi32.csproj
@@ -33,10 +33,12 @@
       <Project>{1387e009-7086-4572-ac8d-ce4242adec77}</Project>
       <Name>CodeGenerationAttributes</Name>
       <Private>False</Private>
+      <ExcludeFromNuPkg>true</ExcludeFromNuPkg>
     </ProjectReference>
     <ProjectReference Include="..\CodeGeneration\CodeGeneration.csproj">
       <Project>{C1815471-02AF-4BB9-8D83-652ADBAFF5B6}</Project>
       <Name>CodeGeneration</Name>
+      <ExcludeFromNuPkg>true</ExcludeFromNuPkg>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
     <ProjectReference Include="..\Kernel32\Kernel32.csproj">

--- a/src/BCrypt/BCrypt.csproj
+++ b/src/BCrypt/BCrypt.csproj
@@ -101,10 +101,12 @@
       <Project>{1387e009-7086-4572-ac8d-ce4242adec77}</Project>
       <Name>CodeGenerationAttributes</Name>
       <Private>False</Private>
+      <ExcludeFromNuPkg>true</ExcludeFromNuPkg>
     </ProjectReference>
     <ProjectReference Include="..\CodeGeneration\CodeGeneration.csproj">
       <Project>{C1815471-02AF-4BB9-8D83-652ADBAFF5B6}</Project>
       <Name>CodeGeneration</Name>
+      <ExcludeFromNuPkg>true</ExcludeFromNuPkg>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
     <ProjectReference Include="..\Kernel32\Kernel32.csproj">

--- a/src/Crypt32.Desktop/Crypt32.Desktop.csproj
+++ b/src/Crypt32.Desktop/Crypt32.Desktop.csproj
@@ -28,10 +28,12 @@
     <ProjectReference Include="..\CodeGenerationAttributes.Net40\CodeGenerationAttributes.Net40.csproj">
       <Project>{6a77281b-c503-44ea-90c1-0e9868d06cd0}</Project>
       <Name>CodeGenerationAttributes.Net40</Name>
+      <ExcludeFromNuPkg>true</ExcludeFromNuPkg>
     </ProjectReference>
     <ProjectReference Include="..\CodeGeneration\CodeGeneration.csproj">
       <Project>{C1815471-02AF-4BB9-8D83-652ADBAFF5B6}</Project>
       <Name>CodeGeneration</Name>
+      <ExcludeFromNuPkg>true</ExcludeFromNuPkg>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
     <ProjectReference Include="..\Windows.Core\Windows.Core.csproj">

--- a/src/Crypt32/Crypt32.csproj
+++ b/src/Crypt32/Crypt32.csproj
@@ -33,10 +33,12 @@
       <Project>{1387e009-7086-4572-ac8d-ce4242adec77}</Project>
       <Name>CodeGenerationAttributes</Name>
       <Private>False</Private>
+      <ExcludeFromNuPkg>true</ExcludeFromNuPkg>
     </ProjectReference>
     <ProjectReference Include="..\CodeGeneration\CodeGeneration.csproj">
       <Project>{C1815471-02AF-4BB9-8D83-652ADBAFF5B6}</Project>
       <Name>CodeGeneration</Name>
+      <ExcludeFromNuPkg>true</ExcludeFromNuPkg>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
     <ProjectReference Include="..\Windows.Core\Windows.Core.csproj">

--- a/src/DbgHelp/DbgHelp.csproj
+++ b/src/DbgHelp/DbgHelp.csproj
@@ -39,10 +39,12 @@
       <Project>{1387e009-7086-4572-ac8d-ce4242adec77}</Project>
       <Name>CodeGenerationAttributes</Name>
       <Private>False</Private>
+      <ExcludeFromNuPkg>true</ExcludeFromNuPkg>
     </ProjectReference>
     <ProjectReference Include="..\CodeGeneration\CodeGeneration.csproj">
       <Project>{C1815471-02AF-4BB9-8D83-652ADBAFF5B6}</Project>
       <Name>CodeGeneration</Name>
+      <ExcludeFromNuPkg>true</ExcludeFromNuPkg>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
     <ProjectReference Include="..\Windows.Core\Windows.Core.csproj">

--- a/src/Kernel32.Desktop/Kernel32.Desktop.csproj
+++ b/src/Kernel32.Desktop/Kernel32.Desktop.csproj
@@ -73,6 +73,7 @@
     <ProjectReference Include="..\CodeGeneration\CodeGeneration.csproj">
       <Project>{C1815471-02AF-4BB9-8D83-652ADBAFF5B6}</Project>
       <Name>CodeGeneration</Name>
+      <ExcludeFromNuPkg>true</ExcludeFromNuPkg>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
     <ProjectReference Include="..\Windows.Core\Windows.Core.csproj">

--- a/src/Kernel32.Desktop/Kernel32.Desktop.csproj
+++ b/src/Kernel32.Desktop/Kernel32.Desktop.csproj
@@ -68,6 +68,7 @@
     <ProjectReference Include="..\CodeGenerationAttributes.Net40\CodeGenerationAttributes.Net40.csproj">
       <Project>{6a77281b-c503-44ea-90c1-0e9868d06cd0}</Project>
       <Name>CodeGenerationAttributes.Net40</Name>
+      <ExcludeFromNuPkg>true</ExcludeFromNuPkg>
     </ProjectReference>
     <ProjectReference Include="..\CodeGeneration\CodeGeneration.csproj">
       <Project>{C1815471-02AF-4BB9-8D83-652ADBAFF5B6}</Project>

--- a/src/Kernel32/Kernel32.csproj
+++ b/src/Kernel32/Kernel32.csproj
@@ -37,6 +37,7 @@
     <ProjectReference Include="..\CodeGeneration\CodeGeneration.csproj">
       <Project>{C1815471-02AF-4BB9-8D83-652ADBAFF5B6}</Project>
       <Name>CodeGeneration</Name>
+      <ExcludeFromNuPkg>true</ExcludeFromNuPkg>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
     <ProjectReference Include="..\Windows.Core\Windows.Core.csproj">

--- a/src/Kernel32/Kernel32.csproj
+++ b/src/Kernel32/Kernel32.csproj
@@ -32,6 +32,7 @@
     <ProjectReference Include="..\CodeGenerationAttributes\CodeGenerationAttributes.csproj">
       <Project>{1387e009-7086-4572-ac8d-ce4242adec77}</Project>
       <Name>CodeGenerationAttributes</Name>
+      <ExcludeFromNuPkg>true</ExcludeFromNuPkg>
     </ProjectReference>
     <ProjectReference Include="..\CodeGeneration\CodeGeneration.csproj">
       <Project>{C1815471-02AF-4BB9-8D83-652ADBAFF5B6}</Project>

--- a/src/MSCorEE.Desktop/MSCorEE.Desktop.csproj
+++ b/src/MSCorEE.Desktop/MSCorEE.Desktop.csproj
@@ -28,10 +28,12 @@
     <ProjectReference Include="..\CodeGenerationAttributes.Net40\CodeGenerationAttributes.Net40.csproj">
       <Project>{6a77281b-c503-44ea-90c1-0e9868d06cd0}</Project>
       <Name>CodeGenerationAttributes.Net40</Name>
+      <ExcludeFromNuPkg>true</ExcludeFromNuPkg>
     </ProjectReference>
     <ProjectReference Include="..\CodeGeneration\CodeGeneration.csproj">
       <Project>{C1815471-02AF-4BB9-8D83-652ADBAFF5B6}</Project>
       <Name>CodeGeneration</Name>
+      <ExcludeFromNuPkg>true</ExcludeFromNuPkg>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>

--- a/src/NCrypt/NCrypt.csproj
+++ b/src/NCrypt/NCrypt.csproj
@@ -61,10 +61,12 @@
       <Project>{1387e009-7086-4572-ac8d-ce4242adec77}</Project>
       <Name>CodeGenerationAttributes</Name>
       <Private>False</Private>
+      <ExcludeFromNuPkg>true</ExcludeFromNuPkg>
     </ProjectReference>
     <ProjectReference Include="..\CodeGeneration\CodeGeneration.csproj">
       <Project>{C1815471-02AF-4BB9-8D83-652ADBAFF5B6}</Project>
       <Name>CodeGeneration</Name>
+      <ExcludeFromNuPkg>true</ExcludeFromNuPkg>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
     <ProjectReference Include="..\BCrypt\BCrypt.csproj">

--- a/src/NTDll.Desktop/NTDll.Desktop.csproj
+++ b/src/NTDll.Desktop/NTDll.Desktop.csproj
@@ -28,10 +28,12 @@
     <ProjectReference Include="..\CodeGenerationAttributes.Net40\CodeGenerationAttributes.Net40.csproj">
       <Project>{6a77281b-c503-44ea-90c1-0e9868d06cd0}</Project>
       <Name>CodeGenerationAttributes.Net40</Name>
+      <ExcludeFromNuPkg>true</ExcludeFromNuPkg>
     </ProjectReference>
     <ProjectReference Include="..\CodeGeneration\CodeGeneration.csproj">
       <Project>{C1815471-02AF-4BB9-8D83-652ADBAFF5B6}</Project>
       <Name>CodeGeneration</Name>
+      <ExcludeFromNuPkg>true</ExcludeFromNuPkg>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
     <ProjectReference Include="..\Windows.Core\Windows.Core.csproj">

--- a/src/NTDll/NTDll.csproj
+++ b/src/NTDll/NTDll.csproj
@@ -33,10 +33,12 @@
       <Project>{1387e009-7086-4572-ac8d-ce4242adec77}</Project>
       <Name>CodeGenerationAttributes</Name>
       <Private>False</Private>
+      <ExcludeFromNuPkg>true</ExcludeFromNuPkg>
     </ProjectReference>
     <ProjectReference Include="..\CodeGeneration\CodeGeneration.csproj">
       <Project>{C1815471-02AF-4BB9-8D83-652ADBAFF5B6}</Project>
       <Name>CodeGeneration</Name>
+      <ExcludeFromNuPkg>true</ExcludeFromNuPkg>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
     <ProjectReference Include="..\Windows.Core\Windows.Core.csproj">

--- a/templates/LIBNAME.Desktop/LIBNAME.Desktop.csproj
+++ b/templates/LIBNAME.Desktop/LIBNAME.Desktop.csproj
@@ -28,10 +28,12 @@
     <ProjectReference Include="..\CodeGenerationAttributes.Net40\CodeGenerationAttributes.Net40.csproj">
       <Project>{6a77281b-c503-44ea-90c1-0e9868d06cd0}</Project>
       <Name>CodeGenerationAttributes.Net40</Name>
+      <ExcludeFromNuPkg>true</ExcludeFromNuPkg>
     </ProjectReference>
     <ProjectReference Include="..\CodeGeneration\CodeGeneration.csproj">
       <Project>{C1815471-02AF-4BB9-8D83-652ADBAFF5B6}</Project>
       <Name>CodeGeneration</Name>
+      <ExcludeFromNuPkg>true</ExcludeFromNuPkg>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
     <ProjectReference Include="..\Windows.Core\Windows.Core.csproj">

--- a/templates/LIBNAME/LIBNAME.csproj
+++ b/templates/LIBNAME/LIBNAME.csproj
@@ -33,10 +33,12 @@
       <Project>{1387e009-7086-4572-ac8d-ce4242adec77}</Project>
       <Name>CodeGenerationAttributes</Name>
       <Private>False</Private>
+      <ExcludeFromNuPkg>true</ExcludeFromNuPkg>
     </ProjectReference>
     <ProjectReference Include="..\CodeGeneration\CodeGeneration.csproj">
       <Project>{C1815471-02AF-4BB9-8D83-652ADBAFF5B6}</Project>
       <Name>CodeGeneration</Name>
+      <ExcludeFromNuPkg>true</ExcludeFromNuPkg>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
     <ProjectReference Include="..\Windows.Core\Windows.Core.csproj">


### PR DESCRIPTION
This is my attempt to solve #160. 
It is definitely excluding `CodeGenerationAttributes.Net40.dll` and `CodeGenerationAttributes.dll` from `PInvoke.Kernel32.nupkg`, I don't know if this is the right solution though.
