### PR TITLE
Audio switcher2

### DIFF
--- a/src/CodeGeneration/OfferFriendlyOverloadsGenerator.cs
+++ b/src/CodeGeneration/OfferFriendlyOverloadsGenerator.cs
@@ -107,7 +107,8 @@ namespace PInvoke
                     .WithAttributeLists(SyntaxFactory.List<AttributeListSyntax>())
                     .WithLeadingTrivia(method.GetLeadingTrivia().Where(t => !t.IsDirective))
                     .WithTrailingTrivia(method.GetTrailingTrivia().Where(t => !t.IsDirective))
-                    .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.None));
+                    .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.None))
+                    .WithExpressionBody(null);
 
                 var flags = GeneratorFlags.NativePointerToIntPtr;
                 var intPtrOverload = transformedMethodBase

--- a/src/Kernel32.Desktop/Kernel32+ResourceTypes.cs
+++ b/src/Kernel32.Desktop/Kernel32+ResourceTypes.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) to owners found in https://github.com/AArnott/pinvoke/blob/master/COPYRIGHT.md. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+
+namespace PInvoke
+{
+    /// <content>
+    /// Contains all the "RT_" constants that represent resource types.
+    /// </content>
+    public partial class Kernel32
+    {
+        /// <summary>Hardware-dependent cursor resource.</summary>
+        public static readonly unsafe char* RT_CURSOR = MAKEINTRESOURCE(1);
+
+        /// <summary>Bitmap resource.</summary>
+        public static readonly unsafe char* RT_BITMAP = MAKEINTRESOURCE(2);
+
+        /// <summary>Hardware-dependent icon resource.</summary>
+        public static readonly unsafe char* RT_ICON = MAKEINTRESOURCE(3);
+
+        /// <summary>Menu resource.</summary>
+        public static readonly unsafe char* RT_MENU = MAKEINTRESOURCE(4);
+
+        /// <summary>Dialog box.</summary>
+        public static readonly unsafe char* RT_DIALOG = MAKEINTRESOURCE(5);
+
+        /// <summary>String-table entry.</summary>
+        public static readonly unsafe char* RT_STRING = MAKEINTRESOURCE(6);
+
+        /// <summary>Font directory resource.</summary>
+        public static readonly unsafe char* RT_FONTDIR = MAKEINTRESOURCE(7);
+
+        /// <summary>Font resource.</summary>
+        public static readonly unsafe char* RT_FONT = MAKEINTRESOURCE(8);
+
+        /// <summary>Accelerator table.</summary>
+        public static readonly unsafe char* RT_ACCELERATOR = MAKEINTRESOURCE(9);
+
+        /// <summary>Application-defined resource (raw data).</summary>
+        public static readonly unsafe char* RT_RCDATA = MAKEINTRESOURCE(10);
+
+        /// <summary>Message-table entry.</summary>
+        public static readonly unsafe char* RT_MESSAGETABLE = MAKEINTRESOURCE(11);
+
+        /// <summary>Hardware-independent cursor resource.</summary>
+        public static readonly unsafe char* RT_GROUP_CURSOR = MAKEINTRESOURCE(12);
+
+        /// <summary>Hardware-independent icon resource.</summary>
+        public static readonly unsafe char* RT_GROUP_ICON = MAKEINTRESOURCE(14);
+
+        /// <summary>Version resource</summary>
+        public static readonly unsafe char* RT_VERSION = MAKEINTRESOURCE(16);
+    }
+}

--- a/src/Kernel32.Desktop/Kernel32+SafeLibraryHandle.cs
+++ b/src/Kernel32.Desktop/Kernel32+SafeLibraryHandle.cs
@@ -16,7 +16,7 @@ namespace PInvoke
         /// </summary>
         public class SafeLibraryHandle : SafeHandle
         {
-            public static readonly SafeLibraryHandle Null = new SafeLibraryHandle(new IntPtr(0), false);
+            public static readonly SafeLibraryHandle Null = new SafeLibraryHandle(IntPtr.Zero, false);
 
             /// <summary>
             /// Initializes a new instance of the <see cref="SafeLibraryHandle"/> class.

--- a/src/Kernel32.Desktop/Kernel32+SafeLibraryHandle.cs
+++ b/src/Kernel32.Desktop/Kernel32+SafeLibraryHandle.cs
@@ -16,6 +16,8 @@ namespace PInvoke
         /// </summary>
         public class SafeLibraryHandle : SafeHandle
         {
+            public static readonly SafeLibraryHandle Null = new SafeLibraryHandle(new IntPtr(0), false);
+
             /// <summary>
             /// Initializes a new instance of the <see cref="SafeLibraryHandle"/> class.
             /// </summary>

--- a/src/Kernel32.Desktop/Kernel32.Desktop.csproj
+++ b/src/Kernel32.Desktop/Kernel32.Desktop.csproj
@@ -48,6 +48,7 @@
     <Compile Include="Kernel32+PROCESS_INFORMATION.cs" />
     <Compile Include="Kernel32+PROC_THREAD_ATTRIBUTE_LIST.cs" />
     <Compile Include="Kernel32+QueryFullProcessImageNameFlags.cs" />
+    <Compile Include="Kernel32+ResourceTypes.cs" />
     <Compile Include="Kernel32+SafeLibraryHandle.cs" />
     <Compile Include="Kernel32+SECURITY_IMPERSONATION_LEVEL.cs" />
     <Compile Include="Kernel32+SECURITY_ATTRIBUTES.cs" />

--- a/src/Kernel32.Desktop/Kernel32.cs
+++ b/src/Kernel32.Desktop/Kernel32.cs
@@ -36,48 +36,6 @@ namespace PInvoke
         /// </summary>
         public const int NMPWAIT_NOWAIT = 0x00000001;
 
-        /// <summary>Hardware-dependent cursor resource.</summary>
-        public static readonly unsafe char* RT_CURSOR = MAKEINTRESOURCE(1);
-
-        /// <summary>Bitmap resource.</summary>
-        public static readonly unsafe char* RT_BITMAP = MAKEINTRESOURCE(2);
-
-        /// <summary>Hardware-dependent icon resource.</summary>
-        public static readonly unsafe char* RT_ICON = MAKEINTRESOURCE(3);
-
-        /// <summary>Menu resource.</summary>
-        public static readonly unsafe char* RT_MENU = MAKEINTRESOURCE(4);
-
-        /// <summary>Dialog box.</summary>
-        public static readonly unsafe char* RT_DIALOG = MAKEINTRESOURCE(5);
-
-        /// <summary>String-table entry.</summary>
-        public static readonly unsafe char* RT_STRING = MAKEINTRESOURCE(6);
-
-        /// <summary>Font directory resource.</summary>
-        public static readonly unsafe char* RT_FONTDIR = MAKEINTRESOURCE(7);
-
-        /// <summary>Font resource.</summary>
-        public static readonly unsafe char* RT_FONT = MAKEINTRESOURCE(8);
-
-        /// <summary>Accelerator table.</summary>
-        public static readonly unsafe char* RT_ACCELERATOR = MAKEINTRESOURCE(9);
-
-        /// <summary>Application-defined resource (raw data).</summary>
-        public static readonly unsafe char* RT_RCDATA = MAKEINTRESOURCE(10);
-
-        /// <summary>Message-table entry.</summary>
-        public static readonly unsafe char* RT_MESSAGETABLE = MAKEINTRESOURCE(11);
-
-        /// <summary>Hardware-independent cursor resource.</summary>
-        public static readonly unsafe char* RT_GROUP_CURSOR = MAKEINTRESOURCE(12);
-
-        /// <summary>Hardware-independent icon resource.</summary>
-        public static readonly unsafe char* RT_GROUP_ICON = MAKEINTRESOURCE(14);
-
-        /// <summary>Version resource</summary>
-        public static readonly unsafe char* RT_VERSION = MAKEINTRESOURCE(16);
-
         /// <summary>
         ///     Allows a resource editing tool to associate a string with an .rc file. Typically, the string is the name of the
         ///     header file that provides symbolic names. The resource compiler parses the string but otherwise ignores the value.

--- a/src/Kernel32.Desktop/Kernel32.cs
+++ b/src/Kernel32.Desktop/Kernel32.cs
@@ -1527,7 +1527,7 @@ namespace PInvoke
         /// </returns>
         [DllImport(nameof(Kernel32), SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern unsafe bool EnumResourceNames(SafeLibraryHandle hModule, IntPtr lpszType, EnumResNameProc lpEnumFunc, IntPtr lParam);
+        public static extern bool EnumResourceNames(SafeLibraryHandle hModule, IntPtr lpszType, EnumResNameProc lpEnumFunc, IntPtr lParam);
 
         /// <summary>Determines whether a value is an integer identifier for a resource.</summary>
         /// <param name="p">The pointer to be tested whether it contains an integer resource identifier.</param>
@@ -1608,6 +1608,33 @@ namespace PInvoke
 
         /// <summary>HTML resource.</summary>
         public static readonly IntPtr RT_HTML = MAKEINTRESOURCE(23);
+
+        /// <summary>
+        ///     Determines the location of a resource with the specified type and name in the specified module.
+        ///     <para>To specify a language, use the FindResourceEx function.</para>
+        /// </summary>
+        /// <param name="hModule">
+        ///     A handle to the module whose portable executable file or an accompanying MUI file contains the
+        ///     resource. If this parameter is NULL, the function searches the module used to create the current process.
+        /// </param>
+        /// <param name="lpName">
+        ///     The name of the resource. Alternately, rather than a pointer, this parameter can be
+        ///     <see cref="MAKEINTRESOURCE" />, where wInteger is the integer identifier of the resource.
+        /// </param>
+        /// <param name="lpType">
+        ///     The resource type. Alternately, rather than a pointer, this parameter can be
+        ///     <see cref="MAKEINTRESOURCE" />, where wInteger is the integer identifier of the given resource type.
+        /// </param>
+        /// <returns>
+        ///     If the function succeeds, the return value is a handle to the specified resource's information block. To obtain a
+        ///     handle to the resource, pass this handle to the LoadResource function.
+        ///     <para>
+        ///         If the function fails, the return value is NULL. To get extended error information, call
+        ///         <see cref="GetLastError" />.
+        ///     </para>
+        /// </returns>
+        [DllImport(nameof(Kernel32), SetLastError = true)]
+        public static extern IntPtr FindResource(SafeLibraryHandle hModule, IntPtr lpName, IntPtr lpType);
 
         /// <summary>
         ///     Frees the loaded dynamic-link library (DLL) module and, if necessary, decrements its reference count. When the

--- a/src/Kernel32.Desktop/Kernel32.cs
+++ b/src/Kernel32.Desktop/Kernel32.cs
@@ -36,6 +36,103 @@ namespace PInvoke
         /// </summary>
         public const int NMPWAIT_NOWAIT = 0x00000001;
 
+        /// <summary>Hardware-dependent cursor resource.</summary>
+        public static readonly unsafe char* RT_CURSOR = MAKEINTRESOURCE(1);
+
+        /// <summary>Bitmap resource.</summary>
+        public static readonly unsafe char* RT_BITMAP = MAKEINTRESOURCE(2);
+
+        /// <summary>Hardware-dependent icon resource.</summary>
+        public static readonly unsafe char* RT_ICON = MAKEINTRESOURCE(3);
+
+        /// <summary>Menu resource.</summary>
+        public static readonly unsafe char* RT_MENU = MAKEINTRESOURCE(4);
+
+        /// <summary>Dialog box.</summary>
+        public static readonly unsafe char* RT_DIALOG = MAKEINTRESOURCE(5);
+
+        /// <summary>String-table entry.</summary>
+        public static readonly unsafe char* RT_STRING = MAKEINTRESOURCE(6);
+
+        /// <summary>Font directory resource.</summary>
+        public static readonly unsafe char* RT_FONTDIR = MAKEINTRESOURCE(7);
+
+        /// <summary>Font resource.</summary>
+        public static readonly unsafe char* RT_FONT = MAKEINTRESOURCE(8);
+
+        /// <summary>Accelerator table.</summary>
+        public static readonly unsafe char* RT_ACCELERATOR = MAKEINTRESOURCE(9);
+
+        /// <summary>Application-defined resource (raw data).</summary>
+        public static readonly unsafe char* RT_RCDATA = MAKEINTRESOURCE(10);
+
+        /// <summary>Message-table entry.</summary>
+        public static readonly unsafe char* RT_MESSAGETABLE = MAKEINTRESOURCE(11);
+
+        /// <summary>Hardware-independent cursor resource.</summary>
+        public static readonly unsafe char* RT_GROUP_CURSOR = MAKEINTRESOURCE(12);
+
+        /// <summary>Hardware-independent icon resource.</summary>
+        public static readonly unsafe char* RT_GROUP_ICON = MAKEINTRESOURCE(14);
+
+        /// <summary>Version resource</summary>
+        public static readonly unsafe char* RT_VERSION = MAKEINTRESOURCE(16);
+
+        /// <summary>
+        ///     Allows a resource editing tool to associate a string with an .rc file. Typically, the string is the name of the
+        ///     header file that provides symbolic names. The resource compiler parses the string but otherwise ignores the value.
+        ///     For example,
+        ///     <para>
+        ///         <code>1 DLGINCLUDE "MyFile.h"</code>
+        ///     </para>
+        /// </summary>
+        public static readonly unsafe char* RT_DLGINCLUDE = MAKEINTRESOURCE(17);
+
+        /// <summary>Plug and Play resource.</summary>
+        public static readonly unsafe char* RT_PLUGPLAY = MAKEINTRESOURCE(19);
+
+        /// <summary>VXD.</summary>
+        public static readonly unsafe char* RT_VXD = MAKEINTRESOURCE(20);
+
+        /// <summary>Animated cursor.</summary>
+        public static readonly unsafe char* RT_ANICURSOR = MAKEINTRESOURCE(21);
+
+        /// <summary>Animated icon.</summary>
+        public static readonly unsafe char* RT_ANIICON = MAKEINTRESOURCE(22);
+
+        /// <summary>HTML resource.</summary>
+        public static readonly unsafe char* RT_HTML = MAKEINTRESOURCE(23);
+
+        /// <summary>
+        ///     An application-defined callback function used with the EnumResourceNames and EnumResourceNamesEx functions. It
+        ///     receives the type and name of a resource. The ENUMRESNAMEPROC type defines a pointer to this callback function.
+        ///     EnumResNameProc is a placeholder for the application-defined function name.
+        /// </summary>
+        /// <param name="hModule">
+        ///     A handle to the module whose executable file contains the resources that are being enumerated.
+        ///     <para>
+        ///         If this parameter is <see langword="null" />, the function enumerates the resource names in the
+        ///         module used to create the current process.
+        ///     </para>
+        /// </param>
+        /// <param name="lpszType">
+        ///     The type of resource for which the name is being enumerated. Alternately, rather than a pointer,
+        ///     this parameter can be <see cref="MAKEINTRESOURCE" />(ID), where ID is an integer value representing a predefined
+        ///     resource type.
+        /// </param>
+        /// <param name="lpszName">
+        ///     The name of a resource of the type being enumerated. Alternately, rather than a pointer, this
+        ///     parameter can be <see cref="MAKEINTRESOURCE" />(ID), where ID is the integer identifier of the resource. For more
+        ///     information, see the Remarks section below.
+        /// </param>
+        /// <param name="lParam">
+        ///     An application-defined parameter passed to the <see cref="EnumResourceNames" /> or
+        ///     EnumResourceNamesEx function. This parameter can be used in error checking.
+        /// </param>
+        /// <returns>Returns TRUE to continue enumeration or FALSE to stop enumeration.</returns>
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public unsafe delegate bool EnumResNameProc(IntPtr hModule, char* lpszType, char* lpszName, IntPtr lParam);
+
         /// <summary>
         /// Generates simple tones on the speaker. The function is synchronous; it performs an alertable wait and does not return control to its caller until the sound finishes.
         /// </summary>
@@ -1467,36 +1564,6 @@ namespace PInvoke
         public static extern unsafe void* LocalFree(void* hMem);
 
         /// <summary>
-        ///     An application-defined callback function used with the EnumResourceNames and EnumResourceNamesEx functions. It
-        ///     receives the type and name of a resource. The ENUMRESNAMEPROC type defines a pointer to this callback function.
-        ///     EnumResNameProc is a placeholder for the application-defined function name.
-        /// </summary>
-        /// <param name="hModule">
-        ///     A handle to the module whose executable file contains the resources that are being enumerated.
-        ///     <para>
-        ///         If this parameter is <see cref="SafeLibraryHandle.Null" />, the function enumerates the resource names in the
-        ///         module used to create the current process.
-        ///     </para>
-        /// </param>
-        /// <param name="lpszType">
-        ///     The type of resource for which the name is being enumerated. Alternately, rather than a pointer,
-        ///     this parameter can be <see cref="MAKEINTRESOURCE" />(ID), where ID is an integer value representing a predefined
-        ///     resource type.
-        /// </param>
-        /// <param name="lpszName">
-        ///     The name of a resource of the type being enumerated. Alternately, rather than a pointer, this
-        ///     parameter can be <see cref="MAKEINTRESOURCE" />(ID), where ID is the integer identifier of the resource. For more
-        ///     information, see the Remarks section below.
-        /// </param>
-        /// <param name="lParam">
-        ///     An application-defined parameter passed to the <see cref="EnumResourceNames" /> or
-        ///     EnumResourceNamesEx function. This parameter can be used in error checking.
-        /// </param>
-        /// <returns>Returns TRUE to continue enumeration or FALSE to stop enumeration.</returns>
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        public delegate bool EnumResNameProc(IntPtr hModule, IntPtr lpszType, IntPtr lpszName, IntPtr lParam);
-
-        /// <summary>
         ///     Enumerates resources of a specified type within a binary module. For Windows Vista and later, this is
         ///     typically a language-neutral Portable Executable (LN file), and the enumeration will also include resources from
         ///     the corresponding language-specific resource files (.mui files) that contain localizable language resources. It is
@@ -1527,12 +1594,12 @@ namespace PInvoke
         /// </returns>
         [DllImport(nameof(Kernel32), SetLastError = true, CharSet = CharSet.Unicode)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool EnumResourceNames(SafeLibraryHandle hModule, IntPtr lpszType, EnumResNameProc lpEnumFunc, IntPtr lParam);
+        public static extern unsafe bool EnumResourceNames(SafeLibraryHandle hModule, char* lpszType, EnumResNameProc lpEnumFunc, IntPtr lParam);
 
         /// <summary>Determines whether a value is an integer identifier for a resource.</summary>
         /// <param name="p">The pointer to be tested whether it contains an integer resource identifier.</param>
         /// <returns>If the value is a resource identifier, the return value is TRUE. Otherwise, the return value is FALSE.</returns>
-        public static bool IS_INTRESOURCE(IntPtr p) => p.ToInt64() >> 16 == 0;
+        public static unsafe bool IS_INTRESOURCE(char* p) => (long)p >> 16 == 0;
 
         /// <summary>
         ///     Converts an integer value to a resource type compatible with the resource-management functions. This macro is
@@ -1540,74 +1607,7 @@ namespace PInvoke
         /// </summary>
         /// <param name="wInteger">The integer value to be converted.</param>
         /// <returns>The return value is the specified value in the low-order word and zero in the high-order word.</returns>
-        public static IntPtr MAKEINTRESOURCE(int wInteger) => new IntPtr(wInteger);
-
-        /// <summary>Hardware-dependent cursor resource.</summary>
-        public static readonly IntPtr RT_CURSOR = MAKEINTRESOURCE(1);
-
-        /// <summary>Bitmap resource.</summary>
-        public static readonly IntPtr RT_BITMAP = MAKEINTRESOURCE(2);
-
-        /// <summary>Hardware-dependent icon resource.</summary>
-        public static readonly IntPtr RT_ICON = MAKEINTRESOURCE(3);
-
-        /// <summary>Menu resource.</summary>
-        public static readonly IntPtr RT_MENU = MAKEINTRESOURCE(4);
-
-        /// <summary>Dialog box.</summary>
-        public static readonly IntPtr RT_DIALOG = MAKEINTRESOURCE(5);
-
-        /// <summary>String-table entry.</summary>
-        public static readonly IntPtr RT_STRING = MAKEINTRESOURCE(6);
-
-        /// <summary>Font directory resource.</summary>
-        public static readonly IntPtr RT_FONTDIR = MAKEINTRESOURCE(7);
-
-        /// <summary>Font resource.</summary>
-        public static readonly IntPtr RT_FONT = MAKEINTRESOURCE(8);
-
-        /// <summary>Accelerator table.</summary>
-        public static readonly IntPtr RT_ACCELERATOR = MAKEINTRESOURCE(9);
-
-        /// <summary>Application-defined resource (raw data).</summary>
-        public static readonly IntPtr RT_RCDATA = MAKEINTRESOURCE(10);
-
-        /// <summary>Message-table entry.</summary>
-        public static readonly IntPtr RT_MESSAGETABLE = MAKEINTRESOURCE(11);
-
-        /// <summary>Hardware-independent cursor resource.</summary>
-        public static readonly IntPtr RT_GROUP_CURSOR = MAKEINTRESOURCE(12);
-
-        /// <summary>Hardware-independent icon resource.</summary>
-        public static readonly IntPtr RT_GROUP_ICON = MAKEINTRESOURCE(14);
-
-        /// <summary>Version resource</summary>
-        public static readonly IntPtr RT_VERSION = MAKEINTRESOURCE(16);
-
-        /// <summary>
-        ///     Allows a resource editing tool to associate a string with an .rc file. Typically, the string is the name of the
-        ///     header file that provides symbolic names. The resource compiler parses the string but otherwise ignores the value.
-        ///     For example,
-        ///     <para>
-        ///         <code>1 DLGINCLUDE "MyFile.h"</code>
-        ///     </para>
-        /// </summary>
-        public static readonly IntPtr RT_DLGINCLUDE = MAKEINTRESOURCE(17);
-
-        /// <summary>Plug and Play resource.</summary>
-        public static readonly IntPtr RT_PLUGPLAY = MAKEINTRESOURCE(19);
-
-        /// <summary>VXD.</summary>
-        public static readonly IntPtr RT_VXD = MAKEINTRESOURCE(20);
-
-        /// <summary>Animated cursor.</summary>
-        public static readonly IntPtr RT_ANICURSOR = MAKEINTRESOURCE(21);
-
-        /// <summary>Animated icon.</summary>
-        public static readonly IntPtr RT_ANIICON = MAKEINTRESOURCE(22);
-
-        /// <summary>HTML resource.</summary>
-        public static readonly IntPtr RT_HTML = MAKEINTRESOURCE(23);
+        public static unsafe char* MAKEINTRESOURCE(int wInteger) => (char*)wInteger;
 
         /// <summary>
         ///     Determines the location of a resource with the specified type and name in the specified module.
@@ -1634,7 +1634,7 @@ namespace PInvoke
         ///     </para>
         /// </returns>
         [DllImport(nameof(Kernel32), SetLastError = true, CharSet = CharSet.Unicode)]
-        public static extern IntPtr FindResource(SafeLibraryHandle hModule, IntPtr lpName, IntPtr lpType);
+        public static extern unsafe IntPtr FindResource(SafeLibraryHandle hModule, char* lpName, char* lpType);
 
         /// <summary>Retrieves a handle that can be used to obtain a pointer to the first byte of the specified resource in memory.</summary>
         /// <param name="hModule">

--- a/src/Kernel32.Desktop/Kernel32.cs
+++ b/src/Kernel32.Desktop/Kernel32.cs
@@ -1615,7 +1615,8 @@ namespace PInvoke
         /// </summary>
         /// <param name="hModule">
         ///     A handle to the module whose portable executable file or an accompanying MUI file contains the
-        ///     resource. If this parameter is NULL, the function searches the module used to create the current process.
+        ///     resource. If this parameter is <see cref="SafeLibraryHandle.Null" />, the function searches the module used to
+        ///     create the current process.
         /// </param>
         /// <param name="lpName">
         ///     The name of the resource. Alternately, rather than a pointer, this parameter can be
@@ -1644,7 +1645,7 @@ namespace PInvoke
         /// </param>
         /// <param name="hResInfo">
         ///     A handle to the resource to be loaded. This handle is returned by the
-        ///     <see cref="FindResource" /> or FindResourceEx function.
+        ///     <see cref="FindResource(SafeLibraryHandle, char*, char*)" /> or FindResourceEx function.
         /// </param>
         /// <returns>
         ///     If the function succeeds, the return value is a handle to the data associated with the resource.

--- a/src/Kernel32.Desktop/Kernel32.cs
+++ b/src/Kernel32.Desktop/Kernel32.cs
@@ -1666,7 +1666,7 @@ namespace PInvoke
         ///     otherwise, it is NULL.
         /// </returns>
         [DllImport(nameof(Kernel32), SetLastError = true)]
-        public static extern IntPtr LockResource(IntPtr hResData);
+        public static unsafe extern void* LockResource(IntPtr hResData);
 
         /// <summary>Retrieves the size, in bytes, of the specified resource.</summary>
         /// <param name="hModule">A handle to the module whose executable file contains the resource.</param>

--- a/src/Kernel32.Desktop/Kernel32.cs
+++ b/src/Kernel32.Desktop/Kernel32.cs
@@ -1525,7 +1525,7 @@ namespace PInvoke
         ///     type specified, or if the function fails for another reason. To get extended error information, call
         ///     <see cref="GetLastError" />.
         /// </returns>
-        [DllImport(nameof(Kernel32), SetLastError = true)]
+        [DllImport(nameof(Kernel32), SetLastError = true, CharSet = CharSet.Unicode)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool EnumResourceNames(SafeLibraryHandle hModule, IntPtr lpszType, EnumResNameProc lpEnumFunc, IntPtr lParam);
 
@@ -1627,14 +1627,59 @@ namespace PInvoke
         /// </param>
         /// <returns>
         ///     If the function succeeds, the return value is a handle to the specified resource's information block. To obtain a
-        ///     handle to the resource, pass this handle to the LoadResource function.
+        ///     handle to the resource, pass this handle to the <see cref="LoadResource"/> function.
+        ///     <para>
+        ///         If the function fails, the return value is NULL. To get extended error information, call
+        ///         <see cref="GetLastError" />.
+        ///     </para>
+        /// </returns>
+        [DllImport(nameof(Kernel32), SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern IntPtr FindResource(SafeLibraryHandle hModule, IntPtr lpName, IntPtr lpType);
+
+        /// <summary>Retrieves a handle that can be used to obtain a pointer to the first byte of the specified resource in memory.</summary>
+        /// <param name="hModule">
+        ///     A handle to the module whose executable file contains the resource. If hModule is
+        ///     <see cref="SafeLibraryHandle.Null" />, the system loads the resource from the module that was used to create the
+        ///     current process.
+        /// </param>
+        /// <param name="hResInfo">
+        ///     A handle to the resource to be loaded. This handle is returned by the
+        ///     <see cref="FindResource" /> or FindResourceEx function.
+        /// </param>
+        /// <returns>
+        ///     If the function succeeds, the return value is a handle to the data associated with the resource.
         ///     <para>
         ///         If the function fails, the return value is NULL. To get extended error information, call
         ///         <see cref="GetLastError" />.
         ///     </para>
         /// </returns>
         [DllImport(nameof(Kernel32), SetLastError = true)]
-        public static extern IntPtr FindResource(SafeLibraryHandle hModule, IntPtr lpName, IntPtr lpType);
+        public static extern IntPtr LoadResource(SafeLibraryHandle hModule, IntPtr hResInfo);
+
+        /// <summary>Retrieves a pointer to the specified resource in memory.</summary>
+        /// <param name="hResData">
+        ///     A handle to the resource to be accessed. The <see cref="LoadResource" /> function returns this
+        ///     handle.
+        /// </param>
+        /// <returns>
+        ///     If the loaded resource is available, the return value is a pointer to the first byte of the resource;
+        ///     otherwise, it is NULL.
+        /// </returns>
+        [DllImport(nameof(Kernel32), SetLastError = true)]
+        public static extern IntPtr LockResource(IntPtr hResData);
+
+        /// <summary>Retrieves the size, in bytes, of the specified resource.</summary>
+        /// <param name="hModule">A handle to the module whose executable file contains the resource.</param>
+        /// <param name="hResInfo">
+        ///     handle to the resource. This handle must be created by using the <see cref="FindResource" /> or
+        ///     FindResourceEx function.
+        /// </param>
+        /// <returns>
+        ///     If the function succeeds, the return value is the number of bytes in the resource.
+        ///     <para>If the function fails, the return value is zero. To get extended error information, call GetLastError.</para>
+        /// </returns>
+        [DllImport(nameof(Kernel32), SetLastError = true)]
+        public static extern int SizeofResource(SafeLibraryHandle hModule, IntPtr hResInfo);
 
         /// <summary>
         ///     Frees the loaded dynamic-link library (DLL) module and, if necessary, decrements its reference count. When the

--- a/src/Kernel32.Desktop/Kernel32.cs
+++ b/src/Kernel32.Desktop/Kernel32.cs
@@ -126,7 +126,7 @@ namespace PInvoke
         ///     information, see the Remarks section below.
         /// </param>
         /// <param name="lParam">
-        ///     An application-defined parameter passed to the <see cref="EnumResourceNames" /> or
+        ///     An application-defined parameter passed to the <see cref="EnumResourceNames(SafeLibraryHandle,char*,EnumResNameProc,IntPtr)" /> or
         ///     EnumResourceNamesEx function. This parameter can be used in error checking.
         /// </param>
         /// <returns>Returns TRUE to continue enumeration or FALSE to stop enumeration.</returns>
@@ -1672,7 +1672,7 @@ namespace PInvoke
         /// <summary>Retrieves the size, in bytes, of the specified resource.</summary>
         /// <param name="hModule">A handle to the module whose executable file contains the resource.</param>
         /// <param name="hResInfo">
-        ///     handle to the resource. This handle must be created by using the <see cref="FindResource" /> or
+        ///     handle to the resource. This handle must be created by using the <see cref="FindResource(SafeLibraryHandle,char*,char*)" /> or
         ///     FindResourceEx function.
         /// </param>
         /// <returns>

--- a/src/Kernel32.Desktop/Kernel32.cs
+++ b/src/Kernel32.Desktop/Kernel32.cs
@@ -1467,6 +1467,149 @@ namespace PInvoke
         public static extern unsafe void* LocalFree(void* hMem);
 
         /// <summary>
+        ///     An application-defined callback function used with the EnumResourceNames and EnumResourceNamesEx functions. It
+        ///     receives the type and name of a resource. The ENUMRESNAMEPROC type defines a pointer to this callback function.
+        ///     EnumResNameProc is a placeholder for the application-defined function name.
+        /// </summary>
+        /// <param name="hModule">
+        ///     A handle to the module whose executable file contains the resources that are being enumerated.
+        ///     <para>
+        ///         If this parameter is <see cref="SafeLibraryHandle.Null" />, the function enumerates the resource names in the
+        ///         module used to create the current process.
+        ///     </para>
+        /// </param>
+        /// <param name="lpszType">
+        ///     The type of resource for which the name is being enumerated. Alternately, rather than a pointer,
+        ///     this parameter can be <see cref="MAKEINTRESOURCE" />(ID), where ID is an integer value representing a predefined
+        ///     resource type.
+        /// </param>
+        /// <param name="lpszName">
+        ///     The name of a resource of the type being enumerated. Alternately, rather than a pointer, this
+        ///     parameter can be <see cref="MAKEINTRESOURCE" />(ID), where ID is the integer identifier of the resource. For more
+        ///     information, see the Remarks section below.
+        /// </param>
+        /// <param name="lParam">
+        ///     An application-defined parameter passed to the <see cref="EnumResourceNames" /> or
+        ///     EnumResourceNamesEx function. This parameter can be used in error checking.
+        /// </param>
+        /// <returns>Returns TRUE to continue enumeration or FALSE to stop enumeration.</returns>
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate bool EnumResNameProc(IntPtr hModule, IntPtr lpszType, IntPtr lpszName, IntPtr lParam);
+
+        /// <summary>
+        ///     Enumerates resources of a specified type within a binary module. For Windows Vista and later, this is
+        ///     typically a language-neutral Portable Executable (LN file), and the enumeration will also include resources from
+        ///     the corresponding language-specific resource files (.mui files) that contain localizable language resources. It is
+        ///     also possible for hModule to specify an .mui file, in which case only that file is searched for resources.
+        /// </summary>
+        /// <param name="hModule">
+        ///     A handle to a module to be searched. Starting with Windows Vista, if this is an LN file, then appropriate .mui
+        ///     files (if any exist) are included in the search.
+        ///     <para>
+        ///         If this parameter is NULL, that is equivalent to passing in a handle to the module used to create the current
+        ///         process.
+        ///     </para>
+        /// </param>
+        /// <param name="lpszType">
+        ///     The type of the resource for which the name is being enumerated. Alternately, rather than a
+        ///     pointer, this parameter can be <see cref="MAKEINTRESOURCE" />(ID), where ID is an integer value representing a
+        ///     predefined resource type.
+        /// </param>
+        /// <param name="lpEnumFunc">A pointer to the callback function to be called for each enumerated resource name or ID.</param>
+        /// <param name="lParam">
+        ///     An application-defined value passed to the callback function. This parameter can be used in error
+        ///     checking.
+        /// </param>
+        /// <returns>
+        ///     The return value is TRUE if the function succeeds or FALSE if the function does not find a resource of the
+        ///     type specified, or if the function fails for another reason. To get extended error information, call
+        ///     <see cref="GetLastError" />.
+        /// </returns>
+        [DllImport(nameof(Kernel32), SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern unsafe bool EnumResourceNames(SafeLibraryHandle hModule, IntPtr lpszType, EnumResNameProc lpEnumFunc, IntPtr lParam);
+
+        /// <summary>Determines whether a value is an integer identifier for a resource.</summary>
+        /// <param name="p">The pointer to be tested whether it contains an integer resource identifier.</param>
+        /// <returns>If the value is a resource identifier, the return value is TRUE. Otherwise, the return value is FALSE.</returns>
+        public static bool IS_INTRESOURCE(IntPtr p) => p.ToInt64() >> 16 == 0;
+
+        /// <summary>
+        ///     Converts an integer value to a resource type compatible with the resource-management functions. This macro is
+        ///     used in place of a string containing the name of the resource.
+        /// </summary>
+        /// <param name="wInteger">The integer value to be converted.</param>
+        /// <returns>The return value is the specified value in the low-order word and zero in the high-order word.</returns>
+        public static IntPtr MAKEINTRESOURCE(int wInteger) => new IntPtr(wInteger);
+
+        /// <summary>Hardware-dependent cursor resource.</summary>
+        public static readonly IntPtr RT_CURSOR = MAKEINTRESOURCE(1);
+
+        /// <summary>Bitmap resource.</summary>
+        public static readonly IntPtr RT_BITMAP = MAKEINTRESOURCE(2);
+
+        /// <summary>Hardware-dependent icon resource.</summary>
+        public static readonly IntPtr RT_ICON = MAKEINTRESOURCE(3);
+
+        /// <summary>Menu resource.</summary>
+        public static readonly IntPtr RT_MENU = MAKEINTRESOURCE(4);
+
+        /// <summary>Dialog box.</summary>
+        public static readonly IntPtr RT_DIALOG = MAKEINTRESOURCE(5);
+
+        /// <summary>String-table entry.</summary>
+        public static readonly IntPtr RT_STRING = MAKEINTRESOURCE(6);
+
+        /// <summary>Font directory resource.</summary>
+        public static readonly IntPtr RT_FONTDIR = MAKEINTRESOURCE(7);
+
+        /// <summary>Font resource.</summary>
+        public static readonly IntPtr RT_FONT = MAKEINTRESOURCE(8);
+
+        /// <summary>Accelerator table.</summary>
+        public static readonly IntPtr RT_ACCELERATOR = MAKEINTRESOURCE(9);
+
+        /// <summary>Application-defined resource (raw data).</summary>
+        public static readonly IntPtr RT_RCDATA = MAKEINTRESOURCE(10);
+
+        /// <summary>Message-table entry.</summary>
+        public static readonly IntPtr RT_MESSAGETABLE = MAKEINTRESOURCE(11);
+
+        /// <summary>Hardware-independent cursor resource.</summary>
+        public static readonly IntPtr RT_GROUP_CURSOR = MAKEINTRESOURCE(12);
+
+        /// <summary>Hardware-independent icon resource.</summary>
+        public static readonly IntPtr RT_GROUP_ICON = MAKEINTRESOURCE(14);
+
+        /// <summary>Version resource</summary>
+        public static readonly IntPtr RT_VERSION = MAKEINTRESOURCE(16);
+
+        /// <summary>
+        ///     Allows a resource editing tool to associate a string with an .rc file. Typically, the string is the name of the
+        ///     header file that provides symbolic names. The resource compiler parses the string but otherwise ignores the value.
+        ///     For example,
+        ///     <para>
+        ///         <code>1 DLGINCLUDE "MyFile.h"</code>
+        ///     </para>
+        /// </summary>
+        public static readonly IntPtr RT_DLGINCLUDE = MAKEINTRESOURCE(17);
+
+        /// <summary>Plug and Play resource.</summary>
+        public static readonly IntPtr RT_PLUGPLAY = MAKEINTRESOURCE(19);
+
+        /// <summary>VXD.</summary>
+        public static readonly IntPtr RT_VXD = MAKEINTRESOURCE(20);
+
+        /// <summary>Animated cursor.</summary>
+        public static readonly IntPtr RT_ANICURSOR = MAKEINTRESOURCE(21);
+
+        /// <summary>Animated icon.</summary>
+        public static readonly IntPtr RT_ANIICON = MAKEINTRESOURCE(22);
+
+        /// <summary>HTML resource.</summary>
+        public static readonly IntPtr RT_HTML = MAKEINTRESOURCE(23);
+
+        /// <summary>
         ///     Frees the loaded dynamic-link library (DLL) module and, if necessary, decrements its reference count. When the
         ///     reference count reaches zero, the module is unloaded from the address space of the calling process and the handle
         ///     is no longer valid.

--- a/src/Kernel32.Tests/Kernel32Facts.cs
+++ b/src/Kernel32.Tests/Kernel32Facts.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -9,9 +10,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using PInvoke;
 using Xunit;
-using static PInvoke.Constants;
 using static PInvoke.Kernel32;
-using System.Collections.Generic;
 
 public partial class Kernel32Facts
 {

--- a/src/Kernel32.Tests/Kernel32Facts.cs
+++ b/src/Kernel32.Tests/Kernel32Facts.cs
@@ -790,13 +790,15 @@ public partial class Kernel32Facts
     }
 
     [Fact]
-    public unsafe void FindResource_LoadResource_LockResource()
+    public unsafe void Find_And_Load_Bmp_Icon_Resource()
     {
-        // Let's load the icon for .bmp files
-        using (var imageRes = LoadLibrary("imageres.dll"))
+        // shell32.dll contains at position #1 the icon for unknown files
+        using (var imageRes = LoadLibrary("shell32.dll"))
         {
+            Assert.False(imageRes.IsInvalid);
+
             // Locate where the resource is (Can be in some language dll)
-            var resInfo = FindResource(imageRes, MAKEINTRESOURCE(66), RT_GROUP_ICON);
+            var resInfo = FindResource(imageRes, MAKEINTRESOURCE(1), RT_GROUP_ICON);
             Assert.NotEqual(IntPtr.Zero, resInfo);
 
             // Get a handle to the resource
@@ -810,11 +812,30 @@ public partial class Kernel32Facts
     }
 
     [Fact]
-    public unsafe void EnumResourceNames_And_Find_Known_One()
+    public unsafe void Get_Size_Of_Bmp_Icon_Resource()
     {
-        // Let's load the icon for bmp files
-        using (var imageRes = LoadLibrary("imageres.dll"))
+        using (var imageRes = LoadLibrary("shell32.dll"))
         {
+            Assert.False(imageRes.IsInvalid);
+
+            // Load the icon for unknown files
+            var resInfo = FindResource(imageRes, MAKEINTRESOURCE(1), RT_GROUP_ICON);
+            Assert.NotEqual(IntPtr.Zero, resInfo);
+
+            // Should be able to get it's size
+            var size = SizeofResource(imageRes, resInfo);
+            Assert.NotEqual(0, size);
+        }
+    }
+
+    [Fact]
+    public unsafe void Enumerate_Imageres_Resources()
+    {
+        // Let's load the icon for unknown files
+        using (var imageRes = LoadLibrary("shell32.dll"))
+        {
+            Assert.False(imageRes.IsInvalid);
+
             List<int> intResources = new List<int>();
 
             EnumResNameProc onResourceFound = (module, type, name, lparam) =>
@@ -830,7 +851,7 @@ public partial class Kernel32Facts
             Assert.True(EnumResourceNames(imageRes, RT_GROUP_ICON, onResourceFound, IntPtr.Zero));
 
             // The icon for .bmp files
-            Assert.Contains(66, intResources);
+            Assert.Contains(1, intResources);
         }
     }
 


### PR DESCRIPTION
This branch add a few things related to #81 
- `EnumResourceNames`
- `FindResource`
- `LoadResource`
- `LockResource`
- `SizeofResource`

And it also fix a bug in the `Friendly` generator around expression bodies.

Things to discuss :
- Is there currently a way to make the generator output `string` variants for `char*` (The pointers are needed to support the common case of passing a number generated by `MAKEINTRESOURCE`) ?
- The generator doesn't try to convert the delegate passed to `EnumResourceNames` so the function isn't usable if you can't use pointers. Should we generate the alternative by hand ?
- `EnumResourceNames` delegate take a library handle but I didn't use `SafeLibraryHandle` as I don't know if the pinvoke layer knows that the delegate won't own the library and so that it shouldn't be freed.
- `FindResource` and `LoadResource` both returns handles / pointers that shouldn't be used but there is no functions to "Dispose" them. I kept them as `IntPtr` but wondered if I should create handle classes that don't do anything when disposed.
