### PR TITLE
Add CharSet.Unicode to FindFirstFileEx DllImport, CharSet.Ansi is the default setting.

### DIFF
--- a/src/Kernel32.Shared/Kernel32.cs
+++ b/src/Kernel32.Shared/Kernel32.cs
@@ -88,7 +88,7 @@ namespace PInvoke
         /// If the function succeeds, the return value is a search handle used in a subsequent call to FindNextFile or FindClose, and the lpFindFileData parameter contains information about the first file or directory found.
         /// If the function fails or fails to locate files from the search string in the lpFileName parameter, the return value is INVALID_HANDLE_VALUE and the contents of lpFindFileData are indeterminate.To get extended error information, call the <see cref="GetLastError"/> function.
         /// </returns>
-        [DllImport(api_ms_win_core_file_l1_2_0)]
+        [DllImport(api_ms_win_core_file_l1_2_0, CharSet = CharSet.Unicode)]
         public static unsafe extern SafeFindFilesHandle FindFirstFileEx(string lpFileName, FINDEX_INFO_LEVELS fInfoLevelId, out WIN32_FIND_DATA lpFindFileData, FINDEX_SEARCH_OPS fSearchOp, void* lpSearchFilter, FindFirstFileExFlags dwAdditionalFlags);
 
         /// <summary>


### PR DESCRIPTION
Andrew,

The FindFirstFileEx DllImport is missing [CharSet.Unicode](https://blogs.msdn.microsoft.com/oldnewthing/20140812-00/?p=263). All executed tests pass with this change.

David
