### PR TITLE
Safehandle unification

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,44 +216,7 @@ Safe handles should follow a few rules :
 * They should have a constructor allowing to reuse pre-existing handles.
 * They should have a static field for each invalid values for easy access.
 
-Example :
-```csharp
-public class MySafeHandle : SafeHandle
-{
-    /// <summary>
-    /// A handle that may be used in place of <see cref="IntPtr.Zero"/>.
-    /// </summary>
-    public static readonly MySafeHandle Null = new MySafeHandle();
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="MySafeHandle"/> class.
-    /// </summary>
-    public MySafeHandle()
-        : base(IntPtr.Zero, true)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="MySafeHandle"/> class.
-    /// </summary>
-    /// <param name="preexistingHandle">An object that represents the pre-existing handle to use.</param>
-    /// <param name="ownsHandle">
-    ///     <see langword="true" /> to have the native handle released when this safe handle is disposed or finalized;
-    ///     <see langword="false" /> otherwise.
-    /// </param>
-    public MySafeHandle(IntPtr preexistingHandle, bool ownsHandle = true)
-        : base(IntPtr.Zero, ownsHandle)
-    {
-        this.SetHandle(preexistingHandle);
-    }
-
-    /// <inheritdoc />
-    public override bool IsInvalid => this.handle == IntPtr.Zero;
-
-    /// <inheritdoc />
-    protected override bool ReleaseHandle() => FindClose(this.handle);
-}
-```
+A good example would be [`SafeHookHandle.cs`](src/User32.Desktop/User32+SafeHookHandle.cs).
 
 ## Self-service releases for contributors
 

--- a/src/AdvApi32.Shared/AdvApi32+SafeServiceHandle.cs
+++ b/src/AdvApi32.Shared/AdvApi32+SafeServiceHandle.cs
@@ -35,9 +35,11 @@ namespace PInvoke
             /// Initializes a new instance of the <see cref="SafeServiceHandle"/> class.
             /// </summary>
             /// <param name="preexistingHandle">An object that represents the pre-existing handle to use.</param>
-            /// <param name="ownsHandle"><see langword="true"/> to reliably release the handle during the finalization
-            /// phase; <see langword="false"/> to prevent reliable release.</param>
-            public SafeServiceHandle(IntPtr preexistingHandle, bool ownsHandle)
+            /// <param name="ownsHandle">
+            ///     <see langword="true" /> to have the native handle released when this safe handle is disposed or finalized;
+            ///     <see langword="false" /> otherwise.
+            /// </param>
+            public SafeServiceHandle(IntPtr preexistingHandle, bool ownsHandle = true)
                 : base(IntPtr.Zero, ownsHandle)
             {
                 this.SetHandle(preexistingHandle);

--- a/src/BCrypt/BCrypt+SafeAlgorithmHandle.cs
+++ b/src/BCrypt/BCrypt+SafeAlgorithmHandle.cs
@@ -42,7 +42,7 @@ namespace PInvoke
             {
                 this.SetHandle(preexistingHandle);
             }
-            
+
             /// <inheritdoc />
             public override bool IsInvalid => this.handle == IntPtr.Zero;
 

--- a/src/BCrypt/BCrypt+SafeAlgorithmHandle.cs
+++ b/src/BCrypt/BCrypt+SafeAlgorithmHandle.cs
@@ -29,6 +29,20 @@ namespace PInvoke
             {
             }
 
+            /// <summary>
+            /// Initializes a new instance of the <see cref="SafeAlgorithmHandle"/> class.
+            /// </summary>
+            /// <param name="preexistingHandle">An object that represents the pre-existing handle to use.</param>
+            /// <param name="ownsHandle">
+            ///     <see langword="true" /> to have the native handle released when this safe handle is disposed or finalized;
+            ///     <see langword="false" /> otherwise.
+            /// </param>
+            public SafeAlgorithmHandle(IntPtr preexistingHandle, bool ownsHandle = true)
+                : base(IntPtr.Zero, ownsHandle)
+            {
+                this.SetHandle(preexistingHandle);
+            }
+            
             /// <inheritdoc />
             public override bool IsInvalid => this.handle == IntPtr.Zero;
 

--- a/src/BCrypt/BCrypt+SafeHashHandle.cs
+++ b/src/BCrypt/BCrypt+SafeHashHandle.cs
@@ -29,6 +29,20 @@ namespace PInvoke
             {
             }
 
+            /// <summary>
+            /// Initializes a new instance of the <see cref="SafeHashHandle"/> class.
+            /// </summary>
+            /// <param name="preexistingHandle">An object that represents the pre-existing handle to use.</param>
+            /// <param name="ownsHandle">
+            ///     <see langword="true" /> to have the native handle released when this safe handle is disposed or finalized;
+            ///     <see langword="false" /> otherwise.
+            /// </param>
+            public SafeHashHandle(IntPtr preexistingHandle, bool ownsHandle = true)
+                : base(IntPtr.Zero, ownsHandle)
+            {
+                this.SetHandle(preexistingHandle);
+            }
+
             /// <inheritdoc />
             public override bool IsInvalid => this.handle == IntPtr.Zero;
 

--- a/src/BCrypt/BCrypt+SafeKeyHandle.cs
+++ b/src/BCrypt/BCrypt+SafeKeyHandle.cs
@@ -29,6 +29,20 @@ namespace PInvoke
             {
             }
 
+            /// <summary>
+            /// Initializes a new instance of the <see cref="SafeKeyHandle"/> class.
+            /// </summary>
+            /// <param name="preexistingHandle">An object that represents the pre-existing handle to use.</param>
+            /// <param name="ownsHandle">
+            ///     <see langword="true" /> to have the native handle released when this safe handle is disposed or finalized;
+            ///     <see langword="false" /> otherwise.
+            /// </param>
+            public SafeKeyHandle(IntPtr preexistingHandle, bool ownsHandle = true)
+                : base(IntPtr.Zero, ownsHandle)
+            {
+                this.SetHandle(preexistingHandle);
+            }
+
             /// <inheritdoc />
             public override bool IsInvalid => this.handle == IntPtr.Zero;
 

--- a/src/BCrypt/BCrypt+SafeSecretHandle.cs
+++ b/src/BCrypt/BCrypt+SafeSecretHandle.cs
@@ -29,6 +29,20 @@ namespace PInvoke
             {
             }
 
+            /// <summary>
+            /// Initializes a new instance of the <see cref="SafeSecretHandle"/> class.
+            /// </summary>
+            /// <param name="preexistingHandle">An object that represents the pre-existing handle to use.</param>
+            /// <param name="ownsHandle">
+            ///     <see langword="true" /> to have the native handle released when this safe handle is disposed or finalized;
+            ///     <see langword="false" /> otherwise.
+            /// </param>
+            public SafeSecretHandle(IntPtr preexistingHandle, bool ownsHandle = true)
+                : base(IntPtr.Zero, ownsHandle)
+            {
+                this.SetHandle(preexistingHandle);
+            }
+
             /// <inheritdoc />
             public override bool IsInvalid => this.handle == IntPtr.Zero;
 

--- a/src/Crypt32.Shared/Crypt32+SafeCertStoreHandle.cs
+++ b/src/Crypt32.Shared/Crypt32+SafeCertStoreHandle.cs
@@ -31,6 +31,20 @@ namespace PInvoke
             {
             }
 
+            /// <summary>
+            /// Initializes a new instance of the <see cref="SafeCertStoreHandle"/> class.
+            /// </summary>
+            /// <param name="preexistingHandle">An object that represents the pre-existing handle to use.</param>
+            /// <param name="ownsHandle">
+            ///     <see langword="true" /> to have the native handle released when this safe handle is disposed or finalized;
+            ///     <see langword="false" /> otherwise.
+            /// </param>
+            public SafeCertStoreHandle(IntPtr preexistingHandle, bool ownsHandle = true)
+                : base(IntPtr.Zero, ownsHandle)
+            {
+                this.SetHandle(preexistingHandle);
+            }
+
             /// <inheritdoc />
             public override bool IsInvalid => this.handle == IntPtr.Zero;
 

--- a/src/Hid.Shared/Hid+SafePreparsedDataHandle.cs
+++ b/src/Hid.Shared/Hid+SafePreparsedDataHandle.cs
@@ -20,6 +20,11 @@ namespace PInvoke
         public class SafePreparsedDataHandle : SafeHandle
         {
             /// <summary>
+            /// An invalid handle that may be used in place of <see cref="INVALID_HANDLE_VALUE"/>.
+            /// </summary>
+            public static readonly SafePreparsedDataHandle Invalid = new SafePreparsedDataHandle();
+
+            /// <summary>
             /// Initializes a new instance of the <see cref="SafePreparsedDataHandle"/> class.
             /// </summary>
             public SafePreparsedDataHandle()

--- a/src/Hid.Shared/Hid+SafePreparsedDataHandle.cs
+++ b/src/Hid.Shared/Hid+SafePreparsedDataHandle.cs
@@ -31,9 +31,11 @@ namespace PInvoke
             /// Initializes a new instance of the <see cref="SafePreparsedDataHandle"/> class.
             /// </summary>
             /// <param name="preexistingHandle">An object that represents the pre-existing handle to use.</param>
-            /// <param name="ownsHandle"><see langword="true"/> to reliably release the handle during the finalization
-            /// phase; <see langword="false"/> to prevent reliable release.</param>
-            public SafePreparsedDataHandle(IntPtr preexistingHandle, bool ownsHandle)
+            /// <param name="ownsHandle">
+            ///     <see langword="true" /> to have the native handle released when this safe handle is disposed or finalized;
+            ///     <see langword="false" /> otherwise.
+            /// </param>
+            public SafePreparsedDataHandle(IntPtr preexistingHandle, bool ownsHandle = true)
                 : base(INVALID_HANDLE_VALUE, ownsHandle)
             {
                 this.SetHandle(preexistingHandle);

--- a/src/Kernel32.Desktop/Kernel32+SafeLibraryHandle.cs
+++ b/src/Kernel32.Desktop/Kernel32+SafeLibraryHandle.cs
@@ -30,9 +30,11 @@ namespace PInvoke
             /// Initializes a new instance of the <see cref="SafeLibraryHandle"/> class.
             /// </summary>
             /// <param name="preexistingHandle">An object that represents the pre-existing handle to use.</param>
-            /// <param name="ownsHandle"><see langword="true"/> to reliably release the handle during the finalization
-            /// phase; <see langword="false"/> to prevent reliable release.</param>
-            public SafeLibraryHandle(IntPtr preexistingHandle, bool ownsHandle)
+            /// <param name="ownsHandle">
+            ///     <see langword="true" /> to have the native handle released when this safe handle is disposed or finalized;
+            ///     <see langword="false" /> otherwise.
+            /// </param>
+            public SafeLibraryHandle(IntPtr preexistingHandle, bool ownsHandle = true)
                 : base(INVALID_HANDLE_VALUE, ownsHandle)
             {
                 this.SetHandle(preexistingHandle);

--- a/src/Kernel32.Desktop/Kernel32+SafeLibraryHandle.cs
+++ b/src/Kernel32.Desktop/Kernel32+SafeLibraryHandle.cs
@@ -16,7 +16,15 @@ namespace PInvoke
         /// </summary>
         public class SafeLibraryHandle : SafeHandle
         {
-            public static readonly SafeLibraryHandle Null = new SafeLibraryHandle(IntPtr.Zero, false);
+            /// <summary>
+            /// A handle that may be used in place of <see cref="IntPtr.Zero"/>.
+            /// </summary>
+            public static readonly SafeLibraryHandle Null = new SafeLibraryHandle(IntPtr.Zero);
+
+            /// <summary>
+            /// An invalid handle that may be used in place of <see cref="INVALID_HANDLE_VALUE"/>.
+            /// </summary>
+            public static readonly SafeLibraryHandle Invalid = new SafeLibraryHandle();
 
             /// <summary>
             /// Initializes a new instance of the <see cref="SafeLibraryHandle"/> class.

--- a/src/Kernel32.Shared/Kernel32+SafeFindFilesHandle.cs
+++ b/src/Kernel32.Shared/Kernel32+SafeFindFilesHandle.cs
@@ -3,6 +3,7 @@
 
 namespace PInvoke
 {
+    using System;
     using System.Runtime.InteropServices;
 
     /// <content>
@@ -21,6 +22,20 @@ namespace PInvoke
             public SafeFindFilesHandle()
                 : base(INVALID_HANDLE_VALUE, true)
             {
+            }
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="SafeFindFilesHandle"/> class.
+            /// </summary>
+            /// <param name="preexistingHandle">An object that represents the pre-existing handle to use.</param>
+            /// <param name="ownsHandle">
+            ///     <see langword="true" /> to have the native handle released when this safe handle is disposed or finalized;
+            ///     <see langword="false" /> otherwise.
+            /// </param>
+            public SafeFindFilesHandle(IntPtr preexistingHandle, bool ownsHandle = true)
+                : base(IntPtr.Zero, ownsHandle)
+            {
+                this.SetHandle(preexistingHandle);
             }
 
             /// <inheritdoc />

--- a/src/Kernel32.Shared/Kernel32+SafeFindFilesHandle.cs
+++ b/src/Kernel32.Shared/Kernel32+SafeFindFilesHandle.cs
@@ -17,6 +17,11 @@ namespace PInvoke
         public class SafeFindFilesHandle : SafeHandle
         {
             /// <summary>
+            /// An invalid handle that may be used in place of <see cref="INVALID_HANDLE_VALUE"/>.
+            /// </summary>
+            public static readonly SafeFindFilesHandle Invalid = new SafeFindFilesHandle();
+
+            /// <summary>
             /// Initializes a new instance of the <see cref="SafeFindFilesHandle"/> class.
             /// </summary>
             public SafeFindFilesHandle()

--- a/src/Kernel32.Shared/Kernel32+SafeObjectHandle.cs
+++ b/src/Kernel32.Shared/Kernel32+SafeObjectHandle.cs
@@ -17,12 +17,12 @@ namespace PInvoke
         public class SafeObjectHandle : SafeHandle
         {
             /// <summary>
-            /// An invalid handle with the value of -1.
+            /// An invalid handle that may be used in place of <see cref="INVALID_HANDLE_VALUE"/>.
             /// </summary>
             public static readonly SafeObjectHandle Invalid = new SafeObjectHandle();
 
             /// <summary>
-            /// An invalid handle with the value of 0 (null).
+            /// A handle that may be used in place of <see cref="IntPtr.Zero"/>.
             /// </summary>
             public static readonly SafeObjectHandle Null = new SafeObjectHandle(IntPtr.Zero, false);
 

--- a/src/Kernel32.Shared/Kernel32+SafeObjectHandle.cs
+++ b/src/Kernel32.Shared/Kernel32+SafeObjectHandle.cs
@@ -38,9 +38,11 @@ namespace PInvoke
             /// Initializes a new instance of the <see cref="SafeObjectHandle"/> class.
             /// </summary>
             /// <param name="preexistingHandle">An object that represents the pre-existing handle to use.</param>
-            /// <param name="ownsHandle"><see langword="true"/> to reliably release the handle during the finalization
-            /// phase; <see langword="false"/> to prevent reliable release.</param>
-            public SafeObjectHandle(IntPtr preexistingHandle, bool ownsHandle)
+            /// <param name="ownsHandle">
+            ///     <see langword="true" /> to have the native handle released when this safe handle is disposed or finalized;
+            ///     <see langword="false" /> otherwise.
+            /// </param>
+            public SafeObjectHandle(IntPtr preexistingHandle, bool ownsHandle = true)
                 : base(INVALID_HANDLE_VALUE, ownsHandle)
             {
                 this.SetHandle(preexistingHandle);

--- a/src/NCrypt/NCrypt+SafeKeyHandle.cs
+++ b/src/NCrypt/NCrypt+SafeKeyHandle.cs
@@ -29,6 +29,20 @@ namespace PInvoke
             {
             }
 
+            /// <summary>
+            /// Initializes a new instance of the <see cref="SafeKeyHandle"/> class.
+            /// </summary>
+            /// <param name="preexistingHandle">An object that represents the pre-existing handle to use.</param>
+            /// <param name="ownsHandle">
+            ///     <see langword="true" /> to have the native handle released when this safe handle is disposed or finalized;
+            ///     <see langword="false" /> otherwise.
+            /// </param>
+            public SafeKeyHandle(IntPtr preexistingHandle, bool ownsHandle = true)
+                : base(IntPtr.Zero, ownsHandle)
+            {
+                this.SetHandle(preexistingHandle);
+            }
+
             /// <inheritdoc />
             public override bool IsInvalid => this.handle == IntPtr.Zero || !NCryptIsKeyHandle(this.handle);
 

--- a/src/NCrypt/NCrypt+SafeProviderHandle.cs
+++ b/src/NCrypt/NCrypt+SafeProviderHandle.cs
@@ -29,6 +29,20 @@ namespace PInvoke
             {
             }
 
+            /// <summary>
+            /// Initializes a new instance of the <see cref="SafeProviderHandle"/> class.
+            /// </summary>
+            /// <param name="preexistingHandle">An object that represents the pre-existing handle to use.</param>
+            /// <param name="ownsHandle">
+            ///     <see langword="true" /> to have the native handle released when this safe handle is disposed or finalized;
+            ///     <see langword="false" /> otherwise.
+            /// </param>
+            public SafeProviderHandle(IntPtr preexistingHandle, bool ownsHandle = true)
+                : base(IntPtr.Zero, ownsHandle)
+            {
+                this.SetHandle(preexistingHandle);
+            }
+
             /// <inheritdoc />
             public override bool IsInvalid => this.handle == IntPtr.Zero;
 

--- a/src/NCrypt/NCrypt+SafeSecretHandle.cs
+++ b/src/NCrypt/NCrypt+SafeSecretHandle.cs
@@ -29,6 +29,20 @@ namespace PInvoke
             {
             }
 
+            /// <summary>
+            /// Initializes a new instance of the <see cref="SafeSecretHandle"/> class.
+            /// </summary>
+            /// <param name="preexistingHandle">An object that represents the pre-existing handle to use.</param>
+            /// <param name="ownsHandle">
+            ///     <see langword="true" /> to have the native handle released when this safe handle is disposed or finalized;
+            ///     <see langword="false" /> otherwise.
+            /// </param>
+            public SafeSecretHandle(IntPtr preexistingHandle, bool ownsHandle = true)
+                : base(IntPtr.Zero, ownsHandle)
+            {
+                this.SetHandle(preexistingHandle);
+            }
+
             /// <inheritdoc />
             public override bool IsInvalid => this.handle == IntPtr.Zero;
 

--- a/src/NTDll.Desktop/NTDll+SafeNTObjectHandle.cs
+++ b/src/NTDll.Desktop/NTDll+SafeNTObjectHandle.cs
@@ -19,7 +19,10 @@ namespace PInvoke
         /// </summary>
         public class SafeNTObjectHandle : SafeHandle
         {
-            public static readonly SafeNTObjectHandle Null = new SafeNTObjectHandle(IntPtr.Zero, false);
+            /// <summary>
+            /// A handle that may be used in place of <see cref="IntPtr.Zero"/>.
+            /// </summary>            
+            public static readonly SafeNTObjectHandle Null = new SafeNTObjectHandle();
 
             /// <summary>
             /// Initializes a new instance of the <see cref="SafeNTObjectHandle"/> class.

--- a/src/NTDll.Desktop/NTDll+SafeNTObjectHandle.cs
+++ b/src/NTDll.Desktop/NTDll+SafeNTObjectHandle.cs
@@ -33,9 +33,11 @@ namespace PInvoke
             /// Initializes a new instance of the <see cref="SafeNTObjectHandle"/> class.
             /// </summary>
             /// <param name="preexistingHandle">An object that represents the pre-existing handle to use.</param>
-            /// <param name="ownsHandle"><see langword="true"/> to reliably release the handle during the finalization
-            /// phase; <see langword="false"/> to prevent reliable release.</param>
-            public SafeNTObjectHandle(IntPtr preexistingHandle, bool ownsHandle)
+            /// <param name="ownsHandle">
+            ///     <see langword="true" /> to have the native handle released when this safe handle is disposed or finalized;
+            ///     <see langword="false" /> otherwise.
+            /// </param>
+            public SafeNTObjectHandle(IntPtr preexistingHandle, bool ownsHandle = true)
                 : base(IntPtr.Zero, ownsHandle)
             {
                 this.SetHandle(preexistingHandle);

--- a/src/NTDll.Desktop/NTDll+SafeNTObjectHandle.cs
+++ b/src/NTDll.Desktop/NTDll+SafeNTObjectHandle.cs
@@ -21,7 +21,7 @@ namespace PInvoke
         {
             /// <summary>
             /// A handle that may be used in place of <see cref="IntPtr.Zero"/>.
-            /// </summary>            
+            /// </summary>
             public static readonly SafeNTObjectHandle Null = new SafeNTObjectHandle();
 
             /// <summary>

--- a/src/SetupApi.Desktop/SetupApi+SafeDeviceInfoSetHandle.cs
+++ b/src/SetupApi.Desktop/SetupApi+SafeDeviceInfoSetHandle.cs
@@ -31,9 +31,11 @@ namespace PInvoke
             /// Initializes a new instance of the <see cref="SafeDeviceInfoSetHandle"/> class.
             /// </summary>
             /// <param name="preexistingHandle">An object that represents the pre-existing handle to use.</param>
-            /// <param name="ownsHandle"><see langword="true"/> to reliably release the handle during the finalization
-            /// phase; <see langword="false"/> to prevent reliable release.</param>
-            public SafeDeviceInfoSetHandle(IntPtr preexistingHandle, bool ownsHandle)
+            /// <param name="ownsHandle">
+            ///     <see langword="true" /> to have the native handle released when this safe handle is disposed or finalized;
+            ///     <see langword="false" /> otherwise.
+            /// </param>
+            public SafeDeviceInfoSetHandle(IntPtr preexistingHandle, bool ownsHandle = true)
                 : base(INVALID_HANDLE_VALUE, ownsHandle)
             {
                 this.SetHandle(preexistingHandle);

--- a/src/SetupApi.Desktop/SetupApi+SafeDeviceInfoSetHandle.cs
+++ b/src/SetupApi.Desktop/SetupApi+SafeDeviceInfoSetHandle.cs
@@ -20,6 +20,11 @@ namespace PInvoke
         public class SafeDeviceInfoSetHandle : SafeHandle
         {
             /// <summary>
+            /// A handle that may be used in place of <see cref="INVALID_HANDLE_VALUE"/>.
+            /// </summary>
+            public static readonly SafeDeviceInfoSetHandle Invalid = new SafeDeviceInfoSetHandle();
+                        
+            /// <summary>
             /// Initializes a new instance of the <see cref="SafeDeviceInfoSetHandle"/> class.
             /// </summary>
             public SafeDeviceInfoSetHandle()

--- a/src/SetupApi.Desktop/SetupApi+SafeDeviceInfoSetHandle.cs
+++ b/src/SetupApi.Desktop/SetupApi+SafeDeviceInfoSetHandle.cs
@@ -23,7 +23,7 @@ namespace PInvoke
             /// A handle that may be used in place of <see cref="INVALID_HANDLE_VALUE"/>.
             /// </summary>
             public static readonly SafeDeviceInfoSetHandle Invalid = new SafeDeviceInfoSetHandle();
-                        
+
             /// <summary>
             /// Initializes a new instance of the <see cref="SafeDeviceInfoSetHandle"/> class.
             /// </summary>

--- a/src/User32.Desktop/User32+SafeHookHandle.cs
+++ b/src/User32.Desktop/User32+SafeHookHandle.cs
@@ -30,9 +30,11 @@ namespace PInvoke
             /// Initializes a new instance of the <see cref="SafeHookHandle"/> class.
             /// </summary>
             /// <param name="preexistingHandle">An object that represents the pre-existing handle to use.</param>
-            /// <param name="ownsHandle"><see langword="true"/> to reliably release the handle during the finalization
-            /// phase; <see langword="false"/> to prevent reliable release.</param>
-            public SafeHookHandle(IntPtr preexistingHandle, bool ownsHandle)
+            /// <param name="ownsHandle">
+            ///     <see langword="true" /> to have the native handle released when this safe handle is disposed or finalized;
+            ///     <see langword="false" /> otherwise.
+            /// </param>
+            public SafeHookHandle(IntPtr preexistingHandle, bool ownsHandle = true)
                 : base(IntPtr.Zero, ownsHandle)
             {
                 this.SetHandle(preexistingHandle);

--- a/src/User32.Desktop/User32+SafeHookHandle.cs
+++ b/src/User32.Desktop/User32+SafeHookHandle.cs
@@ -16,6 +16,9 @@ namespace PInvoke
         /// </summary>
         public class SafeHookHandle : SafeHandle
         {
+            /// <summary>
+            /// A handle that may be used in place of <see cref="IntPtr.Zero"/>.
+            /// </summary>
             public static readonly SafeHookHandle Null = new SafeHookHandle();
 
             /// <summary>

--- a/src/UxTheme.Desktop/UxTheme+SafeThemeHandle.cs
+++ b/src/UxTheme.Desktop/UxTheme+SafeThemeHandle.cs
@@ -16,6 +16,9 @@ namespace PInvoke
         /// </summary>
         public class SafeThemeHandle : SafeHandle
         {
+            /// <summary>
+            /// A handle that may be used in place of <see cref="IntPtr.Zero"/>.
+            /// </summary>
             public static readonly SafeThemeHandle Null = new SafeThemeHandle();
 
             /// <summary>


### PR DESCRIPTION
This should solve #198 and extend a little bit on it :

All `SafeHandle` now have :
- A constructor to create them from an existing `IntPtr`
- A field for each invalid value

The contributing doc is also updated to reflect all of that.
