### PR TITLE
add CharSet.Unicode to FindWindowEx and fix return type of SendMessage

### DIFF
--- a/src/User32.Desktop/User32.cs
+++ b/src/User32.Desktop/User32.cs
@@ -93,7 +93,7 @@ namespace PInvoke
         [DllImport(nameof(User32), SetLastError = false)]
         public static extern int ReleaseDC(IntPtr hWnd, IntPtr hDC);
 
-        [DllImport(nameof(User32), SetLastError = true)]
+        [DllImport(nameof(User32), SetLastError = true, CharSet = CharSet.Unicode)]
         public static extern IntPtr FindWindowEx(
             IntPtr parentHandle,
             IntPtr childAfter,
@@ -107,7 +107,7 @@ namespace PInvoke
         public static extern IntPtr GetForegroundWindow();
 
         [DllImport(nameof(User32))]
-        public static extern int SendMessage(IntPtr hWnd, int wMsg, IntPtr wParam, IntPtr lParam);
+        public static extern IntPtr SendMessage(IntPtr hWnd, int wMsg, IntPtr wParam, IntPtr lParam);
 
         /// <summary>
         ///     Brings the thread that created the specified window into the foreground and activates the window. Keyboard


### PR DESCRIPTION
[FindWindowEx](https://msdn.microsoft.com/en-us/library/windows/desktop/ms633500%28v=vs.85%29.aspx) is missing CharSet.Unicode.
[SendMessage](https://msdn.microsoft.com/en-us/library/ms644950%28VS.85%29.aspx) returns an LRESULT but is declared as returning an int.

All tests pass when I run build.cmd but the build fails from the IDE. I think this is a side effect of installing VS2015 Update 2 but haven't yet determined the cause.
