### PR TITLE
Generate additional native pointer overloads

### DIFF
--- a/src/AdvApi32.Desktop/AdvApi32.Helpers.cs
+++ b/src/AdvApi32.Desktop/AdvApi32.Helpers.cs
@@ -40,7 +40,7 @@ namespace PInvoke
                     scmHandle,
                     ServiceType.SERVICE_WIN32,
                     ServiceStateQuery.SERVICE_STATE_ALL,
-                    null,
+                    IntPtr.Zero,
                     0,
                     ref bufferSizeNeeded,
                     ref numServicesReturned,

--- a/src/AdvApi32.Shared/AdvApi32.cs
+++ b/src/AdvApi32.Shared/AdvApi32.cs
@@ -11,7 +11,7 @@ namespace PInvoke
     /// Exported functions from the AdvApi32.dll Windows library
     /// that are available to Desktop and Store apps.
     /// </content>
-    [OfferIntPtrOverloads]
+    [OfferFriendlyOverloads]
     public static partial class AdvApi32
     {
         /// <summary>

--- a/src/BCrypt/BCrypt.cs
+++ b/src/BCrypt/BCrypt.cs
@@ -11,7 +11,7 @@ namespace PInvoke
     /// <summary>
     /// Exported functions from the BCrypt.dll Windows library.
     /// </summary>
-    [OfferIntPtrOverloads]
+    [OfferFriendlyOverloads]
     public static partial class BCrypt
     {
         /// <summary>

--- a/src/BCrypt/BCrypt.cs
+++ b/src/BCrypt/BCrypt.cs
@@ -151,115 +151,12 @@ namespace PInvoke
         [DllImport(nameof(BCrypt), SetLastError = true)]
         public static unsafe extern NTSTATUS BCryptEncrypt(
             SafeKeyHandle hKey,
-            byte[] pbInput,
-            int cbInput,
-            void* pPaddingInfo,
-            [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 5)] byte[] pbIV,
-            int cbIV,
-            [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 8)] byte[] pbOutput,
-            int cbOutput,
-            out int pcbResult,
-            BCryptEncryptFlags dwFlags);
-
-        /// <summary>
-        /// Encrypts a block of data.
-        /// </summary>
-        /// <param name="hKey">
-        /// The handle of the key to use to encrypt the data. This handle is obtained from one of the key creation functions, such as <see cref="BCryptGenerateSymmetricKey(SafeAlgorithmHandle, byte[], byte[], BCryptGenerateSymmetricKeyFlags)"/>, <see cref="BCryptGenerateKeyPair(SafeAlgorithmHandle, int)"/>, or <see cref="BCryptImportKey(SafeAlgorithmHandle, string, byte[], SafeKeyHandle, byte[], BCryptImportKeyFlags)"/>.
-        /// </param>
-        /// <param name="pbInput">
-        /// The address of a buffer that contains the plaintext to be encrypted. The cbInput parameter contains the size of the plaintext to encrypt.
-        /// </param>
-        /// <param name="cbInput">
-        /// The number of bytes in the pbInput buffer to encrypt.
-        /// </param>
-        /// <param name="pPaddingInfo">
-        /// A pointer to a structure that contains padding information. This parameter is only used with asymmetric keys and authenticated encryption modes. If an authenticated encryption mode is used, this parameter must point to a BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO structure. If asymmetric keys are used, the type of structure this parameter points to is determined by the value of the dwFlags parameter. Otherwise, the parameter must be set to NULL.
-        /// </param>
-        /// <param name="pbIV">
-        /// The address of a buffer that contains the initialization vector (IV) to use during encryption. The cbIV parameter contains the size of this buffer. This function will modify the contents of this buffer. If you need to reuse the IV later, make sure you make a copy of this buffer before calling this function.
-        /// This parameter is optional and can be NULL if no IV is used.
-        /// The required size of the IV can be obtained by calling the <see cref="BCryptGetProperty(SafeHandle, string, BCryptGetPropertyFlags)"/> function to get the BCRYPT_BLOCK_LENGTH property.This will provide the size of a block for the algorithm, which is also the size of the IV.
-        /// </param>
-        /// <param name="cbIV">The size, in bytes, of the pbIV buffer.</param>
-        /// <param name="pbOutput">
-        /// The address of the buffer that receives the ciphertext produced by this function. The <paramref name="cbOutput"/> parameter contains the size of this buffer. For more information, see Remarks.
-        /// If this parameter is NULL, the <see cref="BCryptEncrypt(SafeKeyHandle, byte[], void*, byte[], BCryptEncryptFlags)"/> function calculates the size needed for the ciphertext of the data passed in the <paramref name="pbInput"/> parameter. In this case, the location pointed to by the <paramref name="pcbResult"/> parameter contains this size, and the function returns <see cref="NTSTATUS.Code.STATUS_SUCCESS"/>.The <paramref name="pPaddingInfo"/> parameter is not modified.
-        /// If the values of both the <paramref name="pbOutput"/> and <paramref name="pbInput"/> parameters are NULL, an error is returned unless an authenticated encryption algorithm is in use.In the latter case, the call is treated as an authenticated encryption call with zero length data, and the authentication tag is returned in the <paramref name="pPaddingInfo"/> parameter.
-        /// </param>
-        /// <param name="cbOutput">
-        /// The size, in bytes, of the <paramref name="pbOutput"/> buffer. This parameter is ignored if the <paramref name="pbOutput"/> parameter is NULL.
-        /// </param>
-        /// <param name="pcbResult">
-        /// A pointer to a ULONG variable that receives the number of bytes copied to the <paramref name="pbOutput"/> buffer. If <paramref name="pbOutput"/> is NULL, this receives the size, in bytes, required for the ciphertext.
-        /// </param>
-        /// <param name="dwFlags">
-        /// A set of flags that modify the behavior of this function. The allowed set of flags depends on the type of key specified by the hKey parameter.
-        /// </param>
-        /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
-        /// <remarks>
-        /// The <paramref name="pbInput"/> and <paramref name="pbOutput"/> parameters can point to the same buffer. In this case, this function will perform the encryption in place. It is possible that the encrypted data size will be larger than the unencrypted data size, so the buffer must be large enough to hold the encrypted data.
-        /// </remarks>
-        [DllImport(nameof(BCrypt), SetLastError = true)]
-        public static unsafe extern NTSTATUS BCryptEncrypt(
-            SafeKeyHandle hKey,
             byte* pbInput,
             int cbInput,
             void* pPaddingInfo,
             byte* pbIV,
             int cbIV,
             byte* pbOutput,
-            int cbOutput,
-            out int pcbResult,
-            BCryptEncryptFlags dwFlags);
-
-        /// <summary>
-        /// Decrypts a block of data.
-        /// </summary>
-        /// <param name="hKey">
-        /// The handle of the key to use to decrypt the data. This handle is obtained from one of the key creation functions, such as <see cref="BCryptGenerateSymmetricKey(SafeAlgorithmHandle, byte[], byte[], BCryptGenerateSymmetricKeyFlags)"/>, <see cref="BCryptGenerateKeyPair(SafeAlgorithmHandle, int)"/>, or <see cref="BCryptImportKey(SafeAlgorithmHandle, string, byte[], SafeKeyHandle, byte[], BCryptImportKeyFlags)"/>.
-        /// </param>
-        /// <param name="pbInput">
-        /// The address of a buffer that contains the ciphertext to be decrypted. The <paramref name="cbInput"/> parameter contains the size of the ciphertext to decrypt. For more information, see Remarks.
-        /// </param>
-        /// <param name="cbInput">
-        /// The number of bytes in the <paramref name="pbInput"/> buffer to decrypt.
-        /// </param>
-        /// <param name="pPaddingInfo">
-        /// A pointer to a structure that contains padding information. This parameter is only used with asymmetric keys and authenticated encryption modes. If an authenticated encryption mode is used, this parameter must point to a BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO structure. If asymmetric keys are used, the type of structure this parameter points to is determined by the value of the <paramref name="dwFlags"/> parameter. Otherwise, the parameter must be set to NULL.
-        /// </param>
-        /// <param name="pbIV">
-        /// The address of a buffer that contains the initialization vector (IV) to use during decryption. The <paramref name="cbIV"/> parameter contains the size of this buffer. This function will modify the contents of this buffer. If you need to reuse the IV later, make sure you make a copy of this buffer before calling this function.
-        /// This parameter is optional and can be NULL if no IV is used.
-        /// The required size of the IV can be obtained by calling the <see cref="BCryptGetProperty(SafeHandle, string, BCryptGetPropertyFlags)"/> function to get the <see cref="PropertyNames.BCRYPT_BLOCK_LENGTH"/> property. This will provide the size of a block for the algorithm, which is also the size of the IV.
-        /// </param>
-        /// <param name="cbIV">
-        /// The size, in bytes, of the <paramref name="pbIV"/> buffer.
-        /// </param>
-        /// <param name="pbOutput">
-        /// The address of a buffer to receive the plaintext produced by this function. The cbOutput parameter contains the size of this buffer. For more information, see Remarks.
-        /// If this parameter is NULL, the <see cref="BCryptDecrypt(SafeKeyHandle, byte[], void*, byte[], BCryptEncryptFlags)"/> function calculates the size required for the plaintext of the encrypted data passed in the <paramref name="pbInput"/> parameter.In this case, the location pointed to by the <paramref name="pcbResult"/> parameter contains this size, and the function returns <see cref="NTSTATUS.Code.STATUS_SUCCESS"/>.
-        /// If the values of both the <paramref name="pbOutput"/> and <paramref name="pbInput" /> parameters are NULL, an error is returned unless an authenticated encryption algorithm is in use.In the latter case, the call is treated as an authenticated encryption call with zero length data, and the authentication tag, passed in the <paramref name="pPaddingInfo"/> parameter, is verified.
-        /// </param>
-        /// <param name="cbOutput">
-        /// The size, in bytes, of the <paramref name="pbOutput"/> buffer. This parameter is ignored if the <paramref name="pbOutput"/> parameter is NULL.
-        /// </param>
-        /// <param name="pcbResult">
-        /// A pointer to a ULONG variable to receive the number of bytes copied to the <paramref name="pbOutput"/> buffer. If <paramref name="pbOutput"/> is NULL, this receives the size, in bytes, required for the plaintext.
-        /// </param>
-        /// <param name="dwFlags">
-        /// A set of flags that modify the behavior of this function. The allowed set of flags depends on the type of key specified by the <paramref name="hKey"/> parameter.
-        /// </param>
-        /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
-        [DllImport(nameof(BCrypt), SetLastError = true)]
-        public static unsafe extern NTSTATUS BCryptDecrypt(
-            SafeKeyHandle hKey,
-            byte[] pbInput,
-            int cbInput,
-            void* pPaddingInfo,
-            [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 5)] byte[] pbIV,
-            int cbIV,
-            [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 8)] byte[] pbOutput,
             int cbOutput,
             out int pcbResult,
             BCryptEncryptFlags dwFlags);
@@ -707,25 +604,6 @@ namespace PInvoke
             SafeHandle hObject,
             string pszProperty,
             byte* pbInput,
-            int cbInput,
-            BCryptSetPropertyFlags dwFlags = BCryptSetPropertyFlags.None);
-
-        /// <summary>
-        /// Sets the value of a named property for a CNG object.
-        /// </summary>
-        /// <param name="hObject">A handle that represents the CNG object to set the property value for.</param>
-        /// <param name="pszProperty">
-        /// A pointer to a null-terminated Unicode string that contains the name of the property to set. This can be one of the predefined <see cref="PropertyNames"/> or a custom property identifier.
-        /// </param>
-        /// <param name="pbInput">The address of a buffer that contains the new property value. The <paramref name="cbInput"/> parameter contains the size of this buffer.</param>
-        /// <param name="cbInput">The size, in bytes, of the <paramref name="pbInput"/> buffer.</param>
-        /// <param name="dwFlags">A set of flags that modify the behavior of this function. No flags are defined for this function.</param>
-        /// <returns>Returns a status code that indicates the success or failure of the function.</returns>
-        [DllImport(nameof(BCrypt), SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
-        public static extern NTSTATUS BCryptSetProperty(
-            SafeHandle hObject,
-            string pszProperty,
-            [In, MarshalAs(UnmanagedType.LPArray)] byte[] pbInput,
             int cbInput,
             BCryptSetPropertyFlags dwFlags = BCryptSetPropertyFlags.None);
 

--- a/src/CodeGeneration/CodeGeneration.csproj
+++ b/src/CodeGeneration/CodeGeneration.csproj
@@ -30,7 +30,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="OfferIntPtrOverloadGenerator.cs" />
+    <Compile Include="OfferFriendlyOverloadsGenerator.cs" />
     <Compile Include="OfferIntPtrPropertyAccessorsGenerator.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/CodeGeneration/OfferFriendlyOverloadsGenerator.cs
+++ b/src/CodeGeneration/OfferFriendlyOverloadsGenerator.cs
@@ -15,9 +15,10 @@ namespace PInvoke
     using Microsoft.CodeAnalysis.CSharp.Syntax;
 
     /// <summary>
-    /// Generates an <see cref="IntPtr"/> overload of a method that accepts native pointers.
+    /// Generates <see cref="IntPtr"/> and/or <c>byte[]</c> overloads
+    /// of a method that accepts native pointers.
     /// </summary>
-    public class OfferIntPtrOverloadGenerator : ICodeGenerator
+    public class OfferFriendlyOverloadsGenerator : ICodeGenerator
     {
         private static readonly TypeSyntax VoidStar = SyntaxFactory.ParseTypeName("void*");
 
@@ -28,10 +29,10 @@ namespace PInvoke
         private static readonly TypeSyntax IntPtrTypeSyntax = SyntaxFactory.ParseTypeName("System.IntPtr");
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="OfferIntPtrOverloadGenerator"/> class.
+        /// Initializes a new instance of the <see cref="OfferFriendlyOverloadsGenerator"/> class.
         /// </summary>
         /// <param name="data">Generator attribute data.</param>
-        public OfferIntPtrOverloadGenerator(AttributeData data)
+        public OfferFriendlyOverloadsGenerator(AttributeData data)
         {
         }
 

--- a/src/CodeGenerationAttributes.Net40/CodeGenerationAttributes.Net40.csproj
+++ b/src/CodeGenerationAttributes.Net40/CodeGenerationAttributes.Net40.csproj
@@ -31,8 +31,8 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\CodeGenerationAttributes\OfferIntPtrOverloadsAttribute.cs">
-      <Link>OfferIntPtrOverloadsAttribute.cs</Link>
+    <Compile Include="..\CodeGenerationAttributes\OfferFriendlyOverloadsAttribute.cs">
+      <Link>OfferFriendlyOverloadsAttribute.cs</Link>
     </Compile>
     <Compile Include="..\CodeGenerationAttributes\OfferIntPtrPropertyAccessorsAttribute.cs">
       <Link>OfferIntPtrPropertyAccessorsAttribute.cs</Link>

--- a/src/CodeGenerationAttributes/CodeGenerationAttributes.csproj
+++ b/src/CodeGenerationAttributes/CodeGenerationAttributes.csproj
@@ -28,7 +28,7 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="OfferIntPtrOverloadsAttribute.cs" />
+    <Compile Include="OfferFriendlyOverloadsAttribute.cs" />
     <Compile Include="OfferIntPtrPropertyAccessorsAttribute.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/CodeGenerationAttributes/OfferFriendlyOverloadsAttribute.cs
+++ b/src/CodeGenerationAttributes/OfferFriendlyOverloadsAttribute.cs
@@ -12,9 +12,9 @@ namespace PInvoke
     /// <see cref="IntPtr"/> parameters instead of native pointers.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-    [CodeGenerationAttribute("PInvoke.OfferIntPtrOverloadGenerator, CodeGeneration, Version=0.1.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a")]
+    [CodeGenerationAttribute("PInvoke.OfferFriendlyOverloadsGenerator, CodeGeneration, Version=0.1.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a")]
     [Conditional("CodeGeneration")]
-    public class OfferIntPtrOverloadsAttribute : Attribute
+    public class OfferFriendlyOverloadsAttribute : Attribute
     {
     }
 }

--- a/src/Crypt32.Shared/Crypt32.cs
+++ b/src/Crypt32.Shared/Crypt32.cs
@@ -10,7 +10,7 @@ namespace PInvoke
     /// Exported functions from the Crypt32.dll Windows library
     /// that are available to Desktop and Store apps.
     /// </summary>
-    [OfferIntPtrOverloads]
+    [OfferFriendlyOverloads]
     public static partial class Crypt32
     {
         /// <summary>

--- a/src/Kernel32.Shared/Kernel32.cs
+++ b/src/Kernel32.Shared/Kernel32.cs
@@ -11,7 +11,7 @@ namespace PInvoke
     /// <summary>
     /// Exported functions from the Kernel32.dll Windows library.
     /// </summary>
-    [OfferIntPtrOverloads]
+    [OfferFriendlyOverloads]
     public static partial class Kernel32
     {
         /// <summary>

--- a/src/MSCorEE.Desktop/MSCorEE.Helpers.cs
+++ b/src/MSCorEE.Desktop/MSCorEE.Helpers.cs
@@ -42,7 +42,7 @@ namespace PInvoke
         {
             byte* publicKeyBlob;
             int publicKeyBlobLength;
-            Marshal.ThrowExceptionForHR(StrongNameGetPublicKey(keyContainer, null, 0, out publicKeyBlob, out publicKeyBlobLength));
+            Marshal.ThrowExceptionForHR(StrongNameGetPublicKey(keyContainer, (byte*)null, 0, out publicKeyBlob, out publicKeyBlobLength));
             return MarshalNativeBuffer(publicKeyBlob, publicKeyBlobLength);
         }
 

--- a/src/MSCorEE.Desktop/MSCorEE.cs
+++ b/src/MSCorEE.Desktop/MSCorEE.cs
@@ -10,7 +10,7 @@ namespace PInvoke
     /// Exported functions from the MSCorEE.dll Windows library
     /// that are available to Desktop and Store apps.
     /// </summary>
-    [OfferIntPtrOverloads]
+    [OfferFriendlyOverloads]
     public static partial class MSCorEE
     {
         /// <summary>

--- a/src/NCrypt/NCrypt+NCryptKeyDerivationFlags.cs
+++ b/src/NCrypt/NCrypt+NCryptKeyDerivationFlags.cs
@@ -9,7 +9,7 @@ namespace PInvoke
     public partial class NCrypt
     {
         /// <summary>
-        /// Flags that may be passed to the <see cref="NCryptKeyDerivation(SafeKeyHandle, NCryptBufferDesc*, out byte*, int, out int, NCryptKeyDerivationFlags)"/> method.
+        /// Flags that may be passed to the <see cref="NCryptKeyDerivation(SafeKeyHandle, NCryptBufferDesc*, byte*, int, out int, NCryptKeyDerivationFlags)"/> method.
         /// </summary>
         public enum NCryptKeyDerivationFlags : uint
         {

--- a/src/NCrypt/NCrypt.cs
+++ b/src/NCrypt/NCrypt.cs
@@ -10,7 +10,7 @@ namespace PInvoke
     /// Exported functions from the NCrypt.dll Windows library
     /// that are available to Desktop and Store apps.
     /// </summary>
-    [OfferIntPtrOverloads]
+    [OfferFriendlyOverloads]
     public static partial class NCrypt
     {
         /// <summary>

--- a/src/NCrypt/NCrypt.cs
+++ b/src/NCrypt/NCrypt.cs
@@ -119,13 +119,13 @@ namespace PInvoke
         public static extern unsafe SECURITY_STATUS NCryptKeyDerivation(
             SafeKeyHandle hKey,
             NCryptBufferDesc* pParameterList,
-            out byte* pbDerivedKey,
+            byte* pbDerivedKey,
             int cbDerivedKey,
             out int pcbResult,
             NCryptKeyDerivationFlags dwFlags = NCryptKeyDerivationFlags.None);
 
         /// <summary>
-        /// Derives a key from a secret agreement value. This function is intended to be used as part of a secret agreement procedure using persisted secret agreement keys. To derive key material by using a persisted secret instead, use the <see cref="NCryptKeyDerivation(SafeKeyHandle, NCryptBufferDesc*, out byte*, int, out int, NCryptKeyDerivationFlags)"/> function.
+        /// Derives a key from a secret agreement value. This function is intended to be used as part of a secret agreement procedure using persisted secret agreement keys. To derive key material by using a persisted secret instead, use the <see cref="NCryptKeyDerivation(SafeKeyHandle, NCryptBufferDesc*, byte*, int, out int, NCryptKeyDerivationFlags)"/> function.
         /// </summary>
         /// <param name="hSharedSecret">The secret agreement handle to create the key from. This handle is obtained from the <see cref="NCryptSecretAgreement(SafeKeyHandle, SafeKeyHandle, out SafeSecretHandle, NCryptSecretAgreementFlags)"/> function.</param>
         /// <param name="pwszKDF">A pointer to a null-terminated Unicode string that identifies the key derivation function (KDF) to use to derive the key. It can be one of the strings defined in <see cref="BCrypt.KeyDerivationFunctions"/>.</param>

--- a/src/NTDll.Shared/NTDll.cs
+++ b/src/NTDll.Shared/NTDll.cs
@@ -10,7 +10,7 @@ namespace PInvoke
     /// Exported functions from the NTDll.dll Windows library
     /// that are available to Desktop and Store apps.
     /// </summary>
-    [OfferIntPtrOverloads]
+    [OfferFriendlyOverloads]
     public static partial class NTDll
     {
     }

--- a/templates/LIBNAME.Shared/LIBNAME.cs
+++ b/templates/LIBNAME.Shared/LIBNAME.cs
@@ -10,7 +10,7 @@ namespace PInvoke
     /// Exported functions from the LIBNAME.dll Windows library
     /// that are available to Desktop and Store apps.
     /// </summary>
-    [OfferIntPtrOverloads]
+    [OfferFriendlyOverloads]
     public static partial class LIBNAME
     {
     }


### PR DESCRIPTION
As part of this, I removed the manually written overloads that are now redundant with what we can generate automatically.

Fixes #157
