### PR TITLE
Convert ACCESS_MASK into a struct

### DIFF
--- a/src/AdvApi32.Desktop/AdvApi32.Helpers.cs
+++ b/src/AdvApi32.Desktop/AdvApi32.Helpers.cs
@@ -26,7 +26,7 @@ namespace PInvoke
         /// <exception cref="Win32Exception">If the method fails, returning the calling thread's last-error code value.</exception>
         public static unsafe IEnumerable<ENUM_SERVICE_STATUS> EnumServicesStatus()
         {
-            using (var scmHandle = OpenSCManager(null, null, ServiceManagerAccess.SC_MANAGER_ENUMERATE_SERVICE))
+            using (var scmHandle = OpenSCManager(null, null, (uint)ServiceManagerAccess.SC_MANAGER_ENUMERATE_SERVICE))
             {
                 if (scmHandle.IsInvalid)
                 {
@@ -91,7 +91,7 @@ namespace PInvoke
         /// <param name="hService">
         ///     A handle to the service control manager or the service. Handles to the service control manager
         ///     are returned by the <see cref="OpenSCManager" /> function, and handles to a service are returned by either the
-        ///     <see cref="OpenService" /> or <see cref="CreateService(SafeServiceHandle,string,string,ServiceAccess,ServiceType,ServiceStartType,ServiceErrorControl,string,string,int, string,string,string)" /> function. The handle must have the READ_CONTROL access
+        ///     <see cref="OpenService" /> or <see cref="CreateService(SafeServiceHandle,string,string,ACCESS_MASK,ServiceType,ServiceStartType,ServiceErrorControl,string,string,int, string,string,string)" /> function. The handle must have the READ_CONTROL access
         ///     right.
         /// </param>
         /// <param name="dwSecurityInformation">
@@ -136,7 +136,7 @@ namespace PInvoke
         /// <summary>The SetServiceObjectSecurity function sets the security descriptor of a service object.</summary>
         /// <param name="hService">
         ///     A handle to the service. This handle is returned by the <see cref="OpenService" /> or
-        ///     <see cref="CreateService(SafeServiceHandle,string,string,ServiceAccess,ServiceType,ServiceStartType,ServiceErrorControl,string,string,int, string,string,string)" /> function. The access required for this handle depends on the security information
+        ///     <see cref="CreateService(SafeServiceHandle,string,string,ACCESS_MASK,ServiceType,ServiceStartType,ServiceErrorControl,string,string,int, string,string,string)" /> function. The access required for this handle depends on the security information
         ///     specified in the <paramref name="dwSecurityInformation" /> parameter.
         /// </param>
         /// <param name="dwSecurityInformation">

--- a/src/AdvApi32.Desktop/AdvApi32.Helpers.cs
+++ b/src/AdvApi32.Desktop/AdvApi32.Helpers.cs
@@ -26,7 +26,7 @@ namespace PInvoke
         /// <exception cref="Win32Exception">If the method fails, returning the calling thread's last-error code value.</exception>
         public static unsafe IEnumerable<ENUM_SERVICE_STATUS> EnumServicesStatus()
         {
-            using (var scmHandle = OpenSCManager(null, null, (uint)ServiceManagerAccess.SC_MANAGER_ENUMERATE_SERVICE))
+            using (var scmHandle = OpenSCManager(null, null, ServiceManagerAccess.SC_MANAGER_ENUMERATE_SERVICE))
             {
                 if (scmHandle.IsInvalid)
                 {

--- a/src/AdvApi32.Shared/AdvApi32+SafeServiceHandle.cs
+++ b/src/AdvApi32.Shared/AdvApi32+SafeServiceHandle.cs
@@ -13,7 +13,7 @@ namespace PInvoke
     {
         /// <summary>
         /// Represents a preparsed data handle created by
-        /// <see cref="OpenSCManager(string,string,ServiceManagerAccess)"/> or <see cref="OpenService(SafeServiceHandle,string,ServiceAccess)"/>
+        /// <see cref="OpenSCManager(string,string,Kernel32.ACCESS_MASK)"/> or <see cref="OpenService(SafeServiceHandle,string,Kernel32.ACCESS_MASK)"/>
         /// that can be closed with <see cref="CloseServiceHandle"/>.
         /// </summary>
         public class SafeServiceHandle : SafeHandle

--- a/src/AdvApi32.Shared/AdvApi32+ServiceAccess.cs
+++ b/src/AdvApi32.Shared/AdvApi32+ServiceAccess.cs
@@ -3,7 +3,6 @@
 
 namespace PInvoke
 {
-    using System;
     using static Kernel32;
     using static Kernel32.ACCESS_MASK.StandardRight;
 
@@ -15,28 +14,27 @@ namespace PInvoke
         /// <summary>
         /// Enumerates the <see cref="ACCESS_MASK.SpecificRights"/> that may apply to services.
         /// </summary>
-        [Flags]
-        public enum ServiceAccess : uint
+        public static class ServiceAccess
         {
-            SERVICE_QUERY_CONFIG = 0x0001,
-            SERVICE_CHANGE_CONFIG = 0x0002,
-            SERVICE_QUERY_STATUS = 0x0004,
-            SERVICE_ENUMERATE_DEPENDENTS = 0x0008,
-            SERVICE_START = 0x0010,
-            SERVICE_STOP = 0x0020,
-            SERVICE_PAUSE_CONTINUE = 0x0040,
-            SERVICE_INTERROGATE = 0x0080,
-            SERVICE_USER_DEFINED_CONTROL = 0x0100,
-            SERVICE_ALL_ACCESS = STANDARD_RIGHTS_REQUIRED |
-                                 SERVICE_QUERY_CONFIG |
-                                 SERVICE_CHANGE_CONFIG |
-                                 SERVICE_QUERY_STATUS |
-                                 SERVICE_ENUMERATE_DEPENDENTS |
-                                 SERVICE_START |
-                                 SERVICE_STOP |
-                                 SERVICE_PAUSE_CONTINUE |
-                                 SERVICE_INTERROGATE |
-                                 SERVICE_USER_DEFINED_CONTROL
+            public const uint SERVICE_QUERY_CONFIG = 0x0001;
+            public const uint SERVICE_CHANGE_CONFIG = 0x0002;
+            public const uint SERVICE_QUERY_STATUS = 0x0004;
+            public const uint SERVICE_ENUMERATE_DEPENDENTS = 0x0008;
+            public const uint SERVICE_START = 0x0010;
+            public const uint SERVICE_STOP = 0x0020;
+            public const uint SERVICE_PAUSE_CONTINUE = 0x0040;
+            public const uint SERVICE_INTERROGATE = 0x0080;
+            public const uint SERVICE_USER_DEFINED_CONTROL = 0x0100;
+            public const uint SERVICE_ALL_ACCESS = (uint)STANDARD_RIGHTS_REQUIRED |
+                                                         SERVICE_QUERY_CONFIG |
+                                                         SERVICE_CHANGE_CONFIG |
+                                                         SERVICE_QUERY_STATUS |
+                                                         SERVICE_ENUMERATE_DEPENDENTS |
+                                                         SERVICE_START |
+                                                         SERVICE_STOP |
+                                                         SERVICE_PAUSE_CONTINUE |
+                                                         SERVICE_INTERROGATE |
+                                                         SERVICE_USER_DEFINED_CONTROL;
         }
     }
 }

--- a/src/AdvApi32.Shared/AdvApi32+ServiceAccess.cs
+++ b/src/AdvApi32.Shared/AdvApi32+ServiceAccess.cs
@@ -4,6 +4,8 @@
 namespace PInvoke
 {
     using System;
+    using static Kernel32;
+    using static Kernel32.ACCESS_MASK.StandardRight;
 
     /// <content>
     /// Contains the <see cref="ServiceAccess"/> nested enum.
@@ -11,23 +13,11 @@ namespace PInvoke
     public partial class AdvApi32
     {
         /// <summary>
-        /// Describes service access flags.
+        /// Enumerates the <see cref="ACCESS_MASK.SpecificRights"/> that may apply to services.
         /// </summary>
         [Flags]
         public enum ServiceAccess : uint
         {
-            GenericRead = 0x80000000,
-            GenericWrite = 0x40000000,
-            GenericExecute = 0x20000000,
-
-            AccessSystemSecurity = 0x1000000,
-            Delete = 0x10000,
-            ReadControl = 0x20000,
-            WriteDAC = 0x40000,
-            WriteOwner = 0x80000,
-
-            STANDARD_RIGHTS_REQUIRED = 0xF0000,
-
             SERVICE_QUERY_CONFIG = 0x0001,
             SERVICE_CHANGE_CONFIG = 0x0002,
             SERVICE_QUERY_STATUS = 0x0004,
@@ -38,15 +28,15 @@ namespace PInvoke
             SERVICE_INTERROGATE = 0x0080,
             SERVICE_USER_DEFINED_CONTROL = 0x0100,
             SERVICE_ALL_ACCESS = STANDARD_RIGHTS_REQUIRED |
-                                        SERVICE_QUERY_CONFIG |
-                                        SERVICE_CHANGE_CONFIG |
-                                        SERVICE_QUERY_STATUS |
-                                        SERVICE_ENUMERATE_DEPENDENTS |
-                                        SERVICE_START |
-                                        SERVICE_STOP |
-                                        SERVICE_PAUSE_CONTINUE |
-                                        SERVICE_INTERROGATE |
-                                        SERVICE_USER_DEFINED_CONTROL
+                                 SERVICE_QUERY_CONFIG |
+                                 SERVICE_CHANGE_CONFIG |
+                                 SERVICE_QUERY_STATUS |
+                                 SERVICE_ENUMERATE_DEPENDENTS |
+                                 SERVICE_START |
+                                 SERVICE_STOP |
+                                 SERVICE_PAUSE_CONTINUE |
+                                 SERVICE_INTERROGATE |
+                                 SERVICE_USER_DEFINED_CONTROL
         }
     }
 }

--- a/src/AdvApi32.Shared/AdvApi32+ServiceManagerAccess.cs
+++ b/src/AdvApi32.Shared/AdvApi32+ServiceManagerAccess.cs
@@ -3,7 +3,6 @@
 
 namespace PInvoke
 {
-    using System;
     using static Kernel32;
     using static Kernel32.ACCESS_MASK.StandardRight;
 
@@ -15,22 +14,21 @@ namespace PInvoke
         /// <summary>
         /// Enumerates the <see cref="ACCESS_MASK.SpecificRights"/> that may apply to service managers.
         /// </summary>
-        [Flags]
-        public enum ServiceManagerAccess : uint
+        public static class ServiceManagerAccess
         {
-            SC_MANAGER_CONNECT = 0x0001,
-            SC_MANAGER_CREATE_SERVICE = 0x0002,
-            SC_MANAGER_ENUMERATE_SERVICE = 0x0004,
-            SC_MANAGER_LOCK = 0x0008,
-            SC_MANAGER_QUERY_LOCK_STATUS = 0x0010,
-            SC_MANAGER_MODIFY_BOOT_CONFIG = 0x0020,
-            SC_MANAGER_ALL_ACCESS = STANDARD_RIGHTS_REQUIRED |
-                                    SC_MANAGER_CONNECT |
-                                    SC_MANAGER_CREATE_SERVICE |
-                                    SC_MANAGER_ENUMERATE_SERVICE |
-                                    SC_MANAGER_LOCK |
-                                    SC_MANAGER_QUERY_LOCK_STATUS |
-                                    SC_MANAGER_MODIFY_BOOT_CONFIG
+            public const uint SC_MANAGER_CONNECT = 0x0001;
+            public const uint SC_MANAGER_CREATE_SERVICE = 0x0002;
+            public const uint SC_MANAGER_ENUMERATE_SERVICE = 0x0004;
+            public const uint SC_MANAGER_LOCK = 0x0008;
+            public const uint SC_MANAGER_QUERY_LOCK_STATUS = 0x0010;
+            public const uint SC_MANAGER_MODIFY_BOOT_CONFIG = 0x0020;
+            public const uint SC_MANAGER_ALL_ACCESS = (uint)STANDARD_RIGHTS_REQUIRED |
+                                                            SC_MANAGER_CONNECT |
+                                                            SC_MANAGER_CREATE_SERVICE |
+                                                            SC_MANAGER_ENUMERATE_SERVICE |
+                                                            SC_MANAGER_LOCK |
+                                                            SC_MANAGER_QUERY_LOCK_STATUS |
+                                                            SC_MANAGER_MODIFY_BOOT_CONFIG;
         }
     }
 }

--- a/src/AdvApi32.Shared/AdvApi32+ServiceManagerAccess.cs
+++ b/src/AdvApi32.Shared/AdvApi32+ServiceManagerAccess.cs
@@ -4,6 +4,8 @@
 namespace PInvoke
 {
     using System;
+    using static Kernel32;
+    using static Kernel32.ACCESS_MASK.StandardRight;
 
     /// <content>
     /// Contains the <see cref="ServiceManagerAccess"/> nested enum.
@@ -11,23 +13,11 @@ namespace PInvoke
     public partial class AdvApi32
     {
         /// <summary>
-        /// Describes service manager access flags.
+        /// Enumerates the <see cref="ACCESS_MASK.SpecificRights"/> that may apply to service managers.
         /// </summary>
         [Flags]
         public enum ServiceManagerAccess : uint
         {
-            GenericRead = 0x80000000,
-            GenericWrite = 0x40000000,
-            GenericExecute = 0x20000000,
-
-            AccessSystemSecurity = 0x1000000,
-            Delete = 0x10000,
-            ReadControl = 0x20000,
-            WriteDAC = 0x40000,
-            WriteOwner = 0x80000,
-
-            STANDARD_RIGHTS_REQUIRED = 0xF0000,
-
             SC_MANAGER_CONNECT = 0x0001,
             SC_MANAGER_CREATE_SERVICE = 0x0002,
             SC_MANAGER_ENUMERATE_SERVICE = 0x0004,
@@ -35,12 +25,12 @@ namespace PInvoke
             SC_MANAGER_QUERY_LOCK_STATUS = 0x0010,
             SC_MANAGER_MODIFY_BOOT_CONFIG = 0x0020,
             SC_MANAGER_ALL_ACCESS = STANDARD_RIGHTS_REQUIRED |
-                                        SC_MANAGER_CONNECT |
-                                        SC_MANAGER_CREATE_SERVICE |
-                                        SC_MANAGER_ENUMERATE_SERVICE |
-                                        SC_MANAGER_LOCK |
-                                        SC_MANAGER_QUERY_LOCK_STATUS |
-                                        SC_MANAGER_MODIFY_BOOT_CONFIG
+                                    SC_MANAGER_CONNECT |
+                                    SC_MANAGER_CREATE_SERVICE |
+                                    SC_MANAGER_ENUMERATE_SERVICE |
+                                    SC_MANAGER_LOCK |
+                                    SC_MANAGER_QUERY_LOCK_STATUS |
+                                    SC_MANAGER_MODIFY_BOOT_CONFIG
         }
     }
 }

--- a/src/AdvApi32.Shared/AdvApi32+TokenAccessRights.cs
+++ b/src/AdvApi32.Shared/AdvApi32+TokenAccessRights.cs
@@ -4,6 +4,8 @@
 namespace PInvoke
 {
     using System;
+    using static Kernel32;
+    using static Kernel32.ACCESS_MASK.StandardRight;
 
     /// <content>
     /// Contains the <see cref="TokenAccessRights"/> nested type.
@@ -11,38 +13,11 @@ namespace PInvoke
     public partial class AdvApi32
     {
         /// <summary>
-        /// The different access rights allowed to access an access token.
+        /// Enumerates the <see cref="ACCESS_MASK.SpecificRights"/> that may apply to tokens.
         /// </summary>
         [Flags]
         public enum TokenAccessRights : uint
         {
-            /// <summary>The right to delete the object.</summary>
-            DELETE = 0x00010000,
-
-            /// <summary>
-            ///     The right to read the information in the object's security descriptor, not including the information in the
-            ///     system access control list (SACL).
-            /// </summary>
-            READ_CONTROL = 0x00020000,
-
-            /// <summary>The right to modify the discretionary access control list (DACL) in the object's security descriptor.</summary>
-            WRITE_DAC = 0x00040000,
-
-            /// <summary>The right to change the owner in the object's security descriptor.</summary>
-            WRITE_OWNER = 0x00080000,
-
-            /// <summary>Combines DELETE, READ_CONTROL, WRITE_DAC, and WRITE_OWNER access.</summary>
-            STANDARD_RIGHTS_REQUIRED = 0x000F0000,
-
-            /// <summary>Currently defined to equal READ_CONTROL.</summary>
-            STANDARD_RIGHTS_READ = READ_CONTROL,
-
-            /// <summary>Currently defined to equal READ_CONTROL.</summary>
-            STANDARD_RIGHTS_WRITE = READ_CONTROL,
-
-            /// <summary>Currently defined to equal READ_CONTROL.</summary>
-            STANDARD_RIGHTS_EXECUTE = READ_CONTROL,
-
             /// <summary>
             ///     Required to attach a primary token to a process. The SE_ASSIGNPRIMARYTOKEN_NAME privilege is also required to
             ///     accomplish this task.
@@ -78,9 +53,6 @@ namespace PInvoke
 
             /// <summary>Combines STANDARD_RIGHTS_WRITE, TOKEN_ADJUST_PRIVILEGES, TOKEN_ADJUST_GROUPS, and TOKEN_ADJUST_DEFAULT.</summary>
             TOKEN_WRITE = STANDARD_RIGHTS_WRITE | TOKEN_ADJUST_PRIVILEGES | TOKEN_ADJUST_GROUPS | TOKEN_ADJUST_DEFAULT,
-
-            /// <summary>Required to wait for the process to terminate using the wait functions.</summary>
-            ACCESS_SYSTEM_SECURITY = 0x01000000,
 
             /// <summary>Combines STANDARD_RIGHTS_EXECUTE and TOKEN_IMPERSONATE.</summary>
             TOKEN_EXECUTE = STANDARD_RIGHTS_EXECUTE | TOKEN_IMPERSONATE,

--- a/src/AdvApi32.Shared/AdvApi32+TokenAccessRights.cs
+++ b/src/AdvApi32.Shared/AdvApi32+TokenAccessRights.cs
@@ -3,7 +3,6 @@
 
 namespace PInvoke
 {
-    using System;
     using static Kernel32;
     using static Kernel32.ACCESS_MASK.StandardRight;
 
@@ -15,58 +14,57 @@ namespace PInvoke
         /// <summary>
         /// Enumerates the <see cref="ACCESS_MASK.SpecificRights"/> that may apply to tokens.
         /// </summary>
-        [Flags]
-        public enum TokenAccessRights : uint
+        public static class TokenAccessRights
         {
             /// <summary>
             ///     Required to attach a primary token to a process. The SE_ASSIGNPRIMARYTOKEN_NAME privilege is also required to
             ///     accomplish this task.
             /// </summary>
-            TOKEN_ASSIGN_PRIMARY = 0x0001,
+            public const uint TOKEN_ASSIGN_PRIMARY = 0x0001;
 
             /// <summary>Required to duplicate an access token.</summary>
-            TOKEN_DUPLICATE = 0x0002,
+            public const uint TOKEN_DUPLICATE = 0x0002;
 
             /// <summary>Required to attach an impersonation access token to a process.</summary>
-            TOKEN_IMPERSONATE = 0x0004,
+            public const uint TOKEN_IMPERSONATE = 0x0004;
 
             /// <summary>Required to query an access token.</summary>
-            TOKEN_QUERY = 0x0008,
+            public const uint TOKEN_QUERY = 0x0008;
 
             /// <summary>Required to query the source of an access token.</summary>
-            TOKEN_QUERY_SOURCE = 0x0010,
+            public const uint TOKEN_QUERY_SOURCE = 0x0010;
 
             /// <summary>Required to enable or disable the privileges in an access token.</summary>
-            TOKEN_ADJUST_PRIVILEGES = 0x0020,
+            public const uint TOKEN_ADJUST_PRIVILEGES = 0x0020;
 
             /// <summary>Required to adjust the attributes of the groups in an access token.</summary>
-            TOKEN_ADJUST_GROUPS = 0x0040,
+            public const uint TOKEN_ADJUST_GROUPS = 0x0040;
 
             /// <summary>Required to change the default owner, primary group, or DACL of an access token.</summary>
-            TOKEN_ADJUST_DEFAULT = 0x0080,
+            public const uint TOKEN_ADJUST_DEFAULT = 0x0080;
 
             /// <summary>Required to adjust the session ID of an access token. The SE_TCB_NAME privilege is required.</summary>
-            TOKEN_ADJUST_SESSIONID = 0x0100,
+            public const uint TOKEN_ADJUST_SESSIONID = 0x0100;
 
             /// <summary>Combines STANDARD_RIGHTS_READ and TOKEN_QUERY.</summary>
-            TOKEN_READ = STANDARD_RIGHTS_READ | TOKEN_QUERY,
+            public const uint TOKEN_READ = (uint)STANDARD_RIGHTS_READ | TOKEN_QUERY;
 
             /// <summary>Combines STANDARD_RIGHTS_WRITE, TOKEN_ADJUST_PRIVILEGES, TOKEN_ADJUST_GROUPS, and TOKEN_ADJUST_DEFAULT.</summary>
-            TOKEN_WRITE = STANDARD_RIGHTS_WRITE | TOKEN_ADJUST_PRIVILEGES | TOKEN_ADJUST_GROUPS | TOKEN_ADJUST_DEFAULT,
+            public const uint TOKEN_WRITE = (uint)STANDARD_RIGHTS_WRITE | TOKEN_ADJUST_PRIVILEGES | TOKEN_ADJUST_GROUPS | TOKEN_ADJUST_DEFAULT;
 
             /// <summary>Combines STANDARD_RIGHTS_EXECUTE and TOKEN_IMPERSONATE.</summary>
-            TOKEN_EXECUTE = STANDARD_RIGHTS_EXECUTE | TOKEN_IMPERSONATE,
+            public const uint TOKEN_EXECUTE = (uint)STANDARD_RIGHTS_EXECUTE | TOKEN_IMPERSONATE;
 
             /// <summary>Combines all possible access rights for a token.</summary>
-            TOKEN_ALL_ACCESS = STANDARD_RIGHTS_REQUIRED |
-                               TOKEN_ASSIGN_PRIMARY |
-                               TOKEN_DUPLICATE |
-                               TOKEN_IMPERSONATE |
-                               TOKEN_QUERY |
-                               TOKEN_QUERY_SOURCE |
-                               TOKEN_ADJUST_PRIVILEGES |
-                               TOKEN_ADJUST_GROUPS |
-                               TOKEN_ADJUST_DEFAULT
+            public const uint TOKEN_ALL_ACCESS = (uint)STANDARD_RIGHTS_REQUIRED |
+                                                       TOKEN_ASSIGN_PRIMARY |
+                                                       TOKEN_DUPLICATE |
+                                                       TOKEN_IMPERSONATE |
+                                                       TOKEN_QUERY |
+                                                       TOKEN_QUERY_SOURCE |
+                                                       TOKEN_ADJUST_PRIVILEGES |
+                                                       TOKEN_ADJUST_GROUPS |
+                                                       TOKEN_ADJUST_DEFAULT;
         }
     }
 }

--- a/src/AdvApi32.Shared/AdvApi32.Helpers.cs
+++ b/src/AdvApi32.Shared/AdvApi32.Helpers.cs
@@ -62,7 +62,7 @@ namespace PInvoke
                 throw new ArgumentException("Service name must not be null nor empty", nameof(lpServiceName));
             }
 
-            using (SafeServiceHandle scmHandle = OpenSCManager(null, null, (uint)ServiceManagerAccess.SC_MANAGER_CREATE_SERVICE))
+            using (SafeServiceHandle scmHandle = OpenSCManager(null, null, ServiceManagerAccess.SC_MANAGER_CREATE_SERVICE))
             {
                 if (scmHandle.IsInvalid)
                 {
@@ -73,7 +73,7 @@ namespace PInvoke
                     scmHandle,
                     lpServiceName,
                     lpDisplayName,
-                    (uint)ServiceAccess.SERVICE_ALL_ACCESS,
+                    ServiceAccess.SERVICE_ALL_ACCESS,
                     ServiceType.SERVICE_WIN32_OWN_PROCESS,
                     ServiceStartType.SERVICE_DEMAND_START,
                     ServiceErrorControl.SERVICE_ERROR_NORMAL,

--- a/src/AdvApi32.Shared/AdvApi32.Helpers.cs
+++ b/src/AdvApi32.Shared/AdvApi32.Helpers.cs
@@ -62,7 +62,7 @@ namespace PInvoke
                 throw new ArgumentException("Service name must not be null nor empty", nameof(lpServiceName));
             }
 
-            using (SafeServiceHandle scmHandle = OpenSCManager(null, null, ServiceManagerAccess.SC_MANAGER_CREATE_SERVICE))
+            using (SafeServiceHandle scmHandle = OpenSCManager(null, null, (uint)ServiceManagerAccess.SC_MANAGER_CREATE_SERVICE))
             {
                 if (scmHandle.IsInvalid)
                 {
@@ -73,7 +73,7 @@ namespace PInvoke
                     scmHandle,
                     lpServiceName,
                     lpDisplayName,
-                    ServiceAccess.SERVICE_ALL_ACCESS,
+                    (uint)ServiceAccess.SERVICE_ALL_ACCESS,
                     ServiceType.SERVICE_WIN32_OWN_PROCESS,
                     ServiceStartType.SERVICE_DEMAND_START,
                     ServiceErrorControl.SERVICE_ERROR_NORMAL,
@@ -114,7 +114,7 @@ namespace PInvoke
         /// Marks the specified service for deletion from the service control manager database on the local computer.
         /// </summary>
         /// <param name="lpServiceName">
-        /// The name of the service to be opened. This is the name specified by the lpServiceName parameter of the <see cref="CreateService(SafeServiceHandle,string,string,ServiceAccess,ServiceType,ServiceStartType,ServiceErrorControl,string,string,int, string,string,string)"/> function when the service object was created,
+        /// The name of the service to be opened. This is the name specified by the lpServiceName parameter of the <see cref="CreateService(SafeServiceHandle,string,string,ACCESS_MASK,ServiceType,ServiceStartType,ServiceErrorControl,string,string,int, string,string,string)"/> function when the service object was created,
         /// not the service display name that is shown by user interface applications to identify the service.
         /// The maximum string length is 256 characters. The service control manager database preserves the case of the characters,
         /// but service name comparisons are always case insensitive. Forward-slash (/) and backslash (\) are invalid service name characters.
@@ -128,14 +128,14 @@ namespace PInvoke
                 throw new ArgumentException("Service name must not be null nor empty", nameof(lpServiceName));
             }
 
-            using (SafeServiceHandle scmHandle = OpenSCManager(null, null, ServiceManagerAccess.GenericWrite))
+            using (SafeServiceHandle scmHandle = OpenSCManager(null, null, ACCESS_MASK.GenericRight.GENERIC_WRITE))
             {
                 if (scmHandle.IsInvalid)
                 {
                     throw new Win32Exception();
                 }
 
-                using (SafeServiceHandle svcHandle = OpenService(scmHandle, lpServiceName, ServiceAccess.Delete))
+                using (SafeServiceHandle svcHandle = OpenService(scmHandle, lpServiceName, ACCESS_MASK.StandardRight.DELETE))
                 {
                     if (svcHandle.IsInvalid)
                     {

--- a/src/AdvApi32.Shared/AdvApi32.cs
+++ b/src/AdvApi32.Shared/AdvApi32.cs
@@ -441,6 +441,7 @@ namespace PInvoke
         ///     Specifies an access mask that specifies the requested types of access to the access token.
         ///     These requested access types are compared with the discretionary access control list (DACL) of the token to
         ///     determine which accesses are granted or denied.
+        ///     Common specific rights are defined in <seealso cref="TokenAccessRights"/>.
         /// </param>
         /// <param name="tokenHandle">A handle that identifies the newly opened access token when the function returns.</param>
         /// <returns>
@@ -454,7 +455,7 @@ namespace PInvoke
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool OpenProcessToken(
             IntPtr processHandle,
-            TokenAccessRights desiredAccess,
+            ACCESS_MASK desiredAccess,
             out SafeObjectHandle tokenHandle);
 
         /// <summary>

--- a/src/AdvApi32.Shared/AdvApi32.cs
+++ b/src/AdvApi32.Shared/AdvApi32.cs
@@ -45,7 +45,7 @@ namespace PInvoke
         /// </summary>
         /// <param name="hService">
         /// A handle to the service.
-        /// This handle is returned by the <see cref="OpenService"/> or <see cref="CreateService(SafeServiceHandle,string,string,ServiceAccess,ServiceType,ServiceStartType,ServiceErrorControl,string,string,int, string,string,string)"/> function and
+        /// This handle is returned by the <see cref="OpenService"/> or <see cref="CreateService(SafeServiceHandle,string,string,ACCESS_MASK,ServiceType,ServiceStartType,ServiceErrorControl,string,string,int, string,string,string)"/> function and
         /// must have the <see cref="ServiceAccess.SERVICE_CHANGE_CONFIG"/> access right.
         /// </param>
         /// <param name="dwServiceType">
@@ -199,7 +199,7 @@ namespace PInvoke
         /// </summary>
         /// <param name="hService">
         /// A handle to the service.
-        /// This handle is returned by the <see cref="OpenService"/> or <see cref="CreateService(SafeServiceHandle,string,string,ServiceAccess,ServiceType,ServiceStartType,ServiceErrorControl,string,string,int, string,string,string)"/> function and
+        /// This handle is returned by the <see cref="OpenService"/> or <see cref="CreateService(SafeServiceHandle,string,string,ACCESS_MASK,ServiceType,ServiceStartType,ServiceErrorControl,string,string,int, string,string,string)"/> function and
         /// must have the <see cref="ServiceAccess.SERVICE_CHANGE_CONFIG"/> access right.
         /// </param>
         /// <param name="dwInfoLevel">
@@ -224,7 +224,7 @@ namespace PInvoke
         /// To specify additional information when stopping a service, use the ControlServiceEx function.
         /// </summary>
         /// <param name="hService">
-        /// A handle to the service. This handle is returned by the <see cref="OpenService"/> or <see cref="CreateService(SafeServiceHandle,string,string,ServiceAccess,ServiceType,ServiceStartType,ServiceErrorControl,string,string,int, string,string,string)"/> function.
+        /// A handle to the service. This handle is returned by the <see cref="OpenService"/> or <see cref="CreateService(SafeServiceHandle,string,string,ACCESS_MASK,ServiceType,ServiceStartType,ServiceErrorControl,string,string,int, string,string,string)"/> function.
         /// The access rights required for this handle depend on the <paramref name="dwControl"/> code requested.
         /// </param>
         /// <param name="dwControl">
@@ -297,8 +297,8 @@ namespace PInvoke
         /// Display name comparisons are always case-insensitive.
         /// </param>
         /// <param name="dwDesiredAccess">
-        /// The access to the service (<see cref="ServiceAccess"/>).
         /// Before granting the requested access, the system checks the access token of the calling process.
+        /// Common specific rights are defined in <seealso cref="ServiceAccess"/>.
         /// </param>
         /// <param name="dwServiceType">
         /// The service type (<see cref="ServiceType"/>).
@@ -348,13 +348,13 @@ namespace PInvoke
         /// If the function fails, the return value is NULL
         /// </returns>
         [DllImport(api_ms_win_service_management_l1_1_0, SetLastError = true, CharSet = CharSet.Unicode)]
-        public static extern SafeServiceHandle CreateService(SafeServiceHandle hSCManager, string lpServiceName, string lpDisplayName, ServiceAccess dwDesiredAccess, ServiceType dwServiceType, ServiceStartType dwStartType, ServiceErrorControl dwErrorControl, string lpBinaryPathName, string lpLoadOrderGroup, int lpdwTagId, string lpDependencies, string lpServiceStartName, string lpPassword);
+        public static extern SafeServiceHandle CreateService(SafeServiceHandle hSCManager, string lpServiceName, string lpDisplayName, ACCESS_MASK dwDesiredAccess, ServiceType dwServiceType, ServiceStartType dwStartType, ServiceErrorControl dwErrorControl, string lpBinaryPathName, string lpLoadOrderGroup, int lpdwTagId, string lpDependencies, string lpServiceStartName, string lpPassword);
 
         /// <summary>
         /// Marks the specified service for deletion from the service control manager database.
         /// </summary>
         /// <param name="hService">
-        /// A handle to the service. This handle is returned by the <see cref="OpenService"/> or <see cref="CreateService(SafeServiceHandle,string,string,ServiceAccess,ServiceType,ServiceStartType,ServiceErrorControl,string,string,int, string,string,string)"/> function, and it must have the <see cref="ServiceAccess.Delete"/> access right
+        /// A handle to the service. This handle is returned by the <see cref="OpenService"/> or <see cref="CreateService(SafeServiceHandle,string,string,ACCESS_MASK,ServiceType,ServiceStartType,ServiceErrorControl,string,string,int, string,string,string)"/> function, and it must have the <see cref="ACCESS_MASK.StandardRight.DELETE"/> access right
         /// </param>
         /// <returns>
         /// If the function succeeds, the return value is nonzero.
@@ -381,13 +381,14 @@ namespace PInvoke
         /// The access to the service control manager. For a list of access rights, see Service Security and Access Rights.
         /// Before granting the requested access rights, the system checks the access token of the calling process against the discretionary access-control list of the security descriptor associated with the service control manager.
         /// The <see cref="ServiceManagerAccess.SC_MANAGER_CONNECT"/> access right is implicitly specified by calling this function.
+        /// Common specific rights are defined in <seealso cref="ServiceManagerAccess"/>.
         /// </param>
         /// <returns>
         /// If the function succeeds, the return value is a handle to the specified service control manager database.
         /// If the function fails, the return value is NULL.To get extended error information, call <see cref="Kernel32.GetLastError"/>.
         /// </returns>
         [DllImport(api_ms_win_service_management_l1_1_0, SetLastError = true, CharSet = CharSet.Unicode)]
-        public static extern SafeServiceHandle OpenSCManager(string lpMachineName, string lpDatabaseName, ServiceManagerAccess dwDesiredAccess);
+        public static extern SafeServiceHandle OpenSCManager(string lpMachineName, string lpDatabaseName, ACCESS_MASK dwDesiredAccess);
 
         /// <summary>
         /// Opens an existing service.
@@ -400,21 +401,21 @@ namespace PInvoke
         /// The maximum string length is 256 characters.The service control manager database preserves the case of the characters, but service name comparisons are always case insensitive.Forward-slash(/) and backslash(\) are invalid service name characters.
         /// </param>
         /// <param name="dwDesiredAccess">
-        /// The access to the service (<see cref="ServiceAccess"/>).
         /// Before granting the requested access, the system checks the access token of the calling process against the discretionary access-control list of the security descriptor associated with the service object.
+        /// Common specific rights are defined in <seealso cref="ServiceAccess"/>.
         /// </param>
         /// <returns>
         /// If the function succeeds, the return value is a handle to the service.
         /// If the function fails, the return value is NULL.
         /// </returns>
         [DllImport(api_ms_win_service_management_l1_1_0, SetLastError = true, CharSet = CharSet.Unicode)]
-        public static extern SafeServiceHandle OpenService(SafeServiceHandle hSCManager, string lpServiceName, ServiceAccess dwDesiredAccess);
+        public static extern SafeServiceHandle OpenService(SafeServiceHandle hSCManager, string lpServiceName, ACCESS_MASK dwDesiredAccess);
 
         /// <summary>
         /// Starts a service.
         /// </summary>
         /// <param name="hService">
-        /// A handle to the service. This handle is returned by the <see cref="OpenService"/> or <see cref="CreateService(SafeServiceHandle,string,string,ServiceAccess,ServiceType,ServiceStartType,ServiceErrorControl,string,string,int, string,string,string)"/> function, and it must have the <see cref="ServiceAccess.SERVICE_START"/> access right.
+        /// A handle to the service. This handle is returned by the <see cref="OpenService"/> or <see cref="CreateService(SafeServiceHandle,string,string,ACCESS_MASK,ServiceType,ServiceStartType,ServiceErrorControl,string,string,int, string,string,string)"/> function, and it must have the <see cref="ServiceAccess.SERVICE_START"/> access right.
         /// </param>
         /// <param name="dwNumServiceArgs">
         /// The number of strings in the lpServiceArgVectors array. If lpServiceArgVectors is NULL, this parameter can be zero.
@@ -518,7 +519,7 @@ namespace PInvoke
         /// <param name="hService">
         ///     A handle to the service control manager or the service. Handles to the service control manager
         ///     are returned by the <see cref="OpenSCManager" /> function, and handles to a service are returned by either the
-        ///     <see cref="OpenService" /> or <see cref="CreateService(SafeServiceHandle,string,string,ServiceAccess,ServiceType,ServiceStartType,ServiceErrorControl,string,string,int, string,string,string)" /> function. The handle must have the READ_CONTROL access
+        ///     <see cref="OpenService" /> or <see cref="CreateService(SafeServiceHandle,string,string,ACCESS_MASK,ServiceType,ServiceStartType,ServiceErrorControl,string,string,int, string,string,string)" /> function. The handle must have the READ_CONTROL access
         ///     right.
         /// </param>
         /// <param name="dwSecurityInformation">
@@ -559,7 +560,7 @@ namespace PInvoke
         /// This function has been superseded by the QueryServiceStatusEx function. QueryServiceStatusEx returns the same information <see cref="QueryServiceStatus"/> returns, with the addition of the process identifier and additional information for the service.
         /// </summary>
         /// <param name="hService">
-        /// A handle to the service. This handle is returned by the <see cref="OpenService"/> or the <see cref="CreateService(SafeServiceHandle,string,string,ServiceAccess,ServiceType,ServiceStartType,ServiceErrorControl,string,string,int, string,string,string)"/> function, and it must have the <see cref="ServiceAccess.SERVICE_QUERY_STATUS"/> access right.
+        /// A handle to the service. This handle is returned by the <see cref="OpenService"/> or the <see cref="CreateService(SafeServiceHandle,string,string,ACCESS_MASK,ServiceType,ServiceStartType,ServiceErrorControl,string,string,int, string,string,string)"/> function, and it must have the <see cref="ServiceAccess.SERVICE_QUERY_STATUS"/> access right.
         /// </param>
         /// <param name="dwServiceStatus">
         /// A pointer to a <see cref="SERVICE_STATUS"/> structure that receives the status information.
@@ -575,7 +576,7 @@ namespace PInvoke
         /// <summary>The SetServiceObjectSecurity function sets the security descriptor of a service object.</summary>
         /// <param name="hService">
         ///     A handle to the service. This handle is returned by the <see cref="OpenService" /> or
-        ///     <see cref="CreateService(SafeServiceHandle,string,string,ServiceAccess,ServiceType,ServiceStartType,ServiceErrorControl,string,string,int, string,string,string)" /> function. The access required for this handle depends on the security information
+        ///     <see cref="CreateService(SafeServiceHandle,string,string,ACCESS_MASK,ServiceType,ServiceStartType,ServiceErrorControl,string,string,int, string,string,string)" /> function. The access required for this handle depends on the security information
         ///     specified in the <paramref name="dwSecurityInformation" /> parameter.
         /// </param>
         /// <param name="dwSecurityInformation">
@@ -639,7 +640,7 @@ namespace PInvoke
         /// <param name="hSCObject">
         /// A handle to the service control manager object or the service object to close.
         /// Handles to service control manager objects are returned by the <see cref="OpenSCManager"/> function,
-        /// and handles to service objects are returned by either the <see cref="OpenService"/> or <see cref="CreateService(SafeServiceHandle,string,string,ServiceAccess,ServiceType,ServiceStartType,ServiceErrorControl,string,string,int, string,string,string)"/> function.
+        /// and handles to service objects are returned by either the <see cref="OpenService"/> or <see cref="CreateService(SafeServiceHandle,string,string,ACCESS_MASK,ServiceType,ServiceStartType,ServiceErrorControl,string,string,int, string,string,string)"/> function.
         /// </param>
         /// <returns>
         /// If the function succeeds, the return value is nonzero.

--- a/src/Kernel32.Desktop/Kernel32+CreateFileFlags.cs
+++ b/src/Kernel32.Desktop/Kernel32+CreateFileFlags.cs
@@ -11,7 +11,7 @@ namespace PInvoke
     public partial class Kernel32
     {
         /// <summary>
-        /// File attributes, flags, and security settings that are passed to the <see cref="CreateFile(string, FileAccess, FileShare, SECURITY_ATTRIBUTES*, CreationDisposition, CreateFileFlags, SafeObjectHandle)"/> method.
+        /// File attributes, flags, and security settings that are passed to the <see cref="CreateFile(string, ACCESS_MASK, FileShare, SECURITY_ATTRIBUTES*, CreationDisposition, CreateFileFlags, SafeObjectHandle)"/> method.
         /// </summary>
         [Flags]
         public enum CreateFileFlags : uint
@@ -78,7 +78,7 @@ namespace PInvoke
             /// <summary>
             ///     The file or device is being opened with no system caching for data reads and writes. This flag does not affect
             ///     hard disk caching or memory mapped files. There are strict requirements for successfully working with files opened
-            ///     with <see cref="CreateFile(string, FileAccess, FileShare, SECURITY_ATTRIBUTES*, CreationDisposition, CreateFileFlags, SafeObjectHandle)" /> using the <see cref="FILE_FLAG_NO_BUFFERING" /> flag, for details see File
+            ///     with <see cref="CreateFile(string, ACCESS_MASK, FileShare, SECURITY_ATTRIBUTES*, CreationDisposition, CreateFileFlags, SafeObjectHandle)" /> using the <see cref="FILE_FLAG_NO_BUFFERING" /> flag, for details see File
             ///     Buffering.
             /// </summary>
             FILE_FLAG_NO_BUFFERING = 0x20000000,

--- a/src/Kernel32.Desktop/Kernel32+CreationDisposition.cs
+++ b/src/Kernel32.Desktop/Kernel32+CreationDisposition.cs
@@ -12,7 +12,7 @@ namespace PInvoke
         /// Describes an action to take on a file or device that exists or does not exist.
         /// </summary>
         /// <remarks>
-        /// These are flags to pass to the <see cref="CreateFile(string, FileAccess, FileShare, SECURITY_ATTRIBUTES*, CreationDisposition, CreateFileFlags, SafeObjectHandle)"/> method's dwCreationDisposition parameter.
+        /// These are flags to pass to the <see cref="CreateFile(string, ACCESS_MASK, FileShare, SECURITY_ATTRIBUTES*, CreationDisposition, CreateFileFlags, SafeObjectHandle)"/> method's dwCreationDisposition parameter.
         /// </remarks>
         public enum CreationDisposition : uint
         {

--- a/src/Kernel32.Desktop/Kernel32+FileAccess.cs
+++ b/src/Kernel32.Desktop/Kernel32+FileAccess.cs
@@ -3,7 +3,6 @@
 
 namespace PInvoke
 {
-    using System;
     using static Kernel32.ACCESS_MASK.StandardRight;
 
     /// <content>
@@ -17,76 +16,75 @@ namespace PInvoke
         /// <remarks>
         /// These flags may be passed to <see cref="CreateFile(string, ACCESS_MASK, FileShare, SECURITY_ATTRIBUTES*, CreationDisposition, CreateFileFlags, SafeObjectHandle)"/>.
         /// </remarks>
-        [Flags]
-        public enum FileAccess : uint
+        public static class FileAccess
         {
             /// <summary>
             ///     For a file object, the right to read the corresponding file data. For a directory object, the right to read
             ///     the corresponding directory data.
             /// </summary>
-            FILE_READ_DATA = 0x0001, // file & pipe
+            public const uint FILE_READ_DATA = 0x0001; // file & pipe
 
             /// <summary>For a directory, the right to list the contents of the directory.</summary>
-            FILE_LIST_DIRECTORY = 0x0001, // directory
+            public const uint FILE_LIST_DIRECTORY = 0x0001; // directory
 
             /// <summary>
             ///     For a file object, the right to write data to the file. For a directory object, the right to create a file in
             ///     the directory (<see cref="FILE_ADD_FILE" />).
             /// </summary>
-            FILE_WRITE_DATA = 0x0002, // file & pipe
+            public const uint FILE_WRITE_DATA = 0x0002; // file & pipe
 
             /// <summary>For a directory, the right to create a file in the directory.</summary>
-            FILE_ADD_FILE = 0x0002, // directory
+            public const uint FILE_ADD_FILE = 0x0002; // directory
 
             /// <summary>
             ///     For a file object, the right to append data to the file. (For local files, write operations will not overwrite
             ///     existing data if this flag is specified without <see cref="FILE_WRITE_DATA" />.) For a directory object, the right
             ///     to create a subdirectory (<see cref="FILE_ADD_SUBDIRECTORY" />).
             /// </summary>
-            FILE_APPEND_DATA = 0x0004, // file
+            public const uint FILE_APPEND_DATA = 0x0004; // file
 
             /// <summary>For a directory, the right to create a subdirectory.</summary>
-            FILE_ADD_SUBDIRECTORY = 0x0004, // directory
+            public const uint FILE_ADD_SUBDIRECTORY = 0x0004; // directory
 
             /// <summary>For a named pipe, the right to create a pipe.</summary>
-            FILE_CREATE_PIPE_INSTANCE = 0x0004, // named pipe
+            public const uint FILE_CREATE_PIPE_INSTANCE = 0x0004; // named pipe
 
             /// <summary>The right to read extended file attributes.</summary>
-            FILE_READ_EA = 0x0008, // file & directory
+            public const uint FILE_READ_EA = 0x0008; // file & directory
 
             /// <summary>The right to write extended file attributes.</summary>
-            FILE_WRITE_EA = 0x0010, // file & directory
+            public const uint FILE_WRITE_EA = 0x0010; // file & directory
 
             /// <summary>
             ///     For a native code file, the right to execute the file. This access right given to scripts may cause the script
             ///     to be executable, depending on the script interpreter.
             /// </summary>
-            FILE_EXECUTE = 0x0020, // file
+            public const uint FILE_EXECUTE = 0x0020; // file
 
             /// <summary>
             ///     For a directory, the right to traverse the directory. By default, users are assigned the
             ///     BYPASS_TRAVERSE_CHECKING privilege, which ignores the FILE_TRAVERSE access right.
             /// </summary>
-            FILE_TRAVERSE = 0x0020, // directory
+            public const uint FILE_TRAVERSE = 0x0020; // directory
 
             /// <summary>For a directory, the right to delete a directory and all the files it contains, including read-only files.</summary>
-            FILE_DELETE_CHILD = 0x0040, // directory
+            public const uint FILE_DELETE_CHILD = 0x0040; // directory
 
             /// <summary>The right to read file attributes.</summary>
-            FILE_READ_ATTRIBUTES = 0x0080, // all
+            public const uint FILE_READ_ATTRIBUTES = 0x0080; // all
 
             /// <summary>The right to write file attributes.</summary>
-            FILE_WRITE_ATTRIBUTES = 0x0100, // all
+            public const uint FILE_WRITE_ATTRIBUTES = 0x0100; // all
 
-            SPECIFIC_RIGHTS_ALL = 0x00FFFF,
+            public const uint SPECIFIC_RIGHTS_ALL = 0x00FFFF;
 
-            FILE_ALL_ACCESS = STANDARD_RIGHTS_REQUIRED | SYNCHRONIZE | 0x1FF,
+            public const uint FILE_ALL_ACCESS = (uint)STANDARD_RIGHTS_REQUIRED | (uint)SYNCHRONIZE | 0x1FF;
 
-            FILE_GENERIC_READ = STANDARD_RIGHTS_READ | FILE_READ_DATA | FILE_READ_ATTRIBUTES | FILE_READ_EA | SYNCHRONIZE,
+            public const uint FILE_GENERIC_READ = (uint)STANDARD_RIGHTS_READ | FILE_READ_DATA | FILE_READ_ATTRIBUTES | FILE_READ_EA | (uint)SYNCHRONIZE;
 
-            FILE_GENERIC_WRITE = STANDARD_RIGHTS_WRITE | FILE_WRITE_DATA | FILE_WRITE_ATTRIBUTES | FILE_WRITE_EA | FILE_APPEND_DATA | SYNCHRONIZE,
+            public const uint FILE_GENERIC_WRITE = (uint)STANDARD_RIGHTS_WRITE | FILE_WRITE_DATA | FILE_WRITE_ATTRIBUTES | FILE_WRITE_EA | FILE_APPEND_DATA | (uint)SYNCHRONIZE;
 
-            FILE_GENERIC_EXECUTE = STANDARD_RIGHTS_EXECUTE | FILE_READ_ATTRIBUTES | FILE_EXECUTE | SYNCHRONIZE
+            public const uint FILE_GENERIC_EXECUTE = (uint)STANDARD_RIGHTS_EXECUTE | FILE_READ_ATTRIBUTES | FILE_EXECUTE | (uint)SYNCHRONIZE;
         }
     }
 }

--- a/src/Kernel32.Desktop/Kernel32+FileAccess.cs
+++ b/src/Kernel32.Desktop/Kernel32+FileAccess.cs
@@ -4,7 +4,7 @@
 namespace PInvoke
 {
     using System;
-    using static PInvoke.Kernel32.ACCESS_MASK.StandardRight;
+    using static Kernel32.ACCESS_MASK.StandardRight;
 
     /// <content>
     /// Contains the <see cref="FileAccess"/> nested enum.

--- a/src/Kernel32.Desktop/Kernel32+FileAccess.cs
+++ b/src/Kernel32.Desktop/Kernel32+FileAccess.cs
@@ -4,6 +4,7 @@
 namespace PInvoke
 {
     using System;
+    using static PInvoke.Kernel32.ACCESS_MASK.StandardRight;
 
     /// <content>
     /// Contains the <see cref="FileAccess"/> nested enum.
@@ -11,78 +12,14 @@ namespace PInvoke
     public partial class Kernel32
     {
         /// <summary>
-        /// Describes file access flags that may be passed to <see cref="CreateFile(string, FileAccess, FileShare, SECURITY_ATTRIBUTES*, CreationDisposition, CreateFileFlags, SafeObjectHandle)"/>.
+        /// Enumerates the <see cref="ACCESS_MASK.SpecificRights"/> that may apply to files.
         /// </summary>
+        /// <remarks>
+        /// These flags may be passed to <see cref="CreateFile(string, ACCESS_MASK, FileShare, SECURITY_ATTRIBUTES*, CreationDisposition, CreateFileFlags, SafeObjectHandle)"/>.
+        /// </remarks>
         [Flags]
         public enum FileAccess : uint
         {
-            /// <summary>Read access</summary>
-            GENERIC_READ = 0x80000000,
-
-            /// <summary>Write access</summary>
-            GENERIC_WRITE = 0x40000000,
-
-            /// <summary>Execute access</summary>
-            GENERIC_EXECUTE = 0x20000000,
-
-            /// <summary>All possible access rights</summary>
-            GENERIC_ALL = 0x10000000,
-
-            /// <summary>
-            ///     used to indicate access to a system access control list (SACL). This type of access requires the calling
-            ///     process to have the SE_SECURITY_NAME (Manage auditing and security log) privilege. If this flag is set in the
-            ///     access mask of an audit access ACE (successful or unsuccessful access), the SACL access will be audited.
-            /// </summary>
-            ACCESS_SYSTEM_SECURITY = 0x1000000,
-
-            /// <summary>Maximum allowed</summary>
-            MAXIMUM_ALLOWED = 0x2000000,
-
-            /// <summary>The right to delete the object.</summary>
-            DELETE = 0x10000,
-
-            /// <summary>
-            ///     The right to read the information in the object's security descriptor, not including the information in the
-            ///     system access control list (SACL).
-            /// </summary>
-            READ_CONTROL = 0x20000,
-
-            /// <summary>The right to modify the discretionary access control list (DACL) in the object's security descriptor.</summary>
-            WRITE_DAC = 0x40000,
-
-            /// <summary>The right to change the owner in the object's security descriptor.</summary>
-            WRITE_OWNER = 0x80000,
-
-            /// <summary>
-            ///     The right to use the object for synchronization. This enables a thread to wait until the object is in the
-            ///     signaled state. Some object types do not support this access right.
-            /// </summary>
-            SYNCHRONIZE = 0x100000,
-
-            /// <summary>
-            ///     Combines <see cref="DELETE" />, <see cref="READ_CONTROL" />, <see cref="WRITE_DAC" />, and
-            ///     <see cref="WRITE_OWNER" /> access.
-            /// </summary>
-            STANDARD_RIGHTS_REQUIRED = 0xF0000,
-
-            /// <summary>
-            ///     Includes <see cref="READ_CONTROL" />, which is the right to read the information in the file or directory
-            ///     object's security descriptor. This does not include the information in the SACL.
-            /// </summary>
-            STANDARD_RIGHTS_READ = READ_CONTROL,
-
-            /// <summary>Currently defined to equal <see cref="READ_CONTROL" />.</summary>
-            STANDARD_RIGHTS_WRITE = READ_CONTROL,
-
-            /// <summary>Currently defined to equal <see cref="READ_CONTROL" />.</summary>
-            STANDARD_RIGHTS_EXECUTE = READ_CONTROL,
-
-            /// <summary>
-            ///     Combines <see cref="DELETE" />, <see cref="READ_CONTROL" />, <see cref="WRITE_DAC" />,
-            ///     <see cref="WRITE_OWNER" />, and <see cref="SYNCHRONIZE" /> access.
-            /// </summary>
-            STANDARD_RIGHTS_ALL = 0x1F0000,
-
             /// <summary>
             ///     For a file object, the right to read the corresponding file data. For a directory object, the right to read
             ///     the corresponding directory data.

--- a/src/Kernel32.Desktop/Kernel32+FileShare.cs
+++ b/src/Kernel32.Desktop/Kernel32+FileShare.cs
@@ -14,7 +14,7 @@ namespace PInvoke
         public enum FileShare : uint
         {
             /// <summary>
-            ///
+            /// Prevents other processes from opening a file or device if they request delete, read, or write access.
             /// </summary>
             None = 0x00000000,
 

--- a/src/Kernel32.Desktop/Kernel32+ProcessAccess.cs
+++ b/src/Kernel32.Desktop/Kernel32+ProcessAccess.cs
@@ -8,29 +8,12 @@ namespace PInvoke
     /// <content>Contains the <see cref="ProcessAccess" /> nested struct.</content>
     public partial class Kernel32
     {
-        /// <summary>The valid access rights for process objects.</summary>
+        /// <summary>
+        /// Enumerates the <see cref="ACCESS_MASK.SpecificRights"/> that may apply to processes.
+        /// </summary>
         [Flags]
         public enum ProcessAccess : uint
         {
-            /// <summary>Required to delete the object.</summary>
-            DELETE,
-
-            /// <summary>
-            /// Required to read information in the security descriptor for the object, not including the information in the
-            /// SACL. To read or write the SACL, you must request the <see cref="ACCESS_SYSTEM_SECURITY" /> access right. For more
-            /// information, see SACL Access Right.
-            /// </summary>
-            READ_CONTROL = 0x00020000,
-
-            /// <summary>Required to wait for the process to terminate using the wait functions.</summary>
-            SYNCHRONIZE = 0x00100000,
-
-            /// <summary>Required to modify the DACL in the security descriptor for the object.</summary>
-            WRITE_DAC = 0x00040000,
-
-            /// <summary>Required to change the owner in the security descriptor for the object.</summary>
-            WRITE_OWNER = 0x00080000,
-
             /// <summary>Required to create a process.</summary>
             PROCESS_CREATE_PROCESS = 0x0080,
 
@@ -77,9 +60,6 @@ namespace PInvoke
 
             /// <summary>Required to write to memory in a process using WriteProcessMemory.</summary>
             PROCESS_VM_WRITE = 0x0020,
-
-            /// <summary>Required to wait for the process to terminate using the wait functions.</summary>
-            ACCESS_SYSTEM_SECURITY = 0x01000000
         }
     }
 }

--- a/src/Kernel32.Desktop/Kernel32+ProcessAccess.cs
+++ b/src/Kernel32.Desktop/Kernel32+ProcessAccess.cs
@@ -3,31 +3,28 @@
 
 namespace PInvoke
 {
-    using System;
-
     /// <content>Contains the <see cref="ProcessAccess" /> nested struct.</content>
     public partial class Kernel32
     {
         /// <summary>
         /// Enumerates the <see cref="ACCESS_MASK.SpecificRights"/> that may apply to processes.
         /// </summary>
-        [Flags]
-        public enum ProcessAccess : uint
+        public static class ProcessAccess
         {
             /// <summary>Required to create a process.</summary>
-            PROCESS_CREATE_PROCESS = 0x0080,
+            public const uint PROCESS_CREATE_PROCESS = 0x0080;
 
             /// <summary>Required to create a thread.</summary>
-            PROCESS_CREATE_THREAD = 0x0002,
+            public const uint PROCESS_CREATE_THREAD = 0x0002;
 
             /// <summary>Required to duplicate a handle using DuplicateHandle.</summary>
-            PROCESS_DUP_HANDLE = 0x0040,
+            public const uint PROCESS_DUP_HANDLE = 0x0040;
 
             /// <summary>
             /// Required to retrieve certain information about a process, such as its token, exit code, and priority class
             /// (see OpenProcessToken).
             /// </summary>
-            PROCESS_QUERY_INFORMATION = 0x0400,
+            public const uint PROCESS_QUERY_INFORMATION = 0x0400;
 
             /// <summary>
             /// Required to retrieve certain information about a process (see GetExitCodeProcess, GetPriorityClass,
@@ -35,31 +32,31 @@ namespace PInvoke
             /// is automatically granted <see cref="PROCESS_QUERY_LIMITED_INFORMATION" />.
             /// </summary>
             /// <remarks>Windows Server 2003 and Windows XP:  This access right is not supported.</remarks>
-            PROCESS_QUERY_LIMITED_INFORMATION = 0x1000,
+            public const uint PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
 
             /// <summary>Required to set certain information about a process, such as its priority class (see SetPriorityClass).</summary>
-            PROCESS_SET_INFORMATION = 0x0200,
+            public const uint PROCESS_SET_INFORMATION = 0x0200;
 
             /// <summary>Required to set memory limits using SetProcessWorkingSetSize.</summary>
-            PROCESS_SET_QUOTA = 0x0100,
+            public const uint PROCESS_SET_QUOTA = 0x0100;
 
             /// <summary>Required to suspend or resume a process.</summary>
-            PROCESS_SUSPEND_RESUME = 0x0800,
+            public const uint PROCESS_SUSPEND_RESUME = 0x0800;
 
             /// <summary>Required to terminate a process using TerminateProcess.</summary>
-            PROCESS_TERMINATE = 0x0001,
+            public const uint PROCESS_TERMINATE = 0x0001;
 
             /// <summary>
             /// Required to perform an operation on the address space of a process (see VirtualProtectEx and
             /// WriteProcessMemory).
             /// </summary>
-            PROCESS_VM_OPERATION = 0x0008,
+            public const uint PROCESS_VM_OPERATION = 0x0008;
 
             /// <summary>Required to read memory in a process using ReadProcessMemory.</summary>
-            PROCESS_VM_READ = 0x0010,
+            public const uint PROCESS_VM_READ = 0x0010;
 
             /// <summary>Required to write to memory in a process using WriteProcessMemory.</summary>
-            PROCESS_VM_WRITE = 0x0020,
+            public const uint PROCESS_VM_WRITE = 0x0020;
         }
     }
 }

--- a/src/Kernel32.Desktop/Kernel32.cs
+++ b/src/Kernel32.Desktop/Kernel32.cs
@@ -663,7 +663,7 @@ namespace PInvoke
         /// <returns>If the function succeeds, the return value is an open handle to the specified process.</returns>
         [DllImport(api_ms_win_core_processthreads_l1_1_1, SetLastError = true)]
         public static extern SafeObjectHandle OpenProcess(
-            ProcessAccess dwDesiredAccess,
+            ACCESS_MASK dwDesiredAccess,
             bool bInheritHandle,
             int dwProcessId);
 

--- a/src/Kernel32.Desktop/Kernel32.cs
+++ b/src/Kernel32.Desktop/Kernel32.cs
@@ -8,6 +8,7 @@ namespace PInvoke
     using System;
     using System.Runtime.InteropServices;
     using System.Text;
+    using static PInvoke.Kernel32.ACCESS_MASK.GenericRight;
 
     /// <summary>
     /// Exported functions from the Kernel32.dll Windows library.
@@ -378,15 +379,16 @@ namespace PInvoke
         /// </param>
         /// <param name="access">
         /// The requested access to the file or device, which can be summarized as read, write, both or neither zero).
-        /// The most commonly used values are <see cref="FileAccess.GENERIC_READ"/>, <see cref="FileAccess.GENERIC_WRITE"/>, or both(<see cref="FileAccess.GENERIC_READ"/> | <see cref="FileAccess.GENERIC_WRITE"/>). For more information, see Generic Access Rights, File Security and Access Rights, File Access Rights Constants, and ACCESS_MASK.
-        /// If this parameter is zero, the application can query certain metadata such as file, directory, or device attributes without accessing that file or device, even if <see cref="FileAccess.GENERIC_READ"/> access would have been denied.
+        /// The most commonly used values are <see cref="GENERIC_READ"/>, <see cref="GENERIC_WRITE"/>, or both(<see cref="GENERIC_READ"/> | <see cref="GENERIC_WRITE"/>). For more information, see Generic Access Rights, File Security and Access Rights, File Access Rights Constants, and ACCESS_MASK.
+        /// If this parameter is zero, the application can query certain metadata such as file, directory, or device attributes without accessing that file or device, even if <see cref="GENERIC_READ"/> access would have been denied.
         /// You cannot request an access mode that conflicts with the sharing mode that is specified by the dwShareMode parameter in an open request that already has an open handle.
         /// For more information, see the Remarks section of this topic and Creating and Opening Files.
+        /// Common specific rights are defined in <seealso cref="FileAccess"/>.
         /// </param>
         /// <param name="share">
         /// The requested sharing mode of the file or device, which can be read, write, both, delete, all of these, or none (refer to the following table). Access requests to attributes or extended attributes are not affected by this flag.
-        /// If this parameter is zero and <see cref="CreateFile(string, FileAccess, FileShare, SECURITY_ATTRIBUTES*, CreationDisposition, CreateFileFlags, SafeObjectHandle)"/> succeeds, the file or device cannot be shared and cannot be opened again until the handle to the file or device is closed. For more information, see the Remarks section.
-        /// You cannot request a sharing mode that conflicts with the access mode that is specified in an existing request that has an open handle. <see cref="CreateFile(string, FileAccess, FileShare, SECURITY_ATTRIBUTES*, CreationDisposition, CreateFileFlags, SafeObjectHandle)"/> would fail and the <see cref="GetLastError"/> function would return ERROR_SHARING_VIOLATION.
+        /// If this parameter is zero and <see cref="CreateFile(string, ACCESS_MASK, FileShare, SECURITY_ATTRIBUTES*, CreationDisposition, CreateFileFlags, SafeObjectHandle)"/> succeeds, the file or device cannot be shared and cannot be opened again until the handle to the file or device is closed. For more information, see the Remarks section.
+        /// You cannot request a sharing mode that conflicts with the access mode that is specified in an existing request that has an open handle. <see cref="CreateFile(string, ACCESS_MASK, FileShare, SECURITY_ATTRIBUTES*, CreationDisposition, CreateFileFlags, SafeObjectHandle)"/> would fail and the <see cref="GetLastError"/> function would return ERROR_SHARING_VIOLATION.
         /// To enable a process to share a file or device while another process has the file or device open, use a compatible combination of one or more of the following values. For more information about valid combinations of this parameter with the dwDesiredAccess parameter, see Creating and Opening Files.
         /// </param>
         /// <param name="securityAttributes">
@@ -411,7 +413,7 @@ namespace PInvoke
         /// For more advanced access to file attributes, see SetFileAttributes. For a complete list of all file attributes with their values and descriptions, see File Attribute Constants.
         /// </param>
         /// <param name="templateFile">
-        /// A valid handle to a template file with the <see cref="FileAccess.GENERIC_READ"/> access right. The template file supplies file attributes and extended attributes for the file that is being created.
+        /// A valid handle to a template file with the <see cref="GENERIC_READ"/> access right. The template file supplies file attributes and extended attributes for the file that is being created.
         /// This parameter can be NULL.
         /// When opening an existing file, CreateFile ignores this parameter.
         /// When opening a new encrypted file, the file inherits the discretionary access control list from its parent directory.For additional information, see File Encryption.
@@ -423,7 +425,7 @@ namespace PInvoke
         [DllImport(api_ms_win_core_file_l1_2_0, CharSet = CharSet.Auto, SetLastError = true)]
         public static extern unsafe SafeObjectHandle CreateFile(
             string filename,
-            FileAccess access,
+            ACCESS_MASK access,
             FileShare share,
             [Friendly(FriendlyFlags.In | FriendlyFlags.Optional)] SECURITY_ATTRIBUTES* securityAttributes,
             CreationDisposition creationDisposition,
@@ -1034,9 +1036,9 @@ namespace PInvoke
         ///         <see cref="Win32ErrorCode.ERROR_SEM_TIMEOUT" />.
         ///     </para>
         ///     <para>
-        ///         If the function succeeds, the process should use the <see cref="CreateFile(string, FileAccess, FileShare, SECURITY_ATTRIBUTES*, CreationDisposition, CreateFileFlags, SafeObjectHandle)" /> function to open a handle to
+        ///         If the function succeeds, the process should use the <see cref="CreateFile(string, ACCESS_MASK, FileShare, SECURITY_ATTRIBUTES*, CreationDisposition, CreateFileFlags, SafeObjectHandle)" /> function to open a handle to
         ///         the named pipe. A return value of TRUE indicates that there is at least one instance of the pipe available. A
-        ///         subsequent <see cref="CreateFile(string, FileAccess, FileShare, SECURITY_ATTRIBUTES*, CreationDisposition, CreateFileFlags, SafeObjectHandle)" /> call to the pipe can fail, because the instance was closed by the server
+        ///         subsequent <see cref="CreateFile(string, ACCESS_MASK, FileShare, SECURITY_ATTRIBUTES*, CreationDisposition, CreateFileFlags, SafeObjectHandle)" /> call to the pipe can fail, because the instance was closed by the server
         ///         or opened by another client.
         ///     </para>
         /// </returns>
@@ -1354,7 +1356,7 @@ namespace PInvoke
         /// </summary>
         /// <param name="hNamedPipe">
         ///     A handle to the pipe. This parameter can be a handle to a named pipe instance, as returned by
-        ///     the <see cref="CreateNamedPipe(string, PipeAccessMode, PipeMode, int, int, int, int, SECURITY_ATTRIBUTES*)" /> or <see cref="CreateFile(string, FileAccess, FileShare, SECURITY_ATTRIBUTES*, CreationDisposition, CreateFileFlags, SafeObjectHandle)" /> function, or it can be a handle to the read end of
+        ///     the <see cref="CreateNamedPipe(string, PipeAccessMode, PipeMode, int, int, int, int, SECURITY_ATTRIBUTES*)" /> or <see cref="CreateFile(string, ACCESS_MASK, FileShare, SECURITY_ATTRIBUTES*, CreationDisposition, CreateFileFlags, SafeObjectHandle)" /> function, or it can be a handle to the read end of
         ///     an anonymous pipe, as returned by the <see cref="CreatePipe(out SafeObjectHandle, out SafeObjectHandle, SECURITY_ATTRIBUTES*, int)" /> function. The handle must have GENERIC_READ access
         ///     to the pipe.
         /// </param>
@@ -1400,7 +1402,7 @@ namespace PInvoke
         /// <param name="hNamedPipe">
         ///     A handle to the named pipe instance. This parameter can be a handle to the server end of the
         ///     pipe, as returned by the <see cref="CreateNamedPipe(string, PipeAccessMode, PipeMode, int, int, int, int, SECURITY_ATTRIBUTES*)" /> function, or to the client end of the pipe, as returned by
-        ///     the <see cref="CreateFile(string, FileAccess, FileShare, SECURITY_ATTRIBUTES*, CreationDisposition, CreateFileFlags, SafeObjectHandle)" /> function. The handle must have GENERIC_WRITE access to the named pipe for a
+        ///     the <see cref="CreateFile(string, ACCESS_MASK, FileShare, SECURITY_ATTRIBUTES*, CreationDisposition, CreateFileFlags, SafeObjectHandle)" /> function. The handle must have GENERIC_WRITE access to the named pipe for a
         ///     write-only or read/write pipe, or it must have GENERIC_READ and FILE_WRITE_ATTRIBUTES access for a read-only pipe.
         ///     <para>
         ///         This parameter can also be a handle to an anonymous pipe, as returned by the <see cref="CreatePipe(out SafeObjectHandle, out SafeObjectHandle, SECURITY_ATTRIBUTES*, int)" />
@@ -1443,7 +1445,7 @@ namespace PInvoke
         /// </summary>
         /// <param name="hNamedPipe">
         ///     A handle to the named pipe returned by the <see cref="CreateNamedPipe(string, PipeAccessMode, PipeMode, int, int, int, int, SECURITY_ATTRIBUTES*)" /> or
-        ///     <see cref="CreateFile(string, FileAccess, FileShare, SECURITY_ATTRIBUTES*, CreationDisposition, CreateFileFlags, SafeObjectHandle)" /> function.
+        ///     <see cref="CreateFile(string, ACCESS_MASK, FileShare, SECURITY_ATTRIBUTES*, CreationDisposition, CreateFileFlags, SafeObjectHandle)" /> function.
         ///     <para>
         ///         This parameter can also be a handle to an anonymous pipe, as returned by the <see cref="CreatePipe(out SafeObjectHandle, out SafeObjectHandle, SECURITY_ATTRIBUTES*, int)" />
         ///         function.

--- a/src/Kernel32.Shared/Kernel32+ACCESS_MASK.cs
+++ b/src/Kernel32.Shared/Kernel32+ACCESS_MASK.cs
@@ -201,20 +201,6 @@ namespace PInvoke
             /// <param name="value">The value for the <see cref="ACCESS_MASK"/></param>
             public static implicit operator ACCESS_MASK(GenericRight value) => new ACCESS_MASK((uint)value);
 
-#if DESKTOP
-            /// <summary>
-            /// Casts a <see cref="FileAccess"/> to an <see cref="ACCESS_MASK"/>.
-            /// </summary>
-            /// <param name="value">The value to cast.</param>
-            public static implicit operator ACCESS_MASK(FileAccess value) => new ACCESS_MASK((uint)value);
-
-            /// <summary>
-            /// Casts a <see cref="ProcessAccess"/> to an <see cref="ACCESS_MASK"/>.
-            /// </summary>
-            /// <param name="value">The value to cast.</param>
-            public static implicit operator ACCESS_MASK(ProcessAccess value) => new ACCESS_MASK((uint)value);
-#endif
-
             /// <inheritdoc />
             public override int GetHashCode() => this.AsInt32;
 

--- a/src/Kernel32.Shared/Kernel32+ACCESS_MASK.cs
+++ b/src/Kernel32.Shared/Kernel32+ACCESS_MASK.cs
@@ -207,6 +207,12 @@ namespace PInvoke
             /// </summary>
             /// <param name="value">The value to cast.</param>
             public static implicit operator ACCESS_MASK(FileAccess value) => new ACCESS_MASK((uint)value);
+
+            /// <summary>
+            /// Casts a <see cref="ProcessAccess"/> to an <see cref="ACCESS_MASK"/>.
+            /// </summary>
+            /// <param name="value">The value to cast.</param>
+            public static implicit operator ACCESS_MASK(ProcessAccess value) => new ACCESS_MASK((uint)value);
 #endif
 
             /// <inheritdoc />

--- a/src/Kernel32.Shared/Kernel32+ACCESS_MASK.cs
+++ b/src/Kernel32.Shared/Kernel32+ACCESS_MASK.cs
@@ -9,7 +9,7 @@ namespace PInvoke
     /// <content>
     /// Contains the <see cref="ACCESS_MASK"/> nested type.
     /// </content>
-    public partial class NTDll
+    public partial class Kernel32
     {
         /// <summary>
         /// The ACCESS_MASK type is a bitmask that specifies a set of access rights in the access mask of an access control entry.
@@ -104,10 +104,19 @@ namespace PInvoke
 
                 STANDARD_RIGHTS_REQUIRED = 0x000F0000,
 
+                /// <summary>
+                /// See also <see cref="READ_CONTROL"/>
+                /// </summary>
                 STANDARD_RIGHTS_READ = READ_CONTROL,
 
+                /// <summary>
+                /// See also <see cref="READ_CONTROL"/>
+                /// </summary>
                 STANDARD_RIGHTS_WRITE = READ_CONTROL,
 
+                /// <summary>
+                /// See also <see cref="READ_CONTROL"/>
+                /// </summary>
                 STANDARD_RIGHTS_EXECUTE = READ_CONTROL,
 
                 STANDARD_RIGHTS_ALL = 0x001F0000,
@@ -191,6 +200,14 @@ namespace PInvoke
             /// </summary>
             /// <param name="value">The value for the <see cref="ACCESS_MASK"/></param>
             public static implicit operator ACCESS_MASK(GenericRight value) => new ACCESS_MASK((uint)value);
+
+#if DESKTOP
+            /// <summary>
+            /// Casts a <see cref="FileAccess"/> to an <see cref="ACCESS_MASK"/>.
+            /// </summary>
+            /// <param name="value">The value to cast.</param>
+            public static implicit operator ACCESS_MASK(FileAccess value) => new ACCESS_MASK((uint)value);
+#endif
 
             /// <inheritdoc />
             public override int GetHashCode() => this.AsInt32;

--- a/src/Kernel32.Shared/Kernel32.Shared.projitems
+++ b/src/Kernel32.Shared/Kernel32.Shared.projitems
@@ -26,6 +26,7 @@
       <Generator>MSBuild:GenerateCodeFromAttributes</Generator>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Kernel32Extensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Kernel32+ACCESS_MASK.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NTStatusException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Win32Exception.cs" />
   </ItemGroup>

--- a/src/Kernel32.Tests/Kernel32Facts.cs
+++ b/src/Kernel32.Tests/Kernel32Facts.cs
@@ -105,7 +105,7 @@ public partial class Kernel32Facts
         string testPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
         using (var tempFileHandle = CreateFile(
             testPath,
-            Kernel32.FileAccess.GENERIC_WRITE,
+            ACCESS_MASK.GenericRight.GENERIC_WRITE,
             Kernel32.FileShare.FILE_SHARE_READ,
             IntPtr.Zero,
             CreationDisposition.CREATE_ALWAYS,
@@ -269,7 +269,7 @@ public partial class Kernel32Facts
 
             using (var file = CreateFile(
                 testPath,
-                Kernel32.FileAccess.GENERIC_READ,
+                ACCESS_MASK.GenericRight.GENERIC_READ,
                 Kernel32.FileShare.None,
                 IntPtr.Zero,
                 CreationDisposition.OPEN_EXISTING,
@@ -301,7 +301,7 @@ public partial class Kernel32Facts
 
             using (var file = CreateFile(
                 testPath,
-                Kernel32.FileAccess.GENERIC_READ,
+                ACCESS_MASK.GenericRight.GENERIC_READ,
                 Kernel32.FileShare.None,
                 (SECURITY_ATTRIBUTES?)null,
                 CreationDisposition.OPEN_EXISTING,
@@ -350,7 +350,7 @@ public partial class Kernel32Facts
 
             using (var file = CreateFile(
                 testPath,
-                Kernel32.FileAccess.GENERIC_READ,
+                ACCESS_MASK.GenericRight.GENERIC_READ,
                 Kernel32.FileShare.None,
                 (SECURITY_ATTRIBUTES?)null,
                 CreationDisposition.OPEN_EXISTING,
@@ -400,7 +400,7 @@ public partial class Kernel32Facts
 
             using (var file = CreateFile(
                 testPath,
-                Kernel32.FileAccess.GENERIC_WRITE,
+                ACCESS_MASK.GenericRight.GENERIC_WRITE,
                 Kernel32.FileShare.None,
                 IntPtr.Zero,
                 CreationDisposition.OPEN_EXISTING,
@@ -433,7 +433,7 @@ public partial class Kernel32Facts
 
             using (var file = CreateFile(
                 testPath,
-                Kernel32.FileAccess.GENERIC_WRITE,
+                ACCESS_MASK.GenericRight.GENERIC_WRITE,
                 Kernel32.FileShare.None,
                 (SECURITY_ATTRIBUTES?)null,
                 CreationDisposition.OPEN_EXISTING,
@@ -481,7 +481,7 @@ public partial class Kernel32Facts
 
             using (var file = CreateFile(
                 testPath,
-                Kernel32.FileAccess.GENERIC_WRITE,
+                ACCESS_MASK.GenericRight.GENERIC_WRITE,
                 Kernel32.FileShare.None,
                 (SECURITY_ATTRIBUTES?)null,
                 CreationDisposition.OPEN_EXISTING,
@@ -531,7 +531,7 @@ public partial class Kernel32Facts
 
             using (var file = CreateFile(
                 testPath,
-                Kernel32.FileAccess.GENERIC_WRITE,
+                ACCESS_MASK.GenericRight.GENERIC_WRITE,
                 Kernel32.FileShare.None,
                 (SECURITY_ATTRIBUTES?)null,
                 CreationDisposition.OPEN_EXISTING,
@@ -579,7 +579,7 @@ public partial class Kernel32Facts
 
             using (var file = CreateFile(
                 testPath,
-                Kernel32.FileAccess.GENERIC_WRITE,
+                ACCESS_MASK.GenericRight.GENERIC_WRITE,
                 Kernel32.FileShare.None,
                 (SECURITY_ATTRIBUTES?)null,
                 CreationDisposition.OPEN_EXISTING,
@@ -633,7 +633,7 @@ public partial class Kernel32Facts
 
             using (var file = CreateFile(
                 testPath,
-                Kernel32.FileAccess.GENERIC_WRITE,
+                ACCESS_MASK.GenericRight.GENERIC_WRITE,
                 Kernel32.FileShare.None,
                 (SECURITY_ATTRIBUTES?)null,
                 CreationDisposition.OPEN_EXISTING,
@@ -753,7 +753,7 @@ public partial class Kernel32Facts
 
                 var client = CreateFile(
                     pipeName,
-                    Kernel32.FileAccess.GENERIC_READ | Kernel32.FileAccess.FILE_GENERIC_WRITE,
+                    (uint)ACCESS_MASK.GenericRight.GENERIC_READ | (uint)Kernel32.FileAccess.FILE_GENERIC_WRITE,
                     Kernel32.FileShare.None,
                     (SECURITY_ATTRIBUTES?)null,
                     CreationDisposition.OPEN_EXISTING,

--- a/src/NTDll.Desktop/NTDll.cs
+++ b/src/NTDll.Desktop/NTDll.cs
@@ -34,7 +34,7 @@ namespace PInvoke
         [DllImport(nameof(NTDll), CharSet = CharSet.Unicode)]
         public static extern unsafe NTSTATUS NtOpenSection(
             out SafeNTObjectHandle sectionHandle,
-            ACCESS_MASK desiredAccess,
+            Kernel32.ACCESS_MASK desiredAccess,
             [Friendly(FriendlyFlags.In)] OBJECT_ATTRIBUTES* objectAttributes);
 
         /// <summary>

--- a/src/NTDll.Shared/NTDll+ACCESS_MASK.cs
+++ b/src/NTDll.Shared/NTDll+ACCESS_MASK.cs
@@ -3,6 +3,9 @@
 
 namespace PInvoke
 {
+    using System;
+    using System.Diagnostics;
+
     /// <content>
     /// Contains the <see cref="ACCESS_MASK"/> nested type.
     /// </content>
@@ -11,44 +14,204 @@ namespace PInvoke
         /// <summary>
         /// The ACCESS_MASK type is a bitmask that specifies a set of access rights in the access mask of an access control entry.
         /// </summary>
-        public enum ACCESS_MASK : uint
+        /// <remarks>
+        /// Quite well described here: http://blogs.msdn.com/b/openspecification/archive/2010/04/01/about-the-access-mask-structure.aspx
+        /// </remarks>
+        public partial struct ACCESS_MASK : IComparable, IComparable<ACCESS_MASK>, IEquatable<ACCESS_MASK>, IFormattable
         {
             /// <summary>
-            /// Delete access.
+            /// Bits 28-31
             /// </summary>
-            DELETE = 0x00010000,
+            private const uint GenericRightsMask = 0xf0000000;
 
             /// <summary>
-            /// Read access to the owner, group, and discretionary access control list (DACL) of the security descriptor.
+            /// Bits 24-27
             /// </summary>
-            READ_CONTROL = 0x00020000,
+            private const uint SpecialRightsMask = 0x0f000000;
 
             /// <summary>
-            /// Write access to the DACL.
+            /// Bits 16-23
             /// </summary>
-            WRITE_DAC = 0x00040000,
+            private const uint StandardRightsMask = 0x00ff0000;
 
             /// <summary>
-            /// Write access to owner.
+            /// Bits 0-15
             /// </summary>
-            WRITE_OWNER = 0x00080000,
+            private const uint SpecificRightsMask = 0x0000ffff;
 
             /// <summary>
-            /// Synchronize access.
+            /// Initializes a new instance of the <see cref="ACCESS_MASK"/> struct.
             /// </summary>
-            SYNCHRONIZE = 0x00100000,
+            /// <param name="value">The value for the <see cref="ACCESS_MASK"/>.</param>
+            public ACCESS_MASK(uint value)
+            {
+                this.Value = value;
+            }
 
-            STANDARD_RIGHTS_REQUIRED = 0x000F0000,
+            [Flags]
+            public enum GenericRight : uint
+            {
+                GENERIC_ALL = 0x10000000,
+                GENERIC_EXECUTE = 0x20000000,
+                GENERIC_WRITE = 0x40000000,
+                GENERIC_READ = 0x80000000,
+            }
 
-            STANDARD_RIGHTS_READ = READ_CONTROL,
+            [Flags]
+            public enum SpecialRight : uint
+            {
+                /// <summary>
+                /// It is used to indicate access to a system access control list (SACL). This type of access requires the calling process to have the SE_SECURITY_NAME (Manage auditing and security log) privilege. If this flag is set in the access mask of an audit access ACE (successful or unsuccessful access), the SACL access will be audited.
+                /// </summary>
+                ACCESS_SYSTEM_SECURITY = 0x01000000,
 
-            STANDARD_RIGHTS_WRITE = READ_CONTROL,
+                /// <summary>
+                /// Maximum allowed.
+                /// </summary>
+                MAXIMUM_ALLOWED = 0x02000000,
+            }
 
-            STANDARD_RIGHTS_EXECUTE = READ_CONTROL,
+            /// <summary>
+            /// Contains the object's standard access rights.
+            /// </summary>
+            [Flags]
+            public enum StandardRight : uint
+            {
+                /// <summary>
+                /// Delete access.
+                /// </summary>
+                DELETE = 0x00010000,
 
-            STANDARD_RIGHTS_ALL = 0x001F0000,
+                /// <summary>
+                /// Read access to the owner, group, and discretionary access control list (DACL) of the security descriptor.
+                /// </summary>
+                READ_CONTROL = 0x00020000,
 
-            SPECIFIC_RIGHTS_ALL = 0x0000FFFF,
+                /// <summary>
+                /// Write access to the DACL.
+                /// </summary>
+                WRITE_DAC = 0x00040000,
+
+                /// <summary>
+                /// Write access to owner.
+                /// </summary>
+                WRITE_OWNER = 0x00080000,
+
+                /// <summary>
+                /// Synchronize access.
+                /// </summary>
+                SYNCHRONIZE = 0x00100000,
+
+                STANDARD_RIGHTS_REQUIRED = 0x000F0000,
+
+                STANDARD_RIGHTS_READ = READ_CONTROL,
+
+                STANDARD_RIGHTS_WRITE = READ_CONTROL,
+
+                STANDARD_RIGHTS_EXECUTE = READ_CONTROL,
+
+                STANDARD_RIGHTS_ALL = 0x001F0000,
+            }
+
+            /// <summary>
+            /// Contains the access mask specific to the object type associated with the mask.
+            /// </summary>
+            [Flags]
+            public enum SpecificRight : uint
+            {
+                /// <summary>
+                /// The bit mask that covers specific rights.
+                /// </summary>
+                SPECIFIC_RIGHTS_ALL = 0x0000FFFF,
+            }
+
+            /// <summary>
+            /// Gets the ACCESS_MASK as a 32-bit unsigned integer.
+            /// </summary>
+            public uint Value { get; }
+
+            /// <summary>
+            /// Gets the ACCESS_MASK as a 32-bit signed integer.
+            /// </summary>
+            [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+            public int AsInt32 => (int)this.Value;
+
+            /// <summary>
+            /// Gets the generic rights of this value.
+            /// </summary>
+            public GenericRight GenericRights => (GenericRight)(this.Value & GenericRightsMask);
+
+            /// <summary>
+            /// Gets the special rights of this value.
+            /// </summary>
+            public SpecialRight SpecialRights => (SpecialRight)(this.Value & SpecialRightsMask);
+
+            /// <summary>
+            /// Gets the standard rights of this value.
+            /// </summary>
+            public StandardRight StandardRights => (StandardRight)(this.Value & StandardRightsMask);
+
+            /// <summary>
+            /// Gets the specific rights of this value.
+            /// </summary>
+            public SpecificRight SpecificRights => (SpecificRight)(this.Value & SpecificRightsMask);
+
+            /// <summary>
+            /// Converts an <see cref="int"/> into an <see cref="ACCESS_MASK"/>.
+            /// </summary>
+            /// <param name="value">The value of the ACCESS_MASK.</param>
+            public static implicit operator ACCESS_MASK(int value) => new ACCESS_MASK((uint)value);
+
+            /// <summary>
+            /// Converts an <see cref="ACCESS_MASK"/> into an <see cref="int"/>.
+            /// </summary>
+            /// <param name="value">The value of the ACCESS_MASK.</param>
+            public static explicit operator int(ACCESS_MASK value) => value.AsInt32;
+
+            /// <summary>
+            /// Converts an <see cref="uint"/> into an <see cref="ACCESS_MASK"/>.
+            /// </summary>
+            /// <param name="value">The value of the ACCESS_MASK.</param>
+            public static implicit operator ACCESS_MASK(uint value) => new ACCESS_MASK(value);
+
+            /// <summary>
+            /// Converts an <see cref="ACCESS_MASK"/> into an <see cref="uint"/>.
+            /// </summary>
+            /// <param name="value">The value of the ACCESS_MASK.</param>
+            public static implicit operator uint(ACCESS_MASK value) => value.Value;
+
+            /// <summary>
+            /// Converts a <see cref="StandardRight"/> to an <see cref="ACCESS_MASK"/>.
+            /// </summary>
+            /// <param name="value">The value for the <see cref="ACCESS_MASK"/></param>
+            public static implicit operator ACCESS_MASK(StandardRight value) => new ACCESS_MASK((uint)value);
+
+            /// <summary>
+            /// Converts a <see cref="GenericRight"/> to an <see cref="ACCESS_MASK"/>.
+            /// </summary>
+            /// <param name="value">The value for the <see cref="ACCESS_MASK"/></param>
+            public static implicit operator ACCESS_MASK(GenericRight value) => new ACCESS_MASK((uint)value);
+
+            /// <inheritdoc />
+            public override int GetHashCode() => this.AsInt32;
+
+            /// <inheritdoc />
+            public bool Equals(ACCESS_MASK other) => this.Value == other.Value;
+
+            /// <inheritdoc />
+            public override bool Equals(object obj) => obj is ACCESS_MASK && this.Equals((ACCESS_MASK)obj);
+
+            /// <inheritdoc />
+            public int CompareTo(object obj) => ((IComparable)this.Value).CompareTo(obj);
+
+            /// <inheritdoc />
+            public int CompareTo(ACCESS_MASK other) => this.Value.CompareTo(other.Value);
+
+            /// <inheritdoc />
+            public override string ToString() => this.Value.ToString();
+
+            /// <inheritdoc />
+            public string ToString(string format, IFormatProvider formatProvider) => this.Value.ToString(format, formatProvider);
         }
     }
 }

--- a/src/NTDll.Shared/NTDll.Shared.projitems
+++ b/src/NTDll.Shared/NTDll.Shared.projitems
@@ -9,7 +9,6 @@
     <Import_RootNamespace>PInvoke</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)NTDll+ACCESS_MASK.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NTDll.Helpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NTDll.cs">
       <Generator>MSBuild:GenerateCodeFromAttributes</Generator>

--- a/src/NTDll.Tests/NTDllFacts.cs
+++ b/src/NTDll.Tests/NTDllFacts.cs
@@ -39,7 +39,7 @@ public class NTDllFacts
             attrs.ObjectName = &objectNameUnicode;
             attrs.Attributes = OBJECT_ATTRIBUTES.ObjectHandleAttributes.OBJ_CASE_INSENSITIVE;
             SafeNTObjectHandle hObject;
-            NTSTATUS status = NtOpenSection(out hObject, ACCESS_MASK.StandardRight.STANDARD_RIGHTS_READ, attrs);
+            NTSTATUS status = NtOpenSection(out hObject, Kernel32.ACCESS_MASK.StandardRight.STANDARD_RIGHTS_READ, attrs);
             Assert.Equal<NTSTATUS>(NTSTATUS.Code.STATUS_ACCESS_DENIED, status);
         }
     }

--- a/src/NTDll.Tests/NTDllFacts.cs
+++ b/src/NTDll.Tests/NTDllFacts.cs
@@ -39,7 +39,7 @@ public class NTDllFacts
             attrs.ObjectName = &objectNameUnicode;
             attrs.Attributes = OBJECT_ATTRIBUTES.ObjectHandleAttributes.OBJ_CASE_INSENSITIVE;
             SafeNTObjectHandle hObject;
-            NTSTATUS status = NtOpenSection(out hObject, ACCESS_MASK.STANDARD_RIGHTS_READ, attrs);
+            NTSTATUS status = NtOpenSection(out hObject, ACCESS_MASK.StandardRight.STANDARD_RIGHTS_READ, attrs);
             Assert.Equal<NTSTATUS>(NTSTATUS.Code.STATUS_ACCESS_DENIED, status);
         }
     }


### PR DESCRIPTION
Fixes #194

I had to make more awkward API decisions around this, as I had to for HResult and other code-as-struct types. In this case it is that the 16 least significant bits are defined by the kind of object that the ACL describes. So the type safety system of .NET will sometimes require a small `(uint)` cast on the specialized enum type so that it 'fits' into the general type.
