### PR TITLE
Automatically push release tags to nuget.org

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,8 @@ configuration: Release
 environment:
   VisualStudioVersion: 14.0
   GeneratePInvokesTxt: true
+  NuGetApiKey:
+    secure: Ql19CstT9GvFNeSIAjXvgHXZg+/pNaYJ2jVkzde4LT2vwSyjiQgQ+M332wVYtu+r
 cache:
 - '%USERPROFILE%\.nuget\packages'
 before_build:
@@ -19,6 +21,14 @@ artifacts:
   name: PInvoke method coverage
 - path: bin\**\*.exports.txt
   name: Exported methods
+on_success:
+- ps: >-
+    if ($env:NuGetApiKey -and $env:APPVEYOR_REPO_TAG_NAME -match "^v\d\.\d") {
+        Write-Output "Publishing release packages to nuget.org due to pushed tag $env:APPVEYOR_REPO_TAG_NAME"
+        Get-ChildItem bin\Release\Packages\*.nupkg -exclude *.symbols.nupkg |% {
+            nuget push $_ -ApiKey $env:NuGetApiKey
+        }
+    }
 notifications:
 - provider: Webhook
   url: https://webhooks.gitter.im/e/c4d61fc5002e9a62a22f

--- a/src/version.json
+++ b/src/version.json
@@ -1,4 +1,8 @@
 {
+  "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
   "version": "0.1.0-beta",
-  "publicReleaseRefSpec": [ "^refs/heads/master$" ]
+  "publicReleaseRefSpec": [
+    "^refs/heads/master$", // we release out of master
+    "^refs/tags/v\\d\\.\\d" // we also release tags starting with vN.N
+  ]
 }


### PR DESCRIPTION
With this change, pushing a tag that matches the regex `^v\d\.\d` will result in AppVeyor publishing the packages to nuget.org if the build of that tag is successful.

Anyone with push permissions to the repo can now initiate a release to nuget.org

We should be careful to only push such tags after confirming what the actual nuget package version built would be. For example, build the commit locally and observe that the built packages have version x.y.z so that the tag you create is also vX.Y.Z.
