### PR TITLE
Add missing constructor overload with ownsHandle

### DIFF
--- a/src/User32.Desktop/User32+SafeDCHandle.cs
+++ b/src/User32.Desktop/User32+SafeDCHandle.cs
@@ -26,8 +26,10 @@ namespace PInvoke
             /// </summary>
             /// <param name="hWnd">The HWND this handle is associated with and must be released with.</param>
             /// <param name="hDC">The handle to the DC.</param>
-            /// <param name="ownsHandle"><see langword="true"/> to reliably release the handle during the finalization
-            /// phase; <see langword="false"/> to prevent reliable release.</param>
+            /// <param name="ownsHandle">
+            ///     <see langword="true" /> to have the native handle released when the
+            ///     <see cref="SafeDCHandle" /> is disposed or finalized; <see langword="false" /> otherwise.
+            /// </param>
             public SafeDCHandle(IntPtr hWnd, IntPtr hDC, bool ownsHandle = true)
                 : base(IntPtr.Zero, ownsHandle)
             {

--- a/src/User32.Desktop/User32+SafeDCHandle.cs
+++ b/src/User32.Desktop/User32+SafeDCHandle.cs
@@ -27,8 +27,8 @@ namespace PInvoke
             /// <param name="hWnd">The HWND this handle is associated with and must be released with.</param>
             /// <param name="hDC">The handle to the DC.</param>
             /// <param name="ownsHandle">
-            ///     <see langword="true" /> to have the native handle released when the
-            ///     <see cref="SafeDCHandle" /> is disposed or finalized; <see langword="false" /> otherwise.
+            ///     <see langword="true" /> to have the native handle released when this safe handle is disposed or finalized;
+            ///     <see langword="false" /> otherwise.
             /// </param>
             public SafeDCHandle(IntPtr hWnd, IntPtr hDC, bool ownsHandle = true)
                 : base(IntPtr.Zero, ownsHandle)

--- a/src/User32.Desktop/User32+SafeDCHandle.cs
+++ b/src/User32.Desktop/User32+SafeDCHandle.cs
@@ -26,8 +26,10 @@ namespace PInvoke
             /// </summary>
             /// <param name="hWnd">The HWND this handle is associated with and must be released with.</param>
             /// <param name="hDC">The handle to the DC.</param>
-            public SafeDCHandle(IntPtr hWnd, IntPtr hDC)
-                : base(IntPtr.Zero, true)
+            /// <param name="ownsHandle"><see langword="true"/> to reliably release the handle during the finalization
+            /// phase; <see langword="false"/> to prevent reliable release.</param>
+            public SafeDCHandle(IntPtr hWnd, IntPtr hDC, bool ownsHandle = true)
+                : base(IntPtr.Zero, ownsHandle)
             {
                 this.HWnd = hWnd;
                 this.SetHandle(hDC);

--- a/src/UxTheme.Desktop/UxTheme+SafeThemeHandle.cs
+++ b/src/UxTheme.Desktop/UxTheme+SafeThemeHandle.cs
@@ -31,8 +31,8 @@ namespace PInvoke
             /// </summary>
             /// <param name="preexistingHandle">An object that represents the pre-existing handle to use.</param>
             /// <param name="ownsHandle">
-            ///     <see langword="true" /> to have the native handle released when the
-            ///     <see cref="SafeThemeHandle" /> is disposed or finalized; <see langword="false" /> otherwise.
+            ///     <see langword="true" /> to have the native handle released when this safe handle is disposed or finalized;
+            ///     <see langword="false" /> otherwise.
             /// </param>
             public SafeThemeHandle(IntPtr preexistingHandle, bool ownsHandle = true)
                 : base(IntPtr.Zero, ownsHandle)

--- a/src/UxTheme.Desktop/UxTheme+SafeThemeHandle.cs
+++ b/src/UxTheme.Desktop/UxTheme+SafeThemeHandle.cs
@@ -26,6 +26,18 @@ namespace PInvoke
             {
             }
 
+            /// <summary>
+            /// Initializes a new instance of the <see cref="SafeThemeHandle"/> class.
+            /// </summary>
+            /// <param name="preexistingHandle">An object that represents the pre-existing handle to use.</param>
+            /// <param name="ownsHandle"><see langword="true"/> to reliably release the handle during the finalization
+            /// phase; <see langword="false"/> to prevent reliable release.</param>
+            public SafeThemeHandle(IntPtr preexistingHandle, bool ownsHandle = true)
+                : base(IntPtr.Zero, ownsHandle)
+            {
+                this.SetHandle(preexistingHandle);
+            }
+
             /// <inheritdoc />
             public override bool IsInvalid => this.handle == IntPtr.Zero;
 

--- a/src/UxTheme.Desktop/UxTheme+SafeThemeHandle.cs
+++ b/src/UxTheme.Desktop/UxTheme+SafeThemeHandle.cs
@@ -30,8 +30,10 @@ namespace PInvoke
             /// Initializes a new instance of the <see cref="SafeThemeHandle"/> class.
             /// </summary>
             /// <param name="preexistingHandle">An object that represents the pre-existing handle to use.</param>
-            /// <param name="ownsHandle"><see langword="true"/> to reliably release the handle during the finalization
-            /// phase; <see langword="false"/> to prevent reliable release.</param>
+            /// <param name="ownsHandle">
+            ///     <see langword="true" /> to have the native handle released when the
+            ///     <see cref="SafeThemeHandle" /> is disposed or finalized; <see langword="false" /> otherwise.
+            /// </param>
             public SafeThemeHandle(IntPtr preexistingHandle, bool ownsHandle = true)
                 : base(IntPtr.Zero, ownsHandle)
             {


### PR DESCRIPTION
They are necessary to port Audio Switcher (#81)

We don't have such constructors on all `SafeHandle` (Some already have them) but I would suggest that we add them.
