### PR TITLE
Psapi NuProj should reference PInvoke.Kernel32.NuProj to exclude PInvoke.Kernel32.dll from the lib folder

### DIFF
--- a/src/Psapi.NuGet/Psapi.NuGet.nuproj
+++ b/src/Psapi.NuGet/Psapi.NuGet.nuproj
@@ -34,6 +34,7 @@
     <EmbedSourceFiles>true</EmbedSourceFiles>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Kernel32.NuGet\Kernel32.NuGet.nuproj" />
     <ProjectReference Include="..\Psapi\Psapi.csproj" />
     <ProjectReference Include="..\Windows.Core.NuGet\Windows.Core.NuGet.nuproj" />
   </ItemGroup>


### PR DESCRIPTION
I found this while fixing #160 
