### PR TITLE
Define FILETIME instead of reusing .NET's 

### DIFF
--- a/src/Kernel32.Shared/Kernel32+FILETIME.cs
+++ b/src/Kernel32.Shared/Kernel32+FILETIME.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) to owners found in https://github.com/AArnott/pinvoke/blob/master/COPYRIGHT.md. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+
+namespace PInvoke
+{
+    using System.Runtime.InteropServices;
+
+    /// <content>
+    /// Contains the <see cref="FILETIME"/> nested struct.
+    /// </content>
+    public partial class Kernel32
+    {
+        /// <summary>
+        /// A 64-bit representation of a file timestamp.
+        /// </summary>
+        /// <remarks>
+        /// This type is equivalent to <see cref="System.Runtime.InteropServices.ComTypes.FILETIME"/>.
+        /// We couldn't use that type directly even though it's in the portable profile because
+        /// Xamarin.Android and Xamarin.iOS omit the type and it causes link failures.
+        /// See https://github.com/AArnott/pinvoke/issues/232
+        /// </remarks>
+        [StructLayout(LayoutKind.Sequential)]
+        public struct FILETIME
+        {
+            /// <summary>
+            /// Specifies the high 32 bits of the FILETIME.
+            /// </summary>
+            public int dwHighDateTime;
+
+            /// <summary>
+            /// Specifies the low 32 bits of the FILETIME.
+            /// </summary>
+            public int dwLowDateTime;
+        }
+    }
+}

--- a/src/Kernel32.Shared/Kernel32+WIN32_FIND_DATA.cs
+++ b/src/Kernel32.Shared/Kernel32+WIN32_FIND_DATA.cs
@@ -4,7 +4,6 @@
 namespace PInvoke
 {
     using System.Runtime.InteropServices;
-    using FILETIME = System.Runtime.InteropServices.ComTypes.FILETIME;
 
     /// <content>
     /// Contains the <see cref="WIN32_FIND_DATA"/> nested struct.

--- a/src/Kernel32.Shared/Kernel32.Shared.projitems
+++ b/src/Kernel32.Shared/Kernel32.Shared.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Kernel32+FileAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Kernel32+FILETIME.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Kernel32+FINDEX_INFO_LEVELS.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Kernel32+FINDEX_SEARCH_OPS.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Kernel32+FindFirstFileExFlags.cs" />

--- a/src/Kernel32.Shared/Kernel32.cs
+++ b/src/Kernel32.Shared/Kernel32.cs
@@ -6,7 +6,6 @@ namespace PInvoke
     using System;
     using System.Runtime.InteropServices;
     using System.Text;
-    using FILETIME = System.Runtime.InteropServices.ComTypes.FILETIME;
 
     /// <summary>
     /// Exported functions from the Kernel32.dll Windows library.

--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.2",
+  "version": "0.3",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
     "^refs/tags/v\\d\\.\\d" // we also release tags starting with vN.N


### PR DESCRIPTION
This is contrary to our normal policy of reusing .NET types that are already defined and compatible. But it blocks adoption by Xamarin.Android and Xamarin.iOS because their linker fails.
This is an API breaking change.

Fixes #232
