### PR TITLE
Update NuGet dependencies

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,8 @@ environment:
     secure: Ql19CstT9GvFNeSIAjXvgHXZg+/pNaYJ2jVkzde4LT2vwSyjiQgQ+M332wVYtu+r
 cache:
 - '%USERPROFILE%\.nuget\packages'
+install:
+- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/install-nuget-3-3-0.ps1'))
 before_build:
 - ps: nuget restore src -Verbosity quiet
 build:

--- a/src/AdvApi32.Desktop/project.json
+++ b/src/AdvApi32.Desktop/project.json
@@ -6,7 +6,6 @@
     ".NETFramework,Version=v4.0": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/AdvApi32.Tests/project.json
+++ b/src/AdvApi32.Tests/project.json
@@ -8,7 +8,6 @@
     ".NETFramework,Version=v4.6": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/BCrypt.Desktop/project.json
+++ b/src/BCrypt.Desktop/project.json
@@ -6,7 +6,6 @@
     ".NETFramework,Version=v4.0": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/BCrypt.Tests/project.json
+++ b/src/BCrypt.Tests/project.json
@@ -8,7 +8,6 @@
     ".NETFramework,Version=v4.6": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/CodeGeneration/project.json
+++ b/src/CodeGeneration/project.json
@@ -5,11 +5,11 @@
       "suppressParent": "none"
     },
     "Nerdbank.GitVersioning": {
-      "version": "1.3.8",
+      "version": "1.4.6",
       "suppressParent": "none"
     },
     "Nuproj.Common": {
-      "version": "0.10.27-beta-g2363d7cd98",
+      "version": "0.10.48-beta-gea4a31bbc5",
       "suppressParent": "none"
     },
     "StyleCop.Analyzers": "1.0.0-rc2"

--- a/src/CodeGeneration/project.json
+++ b/src/CodeGeneration/project.json
@@ -18,7 +18,6 @@
     ".NETFramework,Version=v4.6": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/CodeGenerationAttributes.Net40/project.json
+++ b/src/CodeGenerationAttributes.Net40/project.json
@@ -5,11 +5,11 @@
       "suppressParent": "none"
     },
     "Nerdbank.GitVersioning": {
-      "version": "1.3.8",
+      "version": "1.4.6",
       "suppressParent": "none"
     },
     "Nuproj.Common": {
-      "version": "0.10.27-beta-g2363d7cd98",
+      "version": "0.10.48-beta-gea4a31bbc5",
       "suppressParent": "none"
     },
     "StyleCop.Analyzers": "1.0.0-rc2"

--- a/src/CodeGenerationAttributes.Net40/project.json
+++ b/src/CodeGenerationAttributes.Net40/project.json
@@ -18,7 +18,6 @@
     ".NETFramework,Version=v4.0": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/CodeGenerationAttributes.Profile111/project.json
+++ b/src/CodeGenerationAttributes.Profile111/project.json
@@ -5,11 +5,11 @@
       "suppressParent": "none"
     },
     "Nerdbank.GitVersioning": {
-      "version": "1.3.8",
+      "version": "1.4.6",
       "suppressParent": "none"
     },
     "Nuproj.Common": {
-      "version": "0.10.27-beta-g2363d7cd98",
+      "version": "0.10.48-beta-gea4a31bbc5",
       "suppressParent": "none"
     },
     "StyleCop.Analyzers": "1.0.0-rc2"

--- a/src/CodeGenerationAttributes.Profile111/project.json
+++ b/src/CodeGenerationAttributes.Profile111/project.json
@@ -18,7 +18,6 @@
     ".NETPortable,Version=v4.5,Profile=Profile111": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/CodeGenerationAttributes/project.json
+++ b/src/CodeGenerationAttributes/project.json
@@ -5,11 +5,11 @@
       "suppressParent": "none"
     },
     "Nerdbank.GitVersioning": {
-      "version": "1.3.8",
+      "version": "1.4.6",
       "suppressParent": "none"
     },
     "Nuproj.Common": {
-      "version": "0.10.27-beta-g2363d7cd98",
+      "version": "0.10.48-beta-gea4a31bbc5",
       "suppressParent": "none"
     },
     "StyleCop.Analyzers": "1.0.0-rc2"

--- a/src/CodeGenerationAttributes/project.json
+++ b/src/CodeGenerationAttributes/project.json
@@ -18,7 +18,6 @@
     ".NETPortable,Version=v4.0,Profile=Profile92": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/Crypt32.Desktop/project.json
+++ b/src/Crypt32.Desktop/project.json
@@ -6,7 +6,6 @@
     ".NETFramework,Version=v4.0": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/Crypt32.Tests/project.json
+++ b/src/Crypt32.Tests/project.json
@@ -8,7 +8,6 @@
     ".NETFramework,Version=v4.6": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/DbgHelp.Tests/project.json
+++ b/src/DbgHelp.Tests/project.json
@@ -8,7 +8,6 @@
     ".NETFramework,Version=v4.6": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/DwmApi.Desktop/project.json
+++ b/src/DwmApi.Desktop/project.json
@@ -6,7 +6,6 @@
     ".NETFramework,Version=v4.0": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/DwmApi.Tests/project.json
+++ b/src/DwmApi.Tests/project.json
@@ -8,7 +8,6 @@
     ".NETFramework,Version=v4.6": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/EnlistmentInfo.props
+++ b/src/EnlistmentInfo.props
@@ -7,8 +7,8 @@
   <PropertyGroup>
     <ProjectRoot>$(MSBuildThisFileDirectory)..\</ProjectRoot>
     <SolutionDir>$(MSBuildThisFileDirectory)</SolutionDir>
-    <NuProjPath>$(UserProfile)\.nuget\packages\NuProj\0.10.27-beta-g2363d7cd98\tools\</NuProjPath>
-    <NerdbankGitVersioningPath>$(UserProfile)\.nuget\packages\Nerdbank.GitVersioning\1.3.8\</NerdbankGitVersioningPath>
+    <NuProjPath>$(UserProfile)\.nuget\packages\NuProj\0.10.48-beta-gea4a31bbc5\tools\</NuProjPath>
+    <NerdbankGitVersioningPath>$(UserProfile)\.nuget\packages\Nerdbank.GitVersioning\1.4.6\</NerdbankGitVersioningPath>
 
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/src/EnlistmentInfo.targets
+++ b/src/EnlistmentInfo.targets
@@ -16,5 +16,5 @@
   </ItemGroup>
 
   <Import Project="NuProj.Extra.targets" Condition=" '$(MSBuildProjectExtension)' == '.nuproj' "/>
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), PInvoke.Extra.targets))\PInvoke.Extra.targets" Condition=" !$(MSBuildProjectName.Contains('Test')) AND $(TargetPath) != '' "/>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), PInvoke.Extra.targets))\PInvoke.Extra.targets" Condition=" !$(MSBuildProjectName.Contains('Test')) AND $(TargetPath) != '' and '$(MSBuildProjectExtension)' != '.nuproj'"/>
 </Project>

--- a/src/Fusion.Desktop/project.json
+++ b/src/Fusion.Desktop/project.json
@@ -6,7 +6,6 @@
     ".NETFramework,Version=v4.0": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/Fusion.Tests/project.json
+++ b/src/Fusion.Tests/project.json
@@ -8,7 +8,6 @@
     ".NETFramework,Version=v4.6": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/Hid.Desktop/project.json
+++ b/src/Hid.Desktop/project.json
@@ -6,7 +6,6 @@
     ".NETFramework,Version=v4.0": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/Hid.Tests/project.json
+++ b/src/Hid.Tests/project.json
@@ -8,7 +8,6 @@
     ".NETFramework,Version=v4.6": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/ImageHlp.Tests/project.json
+++ b/src/ImageHlp.Tests/project.json
@@ -8,7 +8,6 @@
     ".NETFramework,Version=v4.6": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/ImageHlp/project.json
+++ b/src/ImageHlp/project.json
@@ -6,7 +6,6 @@
     ".NETFramework,Version=v4.0": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/Kernel32.Desktop/project.json
+++ b/src/Kernel32.Desktop/project.json
@@ -6,7 +6,6 @@
     ".NETFramework,Version=v4.0": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/Kernel32.Tests.Portable/project.json
+++ b/src/Kernel32.Tests.Portable/project.json
@@ -8,7 +8,6 @@
     ".NETPortable,Version=v4.5,Profile=Profile111": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/Kernel32.Tests/project.json
+++ b/src/Kernel32.Tests/project.json
@@ -8,7 +8,6 @@
     ".NETFramework,Version=v4.6": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/MSCorEE.Desktop/project.json
+++ b/src/MSCorEE.Desktop/project.json
@@ -6,7 +6,6 @@
     ".NETFramework,Version=v4.0": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/MSCorEE.Tests/project.json
+++ b/src/MSCorEE.Tests/project.json
@@ -8,7 +8,6 @@
     ".NETFramework,Version=v4.6": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/Msi.Desktop/project.json
+++ b/src/Msi.Desktop/project.json
@@ -6,7 +6,6 @@
     ".NETFramework,Version=v4.0": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/Msi.Tests/project.json
+++ b/src/Msi.Tests/project.json
@@ -8,7 +8,6 @@
     ".NETFramework,Version=v4.6": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/NCrypt.Desktop/project.json
+++ b/src/NCrypt.Desktop/project.json
@@ -6,7 +6,6 @@
     ".NETFramework,Version=v4.0": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/NCrypt.Tests/project.json
+++ b/src/NCrypt.Tests/project.json
@@ -8,7 +8,6 @@
     ".NETFramework,Version=v4.6": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/NTDll.Desktop/project.json
+++ b/src/NTDll.Desktop/project.json
@@ -6,7 +6,6 @@
     ".NETFramework,Version=v4.0": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/NTDll.Tests/project.json
+++ b/src/NTDll.Tests/project.json
@@ -8,7 +8,6 @@
     ".NETFramework,Version=v4.6": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/Psapi.Tests/project.json
+++ b/src/Psapi.Tests/project.json
@@ -8,7 +8,6 @@
     ".NETFramework,Version=v4.6": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/Psapi/project.json
+++ b/src/Psapi/project.json
@@ -6,7 +6,6 @@
     ".NETFramework,Version=v4.0": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/SetupApi.Desktop/project.json
+++ b/src/SetupApi.Desktop/project.json
@@ -6,7 +6,6 @@
     ".NETFramework,Version=v4.0": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/SetupApi.Tests/project.json
+++ b/src/SetupApi.Tests/project.json
@@ -8,7 +8,6 @@
     ".NETFramework,Version=v4.6": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/User32.Tests/project.json
+++ b/src/User32.Tests/project.json
@@ -8,7 +8,6 @@
     ".NETFramework,Version=v4.6": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/Userenv.Desktop/project.json
+++ b/src/Userenv.Desktop/project.json
@@ -6,7 +6,6 @@
     ".NETFramework,Version=v4.0": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/Userenv.Tests/project.json
+++ b/src/Userenv.Tests/project.json
@@ -8,7 +8,6 @@
     ".NETFramework,Version=v4.6": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/UxTheme.Desktop/project.json
+++ b/src/UxTheme.Desktop/project.json
@@ -6,7 +6,6 @@
     ".NETFramework,Version=v4.0": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/UxTheme.Tests/project.json
+++ b/src/UxTheme.Tests/project.json
@@ -8,7 +8,6 @@
     ".NETFramework,Version=v4.6": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/Windows.Core.Profile111/project.json
+++ b/src/Windows.Core.Profile111/project.json
@@ -2,12 +2,12 @@
   "supports": { },
   "dependencies": {
     "Nerdbank.GitVersioning": {
-      "version": "1.3.8",
+      "version": "1.4.6",
       "suppressParent": "none"
     },
-    "Nuproj": "0.10.27-beta-g2363d7cd98",
+    "Nuproj": "0.10.48-beta-gea4a31bbc5",
     "Nuproj.Common": {
-      "version": "0.10.27-beta-g2363d7cd98",
+      "version": "0.10.48-beta-gea4a31bbc5",
       "suppressParent": "none"
     },
     "StyleCop.Analyzers": "1.0.0-rc2"

--- a/src/Windows.Core.Tests/project.json
+++ b/src/Windows.Core.Tests/project.json
@@ -8,7 +8,6 @@
     ".NETFramework,Version=v4.6": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/src/Windows.Core/project.json
+++ b/src/Windows.Core/project.json
@@ -2,12 +2,12 @@
   "supports": { },
   "dependencies": {
     "Nerdbank.GitVersioning": {
-      "version": "1.3.8",
+      "version": "1.4.6",
       "suppressParent": "none"
     },
-    "Nuproj": "0.10.27-beta-g2363d7cd98",
+    "Nuproj": "0.10.48-beta-gea4a31bbc5",
     "Nuproj.Common": {
-      "version": "0.10.27-beta-g2363d7cd98",
+      "version": "0.10.48-beta-gea4a31bbc5",
       "suppressParent": "none"
     },
     "StyleCop.Analyzers": "1.0.0-rc2"

--- a/templates/LIBNAME.Desktop/project.json
+++ b/templates/LIBNAME.Desktop/project.json
@@ -6,7 +6,6 @@
     ".NETFramework,Version=v4.0": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }

--- a/templates/LIBNAME.Tests/project.json
+++ b/templates/LIBNAME.Tests/project.json
@@ -8,7 +8,6 @@
     ".NETFramework,Version=v4.6": { }
   },
   "runtimes": {
-    "win-anycpu": { },
     "win": { }
   }
 }


### PR DESCRIPTION
This fixes the "invalid portable frameworks" error that the latest versions of nuget.exe fail with.
