### PR TITLE
Generate additional native pointer overloads

### DIFF
--- a/src/AdvApi32.Desktop/AdvApi32.Helpers.cs
+++ b/src/AdvApi32.Desktop/AdvApi32.Helpers.cs
@@ -40,7 +40,7 @@ namespace PInvoke
                     scmHandle,
                     ServiceType.SERVICE_WIN32,
                     ServiceStateQuery.SERVICE_STATE_ALL,
-                    null,
+                    IntPtr.Zero,
                     0,
                     ref bufferSizeNeeded,
                     ref numServicesReturned,

--- a/src/BCrypt/BCrypt.cs
+++ b/src/BCrypt/BCrypt.cs
@@ -151,115 +151,12 @@ namespace PInvoke
         [DllImport(nameof(BCrypt), SetLastError = true)]
         public static unsafe extern NTSTATUS BCryptEncrypt(
             SafeKeyHandle hKey,
-            byte[] pbInput,
-            int cbInput,
-            void* pPaddingInfo,
-            [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 5)] byte[] pbIV,
-            int cbIV,
-            [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 8)] byte[] pbOutput,
-            int cbOutput,
-            out int pcbResult,
-            BCryptEncryptFlags dwFlags);
-
-        /// <summary>
-        /// Encrypts a block of data.
-        /// </summary>
-        /// <param name="hKey">
-        /// The handle of the key to use to encrypt the data. This handle is obtained from one of the key creation functions, such as <see cref="BCryptGenerateSymmetricKey(SafeAlgorithmHandle, byte[], byte[], BCryptGenerateSymmetricKeyFlags)"/>, <see cref="BCryptGenerateKeyPair(SafeAlgorithmHandle, int)"/>, or <see cref="BCryptImportKey(SafeAlgorithmHandle, string, byte[], SafeKeyHandle, byte[], BCryptImportKeyFlags)"/>.
-        /// </param>
-        /// <param name="pbInput">
-        /// The address of a buffer that contains the plaintext to be encrypted. The cbInput parameter contains the size of the plaintext to encrypt.
-        /// </param>
-        /// <param name="cbInput">
-        /// The number of bytes in the pbInput buffer to encrypt.
-        /// </param>
-        /// <param name="pPaddingInfo">
-        /// A pointer to a structure that contains padding information. This parameter is only used with asymmetric keys and authenticated encryption modes. If an authenticated encryption mode is used, this parameter must point to a BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO structure. If asymmetric keys are used, the type of structure this parameter points to is determined by the value of the dwFlags parameter. Otherwise, the parameter must be set to NULL.
-        /// </param>
-        /// <param name="pbIV">
-        /// The address of a buffer that contains the initialization vector (IV) to use during encryption. The cbIV parameter contains the size of this buffer. This function will modify the contents of this buffer. If you need to reuse the IV later, make sure you make a copy of this buffer before calling this function.
-        /// This parameter is optional and can be NULL if no IV is used.
-        /// The required size of the IV can be obtained by calling the <see cref="BCryptGetProperty(SafeHandle, string, BCryptGetPropertyFlags)"/> function to get the BCRYPT_BLOCK_LENGTH property.This will provide the size of a block for the algorithm, which is also the size of the IV.
-        /// </param>
-        /// <param name="cbIV">The size, in bytes, of the pbIV buffer.</param>
-        /// <param name="pbOutput">
-        /// The address of the buffer that receives the ciphertext produced by this function. The <paramref name="cbOutput"/> parameter contains the size of this buffer. For more information, see Remarks.
-        /// If this parameter is NULL, the <see cref="BCryptEncrypt(SafeKeyHandle, byte[], void*, byte[], BCryptEncryptFlags)"/> function calculates the size needed for the ciphertext of the data passed in the <paramref name="pbInput"/> parameter. In this case, the location pointed to by the <paramref name="pcbResult"/> parameter contains this size, and the function returns <see cref="NTSTATUS.Code.STATUS_SUCCESS"/>.The <paramref name="pPaddingInfo"/> parameter is not modified.
-        /// If the values of both the <paramref name="pbOutput"/> and <paramref name="pbInput"/> parameters are NULL, an error is returned unless an authenticated encryption algorithm is in use.In the latter case, the call is treated as an authenticated encryption call with zero length data, and the authentication tag is returned in the <paramref name="pPaddingInfo"/> parameter.
-        /// </param>
-        /// <param name="cbOutput">
-        /// The size, in bytes, of the <paramref name="pbOutput"/> buffer. This parameter is ignored if the <paramref name="pbOutput"/> parameter is NULL.
-        /// </param>
-        /// <param name="pcbResult">
-        /// A pointer to a ULONG variable that receives the number of bytes copied to the <paramref name="pbOutput"/> buffer. If <paramref name="pbOutput"/> is NULL, this receives the size, in bytes, required for the ciphertext.
-        /// </param>
-        /// <param name="dwFlags">
-        /// A set of flags that modify the behavior of this function. The allowed set of flags depends on the type of key specified by the hKey parameter.
-        /// </param>
-        /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
-        /// <remarks>
-        /// The <paramref name="pbInput"/> and <paramref name="pbOutput"/> parameters can point to the same buffer. In this case, this function will perform the encryption in place. It is possible that the encrypted data size will be larger than the unencrypted data size, so the buffer must be large enough to hold the encrypted data.
-        /// </remarks>
-        [DllImport(nameof(BCrypt), SetLastError = true)]
-        public static unsafe extern NTSTATUS BCryptEncrypt(
-            SafeKeyHandle hKey,
             byte* pbInput,
             int cbInput,
             void* pPaddingInfo,
             byte* pbIV,
             int cbIV,
             byte* pbOutput,
-            int cbOutput,
-            out int pcbResult,
-            BCryptEncryptFlags dwFlags);
-
-        /// <summary>
-        /// Decrypts a block of data.
-        /// </summary>
-        /// <param name="hKey">
-        /// The handle of the key to use to decrypt the data. This handle is obtained from one of the key creation functions, such as <see cref="BCryptGenerateSymmetricKey(SafeAlgorithmHandle, byte[], byte[], BCryptGenerateSymmetricKeyFlags)"/>, <see cref="BCryptGenerateKeyPair(SafeAlgorithmHandle, int)"/>, or <see cref="BCryptImportKey(SafeAlgorithmHandle, string, byte[], SafeKeyHandle, byte[], BCryptImportKeyFlags)"/>.
-        /// </param>
-        /// <param name="pbInput">
-        /// The address of a buffer that contains the ciphertext to be decrypted. The <paramref name="cbInput"/> parameter contains the size of the ciphertext to decrypt. For more information, see Remarks.
-        /// </param>
-        /// <param name="cbInput">
-        /// The number of bytes in the <paramref name="pbInput"/> buffer to decrypt.
-        /// </param>
-        /// <param name="pPaddingInfo">
-        /// A pointer to a structure that contains padding information. This parameter is only used with asymmetric keys and authenticated encryption modes. If an authenticated encryption mode is used, this parameter must point to a BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO structure. If asymmetric keys are used, the type of structure this parameter points to is determined by the value of the <paramref name="dwFlags"/> parameter. Otherwise, the parameter must be set to NULL.
-        /// </param>
-        /// <param name="pbIV">
-        /// The address of a buffer that contains the initialization vector (IV) to use during decryption. The <paramref name="cbIV"/> parameter contains the size of this buffer. This function will modify the contents of this buffer. If you need to reuse the IV later, make sure you make a copy of this buffer before calling this function.
-        /// This parameter is optional and can be NULL if no IV is used.
-        /// The required size of the IV can be obtained by calling the <see cref="BCryptGetProperty(SafeHandle, string, BCryptGetPropertyFlags)"/> function to get the <see cref="PropertyNames.BCRYPT_BLOCK_LENGTH"/> property. This will provide the size of a block for the algorithm, which is also the size of the IV.
-        /// </param>
-        /// <param name="cbIV">
-        /// The size, in bytes, of the <paramref name="pbIV"/> buffer.
-        /// </param>
-        /// <param name="pbOutput">
-        /// The address of a buffer to receive the plaintext produced by this function. The cbOutput parameter contains the size of this buffer. For more information, see Remarks.
-        /// If this parameter is NULL, the <see cref="BCryptDecrypt(SafeKeyHandle, byte[], void*, byte[], BCryptEncryptFlags)"/> function calculates the size required for the plaintext of the encrypted data passed in the <paramref name="pbInput"/> parameter.In this case, the location pointed to by the <paramref name="pcbResult"/> parameter contains this size, and the function returns <see cref="NTSTATUS.Code.STATUS_SUCCESS"/>.
-        /// If the values of both the <paramref name="pbOutput"/> and <paramref name="pbInput" /> parameters are NULL, an error is returned unless an authenticated encryption algorithm is in use.In the latter case, the call is treated as an authenticated encryption call with zero length data, and the authentication tag, passed in the <paramref name="pPaddingInfo"/> parameter, is verified.
-        /// </param>
-        /// <param name="cbOutput">
-        /// The size, in bytes, of the <paramref name="pbOutput"/> buffer. This parameter is ignored if the <paramref name="pbOutput"/> parameter is NULL.
-        /// </param>
-        /// <param name="pcbResult">
-        /// A pointer to a ULONG variable to receive the number of bytes copied to the <paramref name="pbOutput"/> buffer. If <paramref name="pbOutput"/> is NULL, this receives the size, in bytes, required for the plaintext.
-        /// </param>
-        /// <param name="dwFlags">
-        /// A set of flags that modify the behavior of this function. The allowed set of flags depends on the type of key specified by the <paramref name="hKey"/> parameter.
-        /// </param>
-        /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
-        [DllImport(nameof(BCrypt), SetLastError = true)]
-        public static unsafe extern NTSTATUS BCryptDecrypt(
-            SafeKeyHandle hKey,
-            byte[] pbInput,
-            int cbInput,
-            void* pPaddingInfo,
-            [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 5)] byte[] pbIV,
-            int cbIV,
-            [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 8)] byte[] pbOutput,
             int cbOutput,
             out int pcbResult,
             BCryptEncryptFlags dwFlags);
@@ -707,25 +604,6 @@ namespace PInvoke
             SafeHandle hObject,
             string pszProperty,
             byte* pbInput,
-            int cbInput,
-            BCryptSetPropertyFlags dwFlags = BCryptSetPropertyFlags.None);
-
-        /// <summary>
-        /// Sets the value of a named property for a CNG object.
-        /// </summary>
-        /// <param name="hObject">A handle that represents the CNG object to set the property value for.</param>
-        /// <param name="pszProperty">
-        /// A pointer to a null-terminated Unicode string that contains the name of the property to set. This can be one of the predefined <see cref="PropertyNames"/> or a custom property identifier.
-        /// </param>
-        /// <param name="pbInput">The address of a buffer that contains the new property value. The <paramref name="cbInput"/> parameter contains the size of this buffer.</param>
-        /// <param name="cbInput">The size, in bytes, of the <paramref name="pbInput"/> buffer.</param>
-        /// <param name="dwFlags">A set of flags that modify the behavior of this function. No flags are defined for this function.</param>
-        /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
-        [DllImport(nameof(BCrypt), SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
-        public static extern NTSTATUS BCryptSetProperty(
-            SafeHandle hObject,
-            string pszProperty,
-            [In, MarshalAs(UnmanagedType.LPArray)] byte[] pbInput,
             int cbInput,
             BCryptSetPropertyFlags dwFlags = BCryptSetPropertyFlags.None);
 

--- a/src/CodeGeneration/OfferIntPtrOverloadGenerator.cs
+++ b/src/CodeGeneration/OfferIntPtrOverloadGenerator.cs
@@ -21,6 +21,10 @@ namespace PInvoke
     {
         private static readonly TypeSyntax VoidStar = SyntaxFactory.ParseTypeName("void*");
 
+        private static readonly TypeSyntax ByteStar = SyntaxFactory.ParseTypeName("byte*");
+
+        private static readonly TypeSyntax ByteArray = SyntaxFactory.ParseTypeName("byte[]");
+
         private static readonly TypeSyntax IntPtrTypeSyntax = SyntaxFactory.ParseTypeName("System.IntPtr");
 
         /// <summary>
@@ -29,6 +33,14 @@ namespace PInvoke
         /// <param name="data">Generator attribute data.</param>
         public OfferIntPtrOverloadGenerator(AttributeData data)
         {
+        }
+
+        [Flags]
+        private enum GeneratorFlags
+        {
+            None = 0x0,
+            NativePointerToIntPtr = 0x1,
+            NativeBytePointerToByteArray = 0x2,
         }
 
         /// <inheritdoc />
@@ -44,20 +56,52 @@ namespace PInvoke
 
             foreach (var method in methodsWithNativePointers)
             {
-                var intPtrOverload = method
-                    .WithParameterList(TransformParameterList(method.ParameterList))
+                var transformedMethodBase = method
                     .WithReturnType(TransformReturnType(method.ReturnType))
                     .WithIdentifier(TransformMethodName(method))
                     .WithModifiers(RemoveModifier(method.Modifiers, SyntaxKind.ExternKeyword))
                     .WithAttributeLists(SyntaxFactory.List<AttributeListSyntax>())
                     .WithLeadingTrivia(method.GetLeadingTrivia().Where(t => !t.IsDirective))
                     .WithTrailingTrivia(method.GetTrailingTrivia().Where(t => !t.IsDirective))
-                    .WithBody(CallNativePointerOverload(method))
                     .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.None));
+
+                var flags = GeneratorFlags.NativePointerToIntPtr;
+                var intPtrOverload = transformedMethodBase
+                    .WithParameterList(TransformParameterList(method.ParameterList, flags))
+                    .WithBody(CallNativePointerOverload(method, flags));
                 generatedType = generatedType.AddMembers(intPtrOverload);
+
+                var nativePointerParameters = method.ParameterList.Parameters.Where(p => p.Type is PointerTypeSyntax);
+                var byteArrayParameters = nativePointerParameters.Where(p => IsByteStar(p.Type));
+                if (byteArrayParameters.Any())
+                {
+                    flags = GeneratorFlags.NativePointerToIntPtr | GeneratorFlags.NativeBytePointerToByteArray;
+                    var byteArrayAndIntPtrOverload = transformedMethodBase
+                        .WithParameterList(TransformParameterList(method.ParameterList, flags))
+                        .WithBody(CallNativePointerOverload(method, flags));
+                    generatedType = generatedType.AddMembers(byteArrayAndIntPtrOverload);
+
+                    // If there are native pointers that aren't byte*, it would produce a unique method signature
+                    // for a method that only converts the byte* parameters and leaves other native pointers alone.
+                    if (nativePointerParameters.Except(byteArrayParameters).Any())
+                    {
+                        flags = GeneratorFlags.NativeBytePointerToByteArray;
+                        var byteArrayOverload = transformedMethodBase
+                            .WithParameterList(TransformParameterList(method.ParameterList, flags))
+                            .WithBody(CallNativePointerOverload(method, flags));
+                        generatedType = generatedType.AddMembers(byteArrayOverload);
+                    }
+                }
             }
 
             return Task.FromResult(SyntaxFactory.SingletonList<MemberDeclarationSyntax>(generatedType));
+        }
+
+        private static bool IsByteStar(TypeSyntax typeSyntax)
+        {
+            var nativePointerType = typeSyntax as PointerTypeSyntax;
+            var predefinedElementType = nativePointerType?.ElementType as PredefinedTypeSyntax;
+            return predefinedElementType?.Keyword.IsKind(SyntaxKind.ByteKeyword) ?? false;
         }
 
         private static IEnumerable<ParameterSyntax> WhereIsPointerParameter(IEnumerable<ParameterSyntax> parameters)
@@ -79,11 +123,18 @@ namespace PInvoke
 
         private static TypeSyntax TransformReturnType(TypeSyntax returnType) => returnType is PointerTypeSyntax ? IntPtrTypeSyntax : returnType;
 
-        private static ParameterListSyntax TransformParameterList(ParameterListSyntax list)
+        private static ParameterListSyntax TransformParameterList(ParameterListSyntax list, GeneratorFlags flags)
         {
             var resultingList = list.ReplaceNodes(
                 WhereIsPointerParameter(list.Parameters),
-                (n1, n2) => TransformParameterDefaultValue(n2.WithType(IntPtrTypeSyntax)));
+                (n1, n2) =>
+                {
+                    bool changeToByteArray = flags.HasFlag(GeneratorFlags.NativeBytePointerToByteArray) && IsByteStar(n2.Type);
+                    bool changeToIntPtr = flags.HasFlag(GeneratorFlags.NativePointerToIntPtr);
+                    return changeToByteArray ? TransformParameterDefaultValue(n2.WithType(ByteArray))
+                        : changeToIntPtr ? TransformParameterDefaultValue(n2.WithType(IntPtrTypeSyntax))
+                        : n2;
+                });
             return resultingList;
         }
 
@@ -104,17 +155,28 @@ namespace PInvoke
             return SyntaxFactory.TokenList(list.Where(t => Array.IndexOf(modifiers, t.Kind()) < 0));
         }
 
-        private static BlockSyntax CallNativePointerOverload(MethodDeclarationSyntax nativePointerOverload)
+        private static BlockSyntax CallNativePointerOverload(MethodDeclarationSyntax nativePointerOverload, GeneratorFlags flags)
         {
+            var byteArrayTransformParameters =
+                (from p in nativePointerOverload.ParameterList.Parameters
+                 where flags.HasFlag(GeneratorFlags.NativeBytePointerToByteArray) && IsByteStar(p.Type)
+                 select p).ToList();
             var parametersRequiringCasts =
                 from p in nativePointerOverload.ParameterList.Parameters
+                where flags.HasFlag(GeneratorFlags.NativePointerToIntPtr)
                 where p.Type is PointerTypeSyntax && (p.Modifiers.Any(m => m.IsKind(SyntaxKind.OutKeyword) || m.IsKind(SyntaxKind.RefKeyword)) || !p.Type.Equals(VoidStar))
+                where !byteArrayTransformParameters.Contains(p)
                 group p by p.Type into paramsByType
                 select paramsByType;
 
             var redirectedParameters = new Dictionary<ParameterSyntax, IdentifierNameSyntax>();
 
             var block = SyntaxFactory.Block();
+
+            foreach (var byteStarParam in byteArrayTransformParameters)
+            {
+                redirectedParameters.Add(byteStarParam, SyntaxFactory.IdentifierName("p" + byteStarParam.Identifier.ValueText));
+            }
 
             foreach (var pType in parametersRequiringCasts)
             {
@@ -202,6 +264,23 @@ namespace PInvoke
                         null)
                     : resultVariableName;
                 block = block.AddStatements(SyntaxFactory.ReturnStatement(returnedValue));
+            }
+
+            if (byteArrayTransformParameters.Any())
+            {
+                StatementSyntax outermost = block;
+                foreach (var p in byteArrayTransformParameters)
+                {
+                    var nameOfPointerLocal = redirectedParameters[p].Identifier;
+                    var nameOfArrayParameter = SyntaxFactory.IdentifierName(p.Identifier);
+                    var fixedArrayDecl = SyntaxFactory.VariableDeclarator(nameOfPointerLocal)
+                        .WithInitializer(SyntaxFactory.EqualsValueClause(nameOfArrayParameter));
+                    outermost = SyntaxFactory.FixedStatement(
+                        SyntaxFactory.VariableDeclaration(ByteStar).AddVariables(fixedArrayDecl),
+                        outermost);
+                }
+
+                block = SyntaxFactory.Block(outermost);
             }
 
             return block;

--- a/src/NCrypt/NCrypt.cs
+++ b/src/NCrypt/NCrypt.cs
@@ -119,7 +119,7 @@ namespace PInvoke
         public static extern unsafe SECURITY_STATUS NCryptKeyDerivation(
             SafeKeyHandle hKey,
             NCryptBufferDesc* pParameterList,
-            out byte* pbDerivedKey,
+            byte* pbDerivedKey,
             int cbDerivedKey,
             out int pcbResult,
             NCryptKeyDerivationFlags dwFlags = NCryptKeyDerivationFlags.None);


### PR DESCRIPTION
As part of this, I removed the manually written overloads that are now redundant with what we can generate automatically.

Fixes #157
