### PR TITLE
Use Facts as suffix for all test classes

### DIFF
--- a/src/AdvApi32.Tests/AdvApi32.Tests.csproj
+++ b/src/AdvApi32.Tests/AdvApi32.Tests.csproj
@@ -31,7 +31,7 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AdvApi32.cs" />
+    <Compile Include="AdvApi32Facts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/AdvApi32.Tests/AdvApi32Facts.cs
+++ b/src/AdvApi32.Tests/AdvApi32Facts.cs
@@ -2,11 +2,15 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 
 using System;
-using System.IO;
 using PInvoke;
 using Xunit;
-using static PInvoke.Kernel32;
+using static PInvoke.AdvApi32;
 
-public partial class Kernel32
+public class AdvApi32Facts
 {
+    [Fact]
+    public void LsaNtStatusToWinError_UsesTable()
+    {
+        Assert.Equal(Win32ErrorCode.ERROR_NOACCESS, LsaNtStatusToWinError(NTSTATUS.Code.STATUS_ACCESS_VIOLATION));
+    }
 }

--- a/src/BCrypt.Tests/BCrypt.Tests.csproj
+++ b/src/BCrypt.Tests/BCrypt.Tests.csproj
@@ -31,7 +31,7 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="BCrypt.cs" />
+    <Compile Include="BCryptFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/BCrypt.Tests/BCryptFacts.cs
+++ b/src/BCrypt.Tests/BCryptFacts.cs
@@ -10,11 +10,11 @@ using Xunit;
 using Xunit.Abstractions;
 using static PInvoke.BCrypt;
 
-public class BCrypt
+public class BCryptFacts
 {
     private readonly ITestOutputHelper logger;
 
-    public BCrypt(ITestOutputHelper logger)
+    public BCryptFacts(ITestOutputHelper logger)
     {
         this.logger = logger;
     }

--- a/src/Crypt32.Tests/Crypt32.Tests.csproj
+++ b/src/Crypt32.Tests/Crypt32.Tests.csproj
@@ -32,7 +32,7 @@
     <EmbeddedResource Include="protectedPair.pfx" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Crypt32.cs" />
+    <Compile Include="Crypt32Facts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Crypt32.Tests/Crypt32Facts.cs
+++ b/src/Crypt32.Tests/Crypt32Facts.cs
@@ -9,7 +9,7 @@ using PInvoke;
 using Xunit;
 using static PInvoke.Crypt32;
 
-public class Crypt32
+public class Crypt32Facts
 {
     [Fact]
     public unsafe void PFXImportCertStoreTest()

--- a/src/DbgHelp.Tests/DbgHelp.Tests.csproj
+++ b/src/DbgHelp.Tests/DbgHelp.Tests.csproj
@@ -31,7 +31,7 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="DbgHelp.cs" />
+    <Compile Include="DbgHelpFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/DbgHelp.Tests/DbgHelpFacts.cs
+++ b/src/DbgHelp.Tests/DbgHelpFacts.cs
@@ -4,12 +4,14 @@
 using System;
 using PInvoke;
 using Xunit;
-using static PInvoke.LIBNAME;
+using static PInvoke.DbgHelp;
 
-public class LIBNAME
+public class DbgHelpFacts
 {
-    [Fact(Skip = "No tests yet")]
-    public void NoTests()
+    [Fact]
+    public void IntPtrGeneration()
     {
+        LOADED_IMAGE image = default(LOADED_IMAGE);
+        image.FileHeader_IntPtr = IntPtr.Zero;
     }
 }

--- a/src/Hid.Tests/Hid.Tests.csproj
+++ b/src/Hid.Tests/Hid.Tests.csproj
@@ -31,7 +31,7 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Hid.cs" />
+    <Compile Include="HidFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Hid.Tests/HidFacts.cs
+++ b/src/Hid.Tests/HidFacts.cs
@@ -7,7 +7,7 @@ using Xunit;
 using static PInvoke.Hid;
 using static PInvoke.Kernel32;
 
-public class Hid
+public class HidFacts
 {
     [Fact]
     public void HidD_GetHidGuid_ReturnExpectedValue()

--- a/src/ImageHlp.Tests/ImageHlp.Tests.csproj
+++ b/src/ImageHlp.Tests/ImageHlp.Tests.csproj
@@ -31,7 +31,7 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="ImageHlp.cs" />
+    <Compile Include="ImageHlpFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ImageHlp.Tests/ImageHlpFacts.cs
+++ b/src/ImageHlp.Tests/ImageHlpFacts.cs
@@ -7,7 +7,7 @@ using Xunit;
 using static PInvoke.DbgHelp;
 using static PInvoke.ImageHlp;
 
-public class ImageHlp
+public class ImageHlpFacts
 {
     [Fact(Skip = "Fails on appveyor")]
     public void MapAndLoadTest()

--- a/src/Kernel32.Tests.Shared/Kernel32.Tests.Shared.projitems
+++ b/src/Kernel32.Tests.Shared/Kernel32.Tests.Shared.projitems
@@ -11,8 +11,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Kernel32Facts.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)NTStatusExceptionTests.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Win32ExceptionTests.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Kernel32ExtensionsTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)NTStatusExceptionFacts.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Win32ExceptionFacts.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Kernel32ExtensionsFacts.cs" />
   </ItemGroup>
 </Project>

--- a/src/Kernel32.Tests.Shared/Kernel32.Tests.Shared.projitems
+++ b/src/Kernel32.Tests.Shared/Kernel32.Tests.Shared.projitems
@@ -10,7 +10,7 @@
     </Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)Kernel32.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Kernel32Facts.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NTStatusExceptionTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Win32ExceptionTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Kernel32ExtensionsTests.cs" />

--- a/src/Kernel32.Tests.Shared/Kernel32ExtensionsFacts.cs
+++ b/src/Kernel32.Tests.Shared/Kernel32ExtensionsFacts.cs
@@ -4,7 +4,7 @@
 using PInvoke;
 using Xunit;
 
-public partial class Kernel32ExtensionsTests
+public partial class Kernel32ExtensionsFacts
 {
     [Fact]
     public void ThrowOnError_Win32ErrorCode()

--- a/src/Kernel32.Tests.Shared/Kernel32Facts.cs
+++ b/src/Kernel32.Tests.Shared/Kernel32Facts.cs
@@ -2,14 +2,11 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 
 using System;
+using System.IO;
 using PInvoke;
 using Xunit;
-using static PInvoke.SetupApi;
+using static PInvoke.Kernel32;
 
-public class SetupApi
+public partial class Kernel32Facts
 {
-    [Fact(Skip = "No tests yet")]
-    public void NoTests()
-    {
-    }
 }

--- a/src/Kernel32.Tests.Shared/NTStatusExceptionFacts.cs
+++ b/src/Kernel32.Tests.Shared/NTStatusExceptionFacts.cs
@@ -7,7 +7,7 @@ using PInvoke;
 using Xunit;
 using static PInvoke.Kernel32;
 
-public partial class NTStatusExceptionTests
+public partial class NTStatusExceptionFacts
 {
     [Fact]
     public void NTStatusException_NativeErrorCode()

--- a/src/Kernel32.Tests.Shared/Win32ExceptionFacts.cs
+++ b/src/Kernel32.Tests.Shared/Win32ExceptionFacts.cs
@@ -7,7 +7,7 @@ using PInvoke;
 using Xunit;
 using static PInvoke.Kernel32;
 
-public partial class Win32ExceptionTests
+public partial class Win32ExceptionFacts
 {
     [Fact]
     public void Win32Exception_NativeErrorCode()

--- a/src/Kernel32.Tests/Kernel32.Tests.csproj
+++ b/src/Kernel32.Tests/Kernel32.Tests.csproj
@@ -33,7 +33,7 @@
   <ItemGroup>
     <Compile Include="Kernel32Facts.cs" />
     <Compile Include="IgnoreOnOsVersionUnderFactAttribute.cs" />
-    <Compile Include="Kernel32ExtensionsTests.cs" />
+    <Compile Include="Kernel32ExtensionsFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Kernel32.Tests/Kernel32.Tests.csproj
+++ b/src/Kernel32.Tests/Kernel32.Tests.csproj
@@ -31,7 +31,7 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Kernel32.cs" />
+    <Compile Include="Kernel32Facts.cs" />
     <Compile Include="IgnoreOnOsVersionUnderFactAttribute.cs" />
     <Compile Include="Kernel32ExtensionsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Kernel32.Tests/Kernel32ExtensionsFacts.cs
+++ b/src/Kernel32.Tests/Kernel32ExtensionsFacts.cs
@@ -7,7 +7,7 @@ using System.Runtime.Serialization.Formatters.Binary;
 using PInvoke;
 using Xunit;
 
-public partial class Kernel32ExtensionsTests
+public partial class Kernel32ExtensionsFacts
 {
     [Fact]
     public void GetMessage_NTStatus()

--- a/src/Kernel32.Tests/Kernel32Facts.cs
+++ b/src/Kernel32.Tests/Kernel32Facts.cs
@@ -12,7 +12,7 @@ using Xunit;
 using static PInvoke.Constants;
 using static PInvoke.Kernel32;
 
-public partial class Kernel32
+public partial class Kernel32Facts
 {
     private readonly Random random = new Random();
 

--- a/src/MSCorEE.Tests/MSCorEE.Tests.csproj
+++ b/src/MSCorEE.Tests/MSCorEE.Tests.csproj
@@ -33,7 +33,7 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="MSCorEE.cs" />
+    <Compile Include="MSCorEEFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/MSCorEE.Tests/MSCorEEFacts.cs
+++ b/src/MSCorEE.Tests/MSCorEEFacts.cs
@@ -8,7 +8,7 @@ using PInvoke;
 using Xunit;
 using static PInvoke.MSCorEE;
 
-public class MSCorEE
+public class MSCorEEFacts
 {
     [Fact]
     public void StrongNameGetPublicKey_ReadSnkFile()

--- a/src/NCrypt.Tests/NCrypt.Tests.csproj
+++ b/src/NCrypt.Tests/NCrypt.Tests.csproj
@@ -31,7 +31,7 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="NCrypt.cs" />
+    <Compile Include="NCryptFacts.cs" />
     <Compile Include="NCryptExtensionsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SecurityStatusExceptionTests.cs" />

--- a/src/NCrypt.Tests/NCrypt.Tests.csproj
+++ b/src/NCrypt.Tests/NCrypt.Tests.csproj
@@ -32,9 +32,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="NCryptFacts.cs" />
-    <Compile Include="NCryptExtensionsTests.cs" />
+    <Compile Include="NCryptExtensionsFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="SecurityStatusExceptionTests.cs" />
+    <Compile Include="SecurityStatusExceptionFacts.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/NCrypt.Tests/NCryptExtensionsFacts.cs
+++ b/src/NCrypt.Tests/NCryptExtensionsFacts.cs
@@ -6,7 +6,7 @@ using PInvoke;
 using Xunit;
 using static PInvoke.NCrypt;
 
-public class NCryptExtensionsTests
+public class NCryptExtensionsFacts
 {
     [Fact]
     public void GetMessage_SecurityStatus()

--- a/src/NCrypt.Tests/NCryptFacts.cs
+++ b/src/NCrypt.Tests/NCryptFacts.cs
@@ -9,11 +9,11 @@ using Xunit;
 using Xunit.Abstractions;
 using static PInvoke.NCrypt;
 
-public class NCrypt
+public class NCryptFacts
 {
     private readonly ITestOutputHelper logger;
 
-    public NCrypt(ITestOutputHelper logger)
+    public NCryptFacts(ITestOutputHelper logger)
     {
         this.logger = logger;
     }

--- a/src/NCrypt.Tests/SecurityStatusExceptionFacts.cs
+++ b/src/NCrypt.Tests/SecurityStatusExceptionFacts.cs
@@ -10,7 +10,7 @@ using PInvoke;
 using Xunit;
 using static PInvoke.NCrypt;
 
-public class SecurityStatusExceptionTests
+public class SecurityStatusExceptionFacts
 {
     [Fact]
     public void SecurityStatusException_NativeErrorCode()

--- a/src/NTDll.Tests/NTDll.Tests.csproj
+++ b/src/NTDll.Tests/NTDll.Tests.csproj
@@ -31,7 +31,7 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="NTDll.cs" />
+    <Compile Include="NTDllFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NTDll.Tests/NTDllFacts.cs
+++ b/src/NTDll.Tests/NTDllFacts.cs
@@ -6,7 +6,7 @@ using PInvoke;
 using Xunit;
 using static PInvoke.NTDll;
 
-public class NTDll
+public class NTDllFacts
 {
     [Fact]
     public void RtlNtStatusToDosError_Test()

--- a/src/Psapi.Tests/Psapi.Tests.csproj
+++ b/src/Psapi.Tests/Psapi.Tests.csproj
@@ -31,7 +31,7 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Psapi.cs" />
+    <Compile Include="PsapiFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Psapi.Tests/PsapiFacts.cs
+++ b/src/Psapi.Tests/PsapiFacts.cs
@@ -2,15 +2,18 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 
 using System;
-using PInvoke;
 using Xunit;
-using static PInvoke.AdvApi32;
+using static PInvoke.Kernel32;
+using static PInvoke.Psapi;
 
-public class AdvApi32
+public class PsapiFacts
 {
     [Fact]
-    public void LsaNtStatusToWinError_UsesTable()
+    public void EmptyWorkingSet_Run()
     {
-        Assert.Equal(Win32ErrorCode.ERROR_NOACCESS, LsaNtStatusToWinError(NTSTATUS.Code.STATUS_ACCESS_VIOLATION));
+        using (var pid = GetCurrentProcess())
+        {
+            Assert.True(EmptyWorkingSet(pid));
+        }
     }
 }

--- a/src/SetupApi.Tests/SetupApi.Tests.csproj
+++ b/src/SetupApi.Tests/SetupApi.Tests.csproj
@@ -12,7 +12,8 @@
     <ProjectGuid>{05468C6E-B6EB-45E9-9F3D-66207D9EFD41}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace></RootNamespace>
+    <RootNamespace>
+    </RootNamespace>
     <AssemblyName>PInvoke.SetupApi.Tests</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
@@ -30,7 +31,7 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="SetupApi.cs" />
+    <Compile Include="SetupApiFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SetupApi.Tests/SetupApiFacts.cs
+++ b/src/SetupApi.Tests/SetupApiFacts.cs
@@ -4,14 +4,12 @@
 using System;
 using PInvoke;
 using Xunit;
-using static PInvoke.DbgHelp;
+using static PInvoke.SetupApi;
 
-public class DbgHelp
+public class SetupApiFacts
 {
-    [Fact]
-    public void IntPtrGeneration()
+    [Fact(Skip = "No tests yet")]
+    public void NoTests()
     {
-        LOADED_IMAGE image = default(LOADED_IMAGE);
-        image.FileHeader_IntPtr = IntPtr.Zero;
     }
 }

--- a/src/Windows.Core.Tests/HResultFacts.cs
+++ b/src/Windows.Core.Tests/HResultFacts.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 using PInvoke;
 using Xunit;
 
-public class HResultTests
+public class HResultFacts
 {
     [Fact]
     public void MarshaledSize()

--- a/src/Windows.Core.Tests/NTStatusFacts.cs
+++ b/src/Windows.Core.Tests/NTStatusFacts.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 using PInvoke;
 using Xunit;
 
-public class NTStatusTests
+public class NTStatusFacts
 {
     [Fact]
     public void MarshaledSize()

--- a/src/Windows.Core.Tests/NullableGuidFacts.cs
+++ b/src/Windows.Core.Tests/NullableGuidFacts.cs
@@ -5,7 +5,7 @@ using System;
 using PInvoke;
 using Xunit;
 
-public class NullableGuidTests
+public class NullableGuidFacts
 {
     private readonly Guid testGuid = Guid.NewGuid();
 

--- a/src/Windows.Core.Tests/NullableUInt32Facts.cs
+++ b/src/Windows.Core.Tests/NullableUInt32Facts.cs
@@ -5,7 +5,7 @@ using System;
 using PInvoke;
 using Xunit;
 
-public class NullableUInt32Tests
+public class NullableUInt32Facts
 {
     [Fact]
     public void ConstructorSetValue()

--- a/src/Windows.Core.Tests/PInvokeExtensionsFacts.cs
+++ b/src/Windows.Core.Tests/PInvokeExtensionsFacts.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 using PInvoke;
 using Xunit;
 
-public class PInvokeExtensionsTests
+public class PInvokeExtensionsFacts
 {
     [Fact]
     public void ToHResult_FromNTStatus()

--- a/src/Windows.Core.Tests/Windows.Core.Tests.csproj
+++ b/src/Windows.Core.Tests/Windows.Core.Tests.csproj
@@ -27,11 +27,11 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="NTStatusTests.cs" />
-    <Compile Include="HResultTests.cs" />
-    <Compile Include="NullableGuidTests.cs" />
-    <Compile Include="NullableUInt32Tests.cs" />
-    <Compile Include="PInvokeExtensionsTests.cs" />
+    <Compile Include="NTStatusFacts.cs" />
+    <Compile Include="HResultFacts.cs" />
+    <Compile Include="NullableGuidFacts.cs" />
+    <Compile Include="NullableUInt32Facts.cs" />
+    <Compile Include="PInvokeExtensionsFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/templates/LIBNAME.Tests/LIBNAME.Tests.csproj
+++ b/templates/LIBNAME.Tests/LIBNAME.Tests.csproj
@@ -31,7 +31,7 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="LIBNAME.cs" />
+    <Compile Include="LIBNAMEFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/templates/LIBNAME.Tests/LIBNAMEFacts.cs
+++ b/templates/LIBNAME.Tests/LIBNAMEFacts.cs
@@ -2,18 +2,14 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 
 using System;
+using PInvoke;
 using Xunit;
-using static PInvoke.Kernel32;
-using static PInvoke.Psapi;
+using static PInvoke.LIBNAME;
 
-public class Psapi
+public class LIBNAMEFacts
 {
-    [Fact]
-    public void EmptyWorkingSet_Run()
+    [Fact(Skip = "No tests yet")]
+    public void NoTests()
     {
-        using (var pid = GetCurrentProcess())
-        {
-            Assert.True(EmptyWorkingSet(pid));
-        }
     }
 }


### PR DESCRIPTION
This adds the suffix to the LIBNAME.cs test classes and file names.
It also replaces the `Tests` suffix that we were using in other test classes with the `Facts` suffix.

Fixes #163
