### PR TITLE
Move more RT_ constants to their own files

### DIFF
--- a/src/Kernel32.Desktop/Kernel32+ResourceTypes.cs
+++ b/src/Kernel32.Desktop/Kernel32+ResourceTypes.cs
@@ -49,5 +49,30 @@ namespace PInvoke
 
         /// <summary>Version resource</summary>
         public static readonly unsafe char* RT_VERSION = MAKEINTRESOURCE(16);
+
+        /// <summary>
+        ///     Allows a resource editing tool to associate a string with an .rc file. Typically, the string is the name of the
+        ///     header file that provides symbolic names. The resource compiler parses the string but otherwise ignores the value.
+        ///     For example,
+        ///     <para>
+        ///         <code>1 DLGINCLUDE "MyFile.h"</code>
+        ///     </para>
+        /// </summary>
+        public static readonly unsafe char* RT_DLGINCLUDE = MAKEINTRESOURCE(17);
+
+        /// <summary>Plug and Play resource.</summary>
+        public static readonly unsafe char* RT_PLUGPLAY = MAKEINTRESOURCE(19);
+
+        /// <summary>VXD.</summary>
+        public static readonly unsafe char* RT_VXD = MAKEINTRESOURCE(20);
+
+        /// <summary>Animated cursor.</summary>
+        public static readonly unsafe char* RT_ANICURSOR = MAKEINTRESOURCE(21);
+
+        /// <summary>Animated icon.</summary>
+        public static readonly unsafe char* RT_ANIICON = MAKEINTRESOURCE(22);
+
+        /// <summary>HTML resource.</summary>
+        public static readonly unsafe char* RT_HTML = MAKEINTRESOURCE(23);
     }
 }

--- a/src/Kernel32.Desktop/Kernel32.cs
+++ b/src/Kernel32.Desktop/Kernel32.cs
@@ -37,31 +37,6 @@ namespace PInvoke
         public const int NMPWAIT_NOWAIT = 0x00000001;
 
         /// <summary>
-        ///     Allows a resource editing tool to associate a string with an .rc file. Typically, the string is the name of the
-        ///     header file that provides symbolic names. The resource compiler parses the string but otherwise ignores the value.
-        ///     For example,
-        ///     <para>
-        ///         <code>1 DLGINCLUDE "MyFile.h"</code>
-        ///     </para>
-        /// </summary>
-        public static readonly unsafe char* RT_DLGINCLUDE = MAKEINTRESOURCE(17);
-
-        /// <summary>Plug and Play resource.</summary>
-        public static readonly unsafe char* RT_PLUGPLAY = MAKEINTRESOURCE(19);
-
-        /// <summary>VXD.</summary>
-        public static readonly unsafe char* RT_VXD = MAKEINTRESOURCE(20);
-
-        /// <summary>Animated cursor.</summary>
-        public static readonly unsafe char* RT_ANICURSOR = MAKEINTRESOURCE(21);
-
-        /// <summary>Animated icon.</summary>
-        public static readonly unsafe char* RT_ANIICON = MAKEINTRESOURCE(22);
-
-        /// <summary>HTML resource.</summary>
-        public static readonly unsafe char* RT_HTML = MAKEINTRESOURCE(23);
-
-        /// <summary>
         ///     An application-defined callback function used with the EnumResourceNames and EnumResourceNamesEx functions. It
         ///     receives the type and name of a resource. The ENUMRESNAMEPROC type defines a pointer to this callback function.
         ///     EnumResNameProc is a placeholder for the application-defined function name.


### PR DESCRIPTION
Some of them were missed when all RT_ constants were moved to a separate file.
