### PR TITLE
Unify XML documentation and Resharper warning suppression

### DIFF
--- a/src/AdvApi32.Desktop/AdvApi32+SERVICE_TRIGGER_SPECIFIC_DATA_ITEM.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+SERVICE_TRIGGER_SPECIFIC_DATA_ITEM.cs
@@ -7,7 +7,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="SERVICE_TRIGGER_SPECIFIC_DATA_ITEM"/> nested struct.
+    /// Contains the <see cref="SERVICE_TRIGGER_SPECIFIC_DATA_ITEM"/> nested type.
     /// </content>
     public partial class AdvApi32
     {

--- a/src/AdvApi32.Desktop/AdvApi32+SafeServiceHandle.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+SafeServiceHandle.cs
@@ -7,7 +7,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="SafeServiceHandle"/> nested class.
+    /// Contains the <see cref="SafeServiceHandle"/> nested type.
     /// </content>
     public partial class AdvApi32
     {

--- a/src/AdvApi32.Desktop/AdvApi32+ServiceAccess.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServiceAccess.cs
@@ -7,7 +7,7 @@ namespace PInvoke
     using static Kernel32.ACCESS_MASK.StandardRight;
 
     /// <content>
-    /// Contains the <see cref="ServiceAccess"/> nested enum.
+    /// Contains the <see cref="ServiceAccess"/> nested type.
     /// </content>
     public partial class AdvApi32
     {

--- a/src/AdvApi32.Desktop/AdvApi32+ServiceControl.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServiceControl.cs
@@ -4,7 +4,7 @@
 namespace PInvoke
 {
     /// <content>
-    /// Contains the <see cref="ServiceControl"/> nested enum.
+    /// Contains the <see cref="ServiceControl"/> nested type.
     /// </content>
     public static partial class AdvApi32
     {

--- a/src/AdvApi32.Desktop/AdvApi32+ServiceControlAction.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServiceControlAction.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="ServiceControlAction"/> nested struct.
+    /// Contains the <see cref="ServiceControlAction"/> nested type.
     /// </content>
     public static partial class AdvApi32
     {

--- a/src/AdvApi32.Desktop/AdvApi32+ServiceControlActionType.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServiceControlActionType.cs
@@ -4,7 +4,7 @@
 namespace PInvoke
 {
     /// <content>
-    /// Contains the <see cref="ServiceControlActionType"/> nested enum.
+    /// Contains the <see cref="ServiceControlActionType"/> nested type.
     /// </content>
     public static partial class AdvApi32
     {

--- a/src/AdvApi32.Desktop/AdvApi32+ServiceDelayedAutoStartInfo.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServiceDelayedAutoStartInfo.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="ServiceDelayedAutoStartInfo"/> nested struct.
+    /// Contains the <see cref="ServiceDelayedAutoStartInfo"/> nested type.
     /// </content>
     public static partial class AdvApi32
     {

--- a/src/AdvApi32.Desktop/AdvApi32+ServiceDescription.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServiceDescription.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="ServiceDescription"/> nested struct.
+    /// Contains the <see cref="ServiceDescription"/> nested type.
     /// </content>
     public static partial class AdvApi32
     {

--- a/src/AdvApi32.Desktop/AdvApi32+ServiceErrorControl.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServiceErrorControl.cs
@@ -4,7 +4,7 @@
 namespace PInvoke
 {
     /// <content>
-    /// Contains the <see cref="ServiceErrorControl"/> nested enum.
+    /// Contains the <see cref="ServiceErrorControl"/> nested type.
     /// </content>
     public partial class AdvApi32
     {

--- a/src/AdvApi32.Desktop/AdvApi32+ServiceFailureActions.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServiceFailureActions.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="ServiceFailureActions"/> nested struct.
+    /// Contains the <see cref="ServiceFailureActions"/> nested type.
     /// </content>
     public static partial class AdvApi32
     {

--- a/src/AdvApi32.Desktop/AdvApi32+ServiceInfoLevel.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServiceInfoLevel.cs
@@ -4,7 +4,7 @@
 namespace PInvoke
 {
     /// <content>
-    /// Contains the <see cref="ServiceInfoLevel"/> nested enum.
+    /// Contains the <see cref="ServiceInfoLevel"/> nested type.
     /// </content>
     public static partial class AdvApi32
     {

--- a/src/AdvApi32.Desktop/AdvApi32+ServiceLaunchProtected.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServiceLaunchProtected.cs
@@ -4,7 +4,7 @@
 namespace PInvoke
 {
     /// <content>
-    /// Contains the <see cref="ServiceLaunchProtected"/> nested enum.
+    /// Contains the <see cref="ServiceLaunchProtected"/> nested type.
     /// </content>
     public static partial class AdvApi32
     {

--- a/src/AdvApi32.Desktop/AdvApi32+ServiceLaunchProtectedInfo.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServiceLaunchProtectedInfo.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="ServiceLaunchProtectedInfo"/> nested struct.
+    /// Contains the <see cref="ServiceLaunchProtectedInfo"/> nested type.
     /// </content>
     public static partial class AdvApi32
     {

--- a/src/AdvApi32.Desktop/AdvApi32+ServiceManagerAccess.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServiceManagerAccess.cs
@@ -7,7 +7,7 @@ namespace PInvoke
     using static Kernel32.ACCESS_MASK.StandardRight;
 
     /// <content>
-    /// Contains the <see cref="ServiceManagerAccess"/> nested enum.
+    /// Contains the <see cref="ServiceManagerAccess"/> nested type.
     /// </content>
     public partial class AdvApi32
     {

--- a/src/AdvApi32.Desktop/AdvApi32+ServicePreferredNodeInfo.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServicePreferredNodeInfo.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="ServicePreferredNodeInfo"/> nested struct.
+    /// Contains the <see cref="ServicePreferredNodeInfo"/> nested type.
     /// </content>
     public static partial class AdvApi32
     {

--- a/src/AdvApi32.Desktop/AdvApi32+ServicePreshutdownInfo.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServicePreshutdownInfo.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="ServicePreshutdownInfo"/> nested struct.
+    /// Contains the <see cref="ServicePreshutdownInfo"/> nested type.
     /// </content>
     public static partial class AdvApi32
     {

--- a/src/AdvApi32.Desktop/AdvApi32+ServiceRequiredPrivilegesInfo.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServiceRequiredPrivilegesInfo.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="ServiceRequiredPrivilegesInfo"/> nested struct.
+    /// Contains the <see cref="ServiceRequiredPrivilegesInfo"/> nested type.
     /// </content>
     public static partial class AdvApi32
     {

--- a/src/AdvApi32.Desktop/AdvApi32+ServiceSidInfo.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServiceSidInfo.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="ServiceSidInfo"/> nested struct.
+    /// Contains the <see cref="ServiceSidInfo"/> nested type.
     /// </content>
     public static partial class AdvApi32
     {

--- a/src/AdvApi32.Desktop/AdvApi32+ServiceSidType.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServiceSidType.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="ServiceSidType"/> nested enum.
+    /// Contains the <see cref="ServiceSidType"/> nested type.
     /// </content>
     public static partial class AdvApi32
     {

--- a/src/AdvApi32.Desktop/AdvApi32+ServiceStartType.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServiceStartType.cs
@@ -4,7 +4,7 @@
 namespace PInvoke
 {
     /// <content>
-    /// Contains the <see cref="ServiceStartType"/> nested enum.
+    /// Contains the <see cref="ServiceStartType"/> nested type.
     /// </content>
     public partial class AdvApi32
     {

--- a/src/AdvApi32.Desktop/AdvApi32+ServiceState.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServiceState.cs
@@ -4,7 +4,7 @@
 namespace PInvoke
 {
     /// <content>
-    /// Contains the <see cref="ServiceState"/> nested enum.
+    /// Contains the <see cref="ServiceState"/> nested type.
     /// </content>
     public partial class AdvApi32
     {

--- a/src/AdvApi32.Desktop/AdvApi32+ServiceStateQuery.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServiceStateQuery.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="ServiceStateQuery"/> nested enum.
+    /// Contains the <see cref="ServiceStateQuery"/> nested type.
     /// </content>
     public partial class AdvApi32
     {

--- a/src/AdvApi32.Desktop/AdvApi32+ServiceTrigger.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServiceTrigger.cs
@@ -7,7 +7,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="ServiceTrigger"/> nested struct.
+    /// Contains the <see cref="ServiceTrigger"/> nested type.
     /// </content>
     public static partial class AdvApi32
     {

--- a/src/AdvApi32.Desktop/AdvApi32+ServiceTriggerAction.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServiceTriggerAction.cs
@@ -4,7 +4,7 @@
 namespace PInvoke
 {
     /// <content>
-    /// Contains the <see cref="ServiceTriggerAction"/> nested enum.
+    /// Contains the <see cref="ServiceTriggerAction"/> nested type.
     /// </content>
     public static partial class AdvApi32
     {

--- a/src/AdvApi32.Desktop/AdvApi32+ServiceTriggerDataType.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServiceTriggerDataType.cs
@@ -4,7 +4,7 @@
 namespace PInvoke
 {
     /// <content>
-    /// Contains the <see cref="ServiceTriggerDataType"/> nested enum.
+    /// Contains the <see cref="ServiceTriggerDataType"/> nested type.
     /// </content>
     public partial class AdvApi32
     {

--- a/src/AdvApi32.Desktop/AdvApi32+ServiceTriggerInfo.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServiceTriggerInfo.cs
@@ -7,7 +7,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="ServiceTriggerInfo"/> nested struct.
+    /// Contains the <see cref="ServiceTriggerInfo"/> nested type.
     /// </content>
     public static partial class AdvApi32
     {

--- a/src/AdvApi32.Desktop/AdvApi32+ServiceTriggerType.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServiceTriggerType.cs
@@ -4,7 +4,7 @@
 namespace PInvoke
 {
     /// <content>
-    /// Contains the <see cref="ServiceTriggerType"/> nested enum.
+    /// Contains the <see cref="ServiceTriggerType"/> nested type.
     /// </content>
     public static partial class AdvApi32
     {

--- a/src/AdvApi32.Desktop/AdvApi32+ServiceType.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+ServiceType.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="ServiceType"/> nested enum.
+    /// Contains the <see cref="ServiceType"/> nested type.
     /// </content>
     public partial class AdvApi32
     {

--- a/src/BCrypt.Desktop/BCrypt+ConfigurationTable.cs
+++ b/src/BCrypt.Desktop/BCrypt+ConfigurationTable.cs
@@ -4,7 +4,7 @@
 namespace PInvoke
 {
     /// <content>
-    /// Contains the <see cref="ChainingModes"/> nested class.
+    /// Contains the <see cref="ChainingModes"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+AlgorithmIdentifiers.cs
+++ b/src/BCrypt.Shared/BCrypt+AlgorithmIdentifiers.cs
@@ -4,7 +4,7 @@
 namespace PInvoke
 {
     /// <content>
-    /// Contains the <see cref="AlgorithmIdentifiers"/> nested class.
+    /// Contains the <see cref="AlgorithmIdentifiers"/> nested type.
     /// </content>
     public static partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+AsymmetricKeyBlobTypes.cs
+++ b/src/BCrypt.Shared/BCrypt+AsymmetricKeyBlobTypes.cs
@@ -6,7 +6,7 @@
 namespace PInvoke
 {
     /// <content>
-    /// Contains the <see cref="AsymmetricKeyBlobTypes"/> nested class.
+    /// Contains the <see cref="AsymmetricKeyBlobTypes"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+BCRYPT_KEY_LENGTHS_STRUCT.cs
+++ b/src/BCrypt.Shared/BCrypt+BCRYPT_KEY_LENGTHS_STRUCT.cs
@@ -7,7 +7,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="BCRYPT_KEY_LENGTHS_STRUCT"/> nested struct.
+    /// Contains the <see cref="BCRYPT_KEY_LENGTHS_STRUCT"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+BCryptBuffer.cs
+++ b/src/BCrypt.Shared/BCrypt+BCryptBuffer.cs
@@ -7,7 +7,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// The <see cref="BCryptBuffer"/> nested class.
+    /// The <see cref="BCryptBuffer"/> nested type.
     /// </content>
     public static partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+BCryptBufferDesc.cs
+++ b/src/BCrypt.Shared/BCrypt+BCryptBufferDesc.cs
@@ -7,7 +7,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// The <see cref="BCryptBufferDesc"/> nested class.
+    /// The <see cref="BCryptBufferDesc"/> nested type.
     /// </content>
     public static partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+BCryptCloseAlgorithmProviderFlags.cs
+++ b/src/BCrypt.Shared/BCrypt+BCryptCloseAlgorithmProviderFlags.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="BCryptCloseAlgorithmProviderFlags"/> nested enum.
+    /// Contains the <see cref="BCryptCloseAlgorithmProviderFlags"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+BCryptCreateHashFlags.cs
+++ b/src/BCrypt.Shared/BCrypt+BCryptCreateHashFlags.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="BCryptCreateHashFlags"/> nested enum.
+    /// Contains the <see cref="BCryptCreateHashFlags"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+BCryptDeriveKeyFlags.cs
+++ b/src/BCrypt.Shared/BCrypt+BCryptDeriveKeyFlags.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="BCryptDeriveKeyFlags"/> nested enum.
+    /// Contains the <see cref="BCryptDeriveKeyFlags"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+BCryptEncryptFlags.cs
+++ b/src/BCrypt.Shared/BCrypt+BCryptEncryptFlags.cs
@@ -7,7 +7,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="BCryptEncryptFlags"/> nested enum.
+    /// Contains the <see cref="BCryptEncryptFlags"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+BCryptEnumAlgorithmsFlags.cs
+++ b/src/BCrypt.Shared/BCrypt+BCryptEnumAlgorithmsFlags.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="BCryptEnumAlgorithmsFlags"/> nested enum.
+    /// Contains the <see cref="BCryptEnumAlgorithmsFlags"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+BCryptExportKeyFlags.cs
+++ b/src/BCrypt.Shared/BCrypt+BCryptExportKeyFlags.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="BCryptExportKeyFlags"/> nested enum.
+    /// Contains the <see cref="BCryptExportKeyFlags"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+BCryptFinalizeKeyPairFlags.cs
+++ b/src/BCrypt.Shared/BCrypt+BCryptFinalizeKeyPairFlags.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="BCryptFinalizeKeyPairFlags"/> nested enum.
+    /// Contains the <see cref="BCryptFinalizeKeyPairFlags"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+BCryptFinishHashFlags.cs
+++ b/src/BCrypt.Shared/BCrypt+BCryptFinishHashFlags.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="BCryptFinishHashFlags"/> nested enum.
+    /// Contains the <see cref="BCryptFinishHashFlags"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+BCryptGenRandomFlags.cs
+++ b/src/BCrypt.Shared/BCrypt+BCryptGenRandomFlags.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="BCryptGenRandomFlags"/> nested enum.
+    /// Contains the <see cref="BCryptGenRandomFlags"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+BCryptGenerateKeyPairFlags.cs
+++ b/src/BCrypt.Shared/BCrypt+BCryptGenerateKeyPairFlags.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="BCryptGenerateKeyPairFlags"/> nested enum.
+    /// Contains the <see cref="BCryptGenerateKeyPairFlags"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+BCryptGenerateSymmetricKeyFlags.cs
+++ b/src/BCrypt.Shared/BCrypt+BCryptGenerateSymmetricKeyFlags.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="BCryptGenerateSymmetricKeyFlags"/> nested enum.
+    /// Contains the <see cref="BCryptGenerateSymmetricKeyFlags"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+BCryptGetPropertyFlags.cs
+++ b/src/BCrypt.Shared/BCrypt+BCryptGetPropertyFlags.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="BCryptGetPropertyFlags"/> nested enum.
+    /// Contains the <see cref="BCryptGetPropertyFlags"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+BCryptHashDataFlags.cs
+++ b/src/BCrypt.Shared/BCrypt+BCryptHashDataFlags.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="BCryptHashDataFlags"/> nested enum.
+    /// Contains the <see cref="BCryptHashDataFlags"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+BCryptImportKeyFlags.cs
+++ b/src/BCrypt.Shared/BCrypt+BCryptImportKeyFlags.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="BCryptImportKeyFlags"/> nested enum.
+    /// Contains the <see cref="BCryptImportKeyFlags"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+BCryptImportKeyPairFlags.cs
+++ b/src/BCrypt.Shared/BCrypt+BCryptImportKeyPairFlags.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="BCryptImportKeyPairFlags"/> nested enum.
+    /// Contains the <see cref="BCryptImportKeyPairFlags"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+BCryptOpenAlgorithmProviderFlags.cs
+++ b/src/BCrypt.Shared/BCrypt+BCryptOpenAlgorithmProviderFlags.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="BCryptOpenAlgorithmProviderFlags"/> nested enum.
+    /// Contains the <see cref="BCryptOpenAlgorithmProviderFlags"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+BCryptSecretAgreementFlags.cs
+++ b/src/BCrypt.Shared/BCrypt+BCryptSecretAgreementFlags.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="BCryptSecretAgreementFlags"/> nested enum.
+    /// Contains the <see cref="BCryptSecretAgreementFlags"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+BCryptSetPropertyFlags.cs
+++ b/src/BCrypt.Shared/BCrypt+BCryptSetPropertyFlags.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="BCryptSetPropertyFlags"/> nested enum.
+    /// Contains the <see cref="BCryptSetPropertyFlags"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+BCryptSignHashFlags.cs
+++ b/src/BCrypt.Shared/BCrypt+BCryptSignHashFlags.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="BCryptSignHashFlags"/> nested enum.
+    /// Contains the <see cref="BCryptSignHashFlags"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+BufferType.cs
+++ b/src/BCrypt.Shared/BCrypt+BufferType.cs
@@ -4,7 +4,7 @@
 namespace PInvoke
 {
     /// <content>
-    /// Contains the <see cref="BufferType"/> nested enum.
+    /// Contains the <see cref="BufferType"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+ChainingModes.cs
+++ b/src/BCrypt.Shared/BCrypt+ChainingModes.cs
@@ -4,7 +4,7 @@
 namespace PInvoke
 {
     /// <content>
-    /// Contains the <see cref="ChainingModes"/> nested class.
+    /// Contains the <see cref="ChainingModes"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+EccKeyBlob.cs
+++ b/src/BCrypt.Shared/BCrypt+EccKeyBlob.cs
@@ -7,7 +7,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="EccKeyBlob"/> nested struct.
+    /// Contains the <see cref="EccKeyBlob"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+EccKeyBlobMagicNumbers.cs
+++ b/src/BCrypt.Shared/BCrypt+EccKeyBlobMagicNumbers.cs
@@ -4,7 +4,7 @@
 namespace PInvoke
 {
     /// <content>
-    /// Contains the <see cref="EccKeyBlobMagicNumbers"/> nested enum.
+    /// Contains the <see cref="EccKeyBlobMagicNumbers"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+KeyDerivationFunctions.cs
+++ b/src/BCrypt.Shared/BCrypt+KeyDerivationFunctions.cs
@@ -4,7 +4,7 @@
 namespace PInvoke
 {
     /// <content>
-    /// Contains the <see cref="KeyDerivationFunctions"/> nested class.
+    /// Contains the <see cref="KeyDerivationFunctions"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+PaddingSchemes.cs
+++ b/src/BCrypt.Shared/BCrypt+PaddingSchemes.cs
@@ -4,7 +4,7 @@
 namespace PInvoke
 {
     /// <content>
-    /// Contains the <see cref="PaddingSchemes"/> nested enum.
+    /// Contains the <see cref="PaddingSchemes"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+PropertyNames.cs
+++ b/src/BCrypt.Shared/BCrypt+PropertyNames.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="PropertyNames"/> nested class.
+    /// Contains the <see cref="PropertyNames"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+SafeAlgorithmHandle.cs
+++ b/src/BCrypt.Shared/BCrypt+SafeAlgorithmHandle.cs
@@ -7,7 +7,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// The <see cref="SafeAlgorithmHandle"/> nested class.
+    /// The <see cref="SafeAlgorithmHandle"/> nested type.
     /// </content>
     public static partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+SafeHashHandle.cs
+++ b/src/BCrypt.Shared/BCrypt+SafeHashHandle.cs
@@ -7,7 +7,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// The <see cref="SafeHashHandle"/> nested class.
+    /// The <see cref="SafeHashHandle"/> nested type.
     /// </content>
     public static partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+SafeKeyHandle.cs
+++ b/src/BCrypt.Shared/BCrypt+SafeKeyHandle.cs
@@ -7,7 +7,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// The <see cref="SafeKeyHandle"/> nested class.
+    /// The <see cref="SafeKeyHandle"/> nested type.
     /// </content>
     public static partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+SafeSecretHandle.cs
+++ b/src/BCrypt.Shared/BCrypt+SafeSecretHandle.cs
@@ -7,7 +7,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// The <see cref="SafeSecretHandle"/> nested class.
+    /// The <see cref="SafeSecretHandle"/> nested type.
     /// </content>
     public static partial class BCrypt
     {

--- a/src/BCrypt.Shared/BCrypt+SymmetricKeyBlobTypes.cs
+++ b/src/BCrypt.Shared/BCrypt+SymmetricKeyBlobTypes.cs
@@ -4,7 +4,7 @@
 namespace PInvoke
 {
     /// <content>
-    /// Contains the <see cref="SymmetricKeyBlobTypes"/> nested class.
+    /// Contains the <see cref="SymmetricKeyBlobTypes"/> nested type.
     /// </content>
     public partial class BCrypt
     {

--- a/src/Hid.Desktop/Hid+HiddAttributes.cs
+++ b/src/Hid.Desktop/Hid+HiddAttributes.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="HiddAttributes"/> nested class.
+    /// Contains the <see cref="HiddAttributes"/> nested type.
     /// </content>
     public static partial class Hid
     {

--- a/src/Hid.Desktop/Hid+HidpCaps.cs
+++ b/src/Hid.Desktop/Hid+HidpCaps.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="HidpCaps"/> nested class.
+    /// Contains the <see cref="HidpCaps"/> nested type.
     /// </content>
     public static partial class Hid
     {

--- a/src/Hid.Desktop/Hid+SafePreparsedDataHandle.cs
+++ b/src/Hid.Desktop/Hid+SafePreparsedDataHandle.cs
@@ -8,7 +8,7 @@ namespace PInvoke
     using static Kernel32;
 
     /// <content>
-    /// Contains the <see cref="SafeObjectHandle"/> nested class.
+    /// Contains the <see cref="SafeObjectHandle"/> nested type.
     /// </content>
     public static partial class Hid
     {

--- a/src/Kernel32.Desktop/Kernel32+ACL.cs
+++ b/src/Kernel32.Desktop/Kernel32+ACL.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="ACL"/> nested struct.
+    /// Contains the <see cref="ACL"/> nested type.
     /// </content>
     public partial class Kernel32
     {

--- a/src/Kernel32.Desktop/Kernel32+CreateFileFlags.cs
+++ b/src/Kernel32.Desktop/Kernel32+CreateFileFlags.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="CreateFileFlags"/> nested enum.
+    /// Contains the <see cref="CreateFileFlags"/> nested type.
     /// </content>
     public partial class Kernel32
     {

--- a/src/Kernel32.Desktop/Kernel32+CreateToolhelp32SnapshotFlags.cs
+++ b/src/Kernel32.Desktop/Kernel32+CreateToolhelp32SnapshotFlags.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="CreateToolhelp32SnapshotFlags"/> nested class.
+    /// Contains the <see cref="CreateToolhelp32SnapshotFlags"/> nested type.
     /// </content>
     public partial class Kernel32
     {

--- a/src/Kernel32.Desktop/Kernel32+CreationDisposition.cs
+++ b/src/Kernel32.Desktop/Kernel32+CreationDisposition.cs
@@ -4,7 +4,7 @@
 namespace PInvoke
 {
     /// <content>
-    /// Contains the <see cref="CreationDisposition"/> nested enum.
+    /// Contains the <see cref="CreationDisposition"/> nested type.
     /// </content>
     public partial class Kernel32
     {

--- a/src/Kernel32.Desktop/Kernel32+FileAccess.cs
+++ b/src/Kernel32.Desktop/Kernel32+FileAccess.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using static Kernel32.ACCESS_MASK.StandardRight;
 
     /// <content>
-    /// Contains the <see cref="FileAccess"/> nested enum.
+    /// Contains the <see cref="FileAccess"/> nested type.
     /// </content>
     public partial class Kernel32
     {

--- a/src/Kernel32.Desktop/Kernel32+FileShare.cs
+++ b/src/Kernel32.Desktop/Kernel32+FileShare.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="FileShare"/> nested enum.
+    /// Contains the <see cref="FileShare"/> nested type.
     /// </content>
     public partial class Kernel32
     {

--- a/src/Kernel32.Desktop/Kernel32+MODULEENTRY32.cs
+++ b/src/Kernel32.Desktop/Kernel32+MODULEENTRY32.cs
@@ -11,7 +11,7 @@ namespace PInvoke
     using System.Text;
 
     /// <content>
-    /// Contains the <see cref="MODULEENTRY32" /> nested struct.
+    /// Contains the <see cref="MODULEENTRY32" /> nested type.
     /// </content>
     public partial class Kernel32
     {

--- a/src/Kernel32.Desktop/Kernel32+PROCESSENTRY32.cs
+++ b/src/Kernel32.Desktop/Kernel32+PROCESSENTRY32.cs
@@ -9,7 +9,7 @@ namespace PInvoke
     using System.Text;
 
     /// <content>
-    /// Contains the <see cref="PROCESSENTRY32" /> nested struct.
+    /// Contains the <see cref="PROCESSENTRY32" /> nested type.
     /// </content>
     public partial class Kernel32
     {

--- a/src/Kernel32.Desktop/Kernel32+ProcessAccess.cs
+++ b/src/Kernel32.Desktop/Kernel32+ProcessAccess.cs
@@ -3,7 +3,7 @@
 
 namespace PInvoke
 {
-    /// <content>Contains the <see cref="ProcessAccess" /> nested struct.</content>
+    /// <content>Contains the <see cref="ProcessAccess" /> nested type.</content>
     public partial class Kernel32
     {
         /// <summary>

--- a/src/Kernel32.Desktop/Kernel32+QueryFullProcessImageNameFlags.cs
+++ b/src/Kernel32.Desktop/Kernel32+QueryFullProcessImageNameFlags.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="QueryFullProcessImageNameFlags" /> nested enum.
+    /// Contains the <see cref="QueryFullProcessImageNameFlags" /> nested type.
     /// </content>
     public partial class Kernel32
     {

--- a/src/Kernel32.Desktop/Kernel32+SECURITY_IMPERSONATION_LEVEL.cs
+++ b/src/Kernel32.Desktop/Kernel32+SECURITY_IMPERSONATION_LEVEL.cs
@@ -4,7 +4,7 @@
 namespace PInvoke
 {
     /// <content>
-    /// Contains the <see cref="SECURITY_IMPERSONATION_LEVEL"/> nested enum.
+    /// Contains the <see cref="SECURITY_IMPERSONATION_LEVEL"/> nested type.
     /// </content>
     public partial class Kernel32
     {

--- a/src/Kernel32.Desktop/Kernel32+STARTUPINFOEX.cs
+++ b/src/Kernel32.Desktop/Kernel32+STARTUPINFOEX.cs
@@ -7,7 +7,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="STARTUPINFOEX"/> nested struct.
+    /// Contains the <see cref="STARTUPINFOEX"/> nested type.
     /// </content>
     public partial class Kernel32
     {

--- a/src/Kernel32.Shared/Kernel32+FILETIME.cs
+++ b/src/Kernel32.Shared/Kernel32+FILETIME.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="FILETIME"/> nested struct.
+    /// Contains the <see cref="FILETIME"/> nested type.
     /// </content>
     public partial class Kernel32
     {

--- a/src/Kernel32.Shared/Kernel32+FINDEX_INFO_LEVELS.cs
+++ b/src/Kernel32.Shared/Kernel32+FINDEX_INFO_LEVELS.cs
@@ -4,7 +4,7 @@
 namespace PInvoke
 {
     /// <content>
-    /// Contains the <see cref="FINDEX_INFO_LEVELS"/> nested enum.
+    /// Contains the <see cref="FINDEX_INFO_LEVELS"/> nested type.
     /// </content>
     public partial class Kernel32
     {

--- a/src/Kernel32.Shared/Kernel32+FINDEX_SEARCH_OPS.cs
+++ b/src/Kernel32.Shared/Kernel32+FINDEX_SEARCH_OPS.cs
@@ -4,7 +4,7 @@
 namespace PInvoke
 {
     /// <content>
-    /// Contains the <see cref="FINDEX_SEARCH_OPS"/> nested enum.
+    /// Contains the <see cref="FINDEX_SEARCH_OPS"/> nested type.
     /// </content>
     public partial class Kernel32
     {

--- a/src/Kernel32.Shared/Kernel32+FindFirstFileExFlags.cs
+++ b/src/Kernel32.Shared/Kernel32+FindFirstFileExFlags.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="FindFirstFileExFlags"/> nested enum.
+    /// Contains the <see cref="FindFirstFileExFlags"/> nested type.
     /// </content>
     public partial class Kernel32
     {

--- a/src/Kernel32.Shared/Kernel32+FormatMessageFlags.cs
+++ b/src/Kernel32.Shared/Kernel32+FormatMessageFlags.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="FormatMessageFlags"/> nested enum.
+    /// Contains the <see cref="FormatMessageFlags"/> nested type.
     /// </content>
     public partial class Kernel32
     {

--- a/src/Kernel32.Shared/Kernel32+SECURITY_ATTRIBUTES.cs
+++ b/src/Kernel32.Shared/Kernel32+SECURITY_ATTRIBUTES.cs
@@ -9,7 +9,7 @@ namespace PInvoke
 #pragma warning disable SA1401 // Fields must be private
 
     /// <content>
-    /// Contains the <see cref="SECURITY_ATTRIBUTES"/> nested struct.
+    /// Contains the <see cref="SECURITY_ATTRIBUTES"/> nested type.
     /// </content>
     public partial class Kernel32
     {

--- a/src/Kernel32.Shared/Kernel32+SECURITY_DESCRIPTOR.cs
+++ b/src/Kernel32.Shared/Kernel32+SECURITY_DESCRIPTOR.cs
@@ -7,7 +7,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="SECURITY_DESCRIPTOR"/> nested struct.
+    /// Contains the <see cref="SECURITY_DESCRIPTOR"/> nested type.
     /// </content>
     public partial class Kernel32
     {

--- a/src/Kernel32.Shared/Kernel32+SafeFindFilesHandle.cs
+++ b/src/Kernel32.Shared/Kernel32+SafeFindFilesHandle.cs
@@ -7,7 +7,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="SafeFindFilesHandle"/> nested class.
+    /// Contains the <see cref="SafeFindFilesHandle"/> nested type.
     /// </content>
     public static partial class Kernel32
     {

--- a/src/Kernel32.Shared/Kernel32+SafeObjectHandle.cs
+++ b/src/Kernel32.Shared/Kernel32+SafeObjectHandle.cs
@@ -7,7 +7,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="SafeObjectHandle"/> nested class.
+    /// Contains the <see cref="SafeObjectHandle"/> nested type.
     /// </content>
     public static partial class Kernel32
     {

--- a/src/Kernel32.Shared/Kernel32+WIN32_FIND_DATA.cs
+++ b/src/Kernel32.Shared/Kernel32+WIN32_FIND_DATA.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="WIN32_FIND_DATA"/> nested struct.
+    /// Contains the <see cref="WIN32_FIND_DATA"/> nested type.
     /// </content>
     public partial class Kernel32
     {

--- a/src/NCrypt.Shared/NCrypt+KeyStorageProviders.cs
+++ b/src/NCrypt.Shared/NCrypt+KeyStorageProviders.cs
@@ -4,7 +4,7 @@
 namespace PInvoke
 {
     /// <content>
-    /// Contains the <see cref="KeyStorageProviders"/> nested class.
+    /// Contains the <see cref="KeyStorageProviders"/> nested type.
     /// </content>
     public partial class NCrypt
     {

--- a/src/NCrypt.Shared/NCrypt+LegacyKeySpec.cs
+++ b/src/NCrypt.Shared/NCrypt+LegacyKeySpec.cs
@@ -4,7 +4,7 @@
 namespace PInvoke
 {
     /// <content>
-    /// Contains the <see cref="LegacyKeySpec"/> nested class.
+    /// Contains the <see cref="LegacyKeySpec"/> nested type.
     /// </content>
     public partial class NCrypt
     {

--- a/src/NCrypt.Shared/NCrypt+NCRYPT_SUPPORTED_LENGTHS.cs
+++ b/src/NCrypt.Shared/NCrypt+NCRYPT_SUPPORTED_LENGTHS.cs
@@ -7,7 +7,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="NCRYPT_SUPPORTED_LENGTHS"/> nested struct.
+    /// Contains the <see cref="NCRYPT_SUPPORTED_LENGTHS"/> nested type.
     /// </content>
     public partial class NCrypt
     {

--- a/src/NCrypt.Shared/NCrypt+NCryptIsAlgSupportedFlags.cs
+++ b/src/NCrypt.Shared/NCrypt+NCryptIsAlgSupportedFlags.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="NCryptIsAlgSupportedFlags"/> nested enum.
+    /// Contains the <see cref="NCryptIsAlgSupportedFlags"/> nested type.
     /// </content>
     public partial class NCrypt
     {

--- a/src/NCrypt.Shared/NCrypt+NCryptOpenStorageProviderFlags.cs
+++ b/src/NCrypt.Shared/NCrypt+NCryptOpenStorageProviderFlags.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="NCryptOpenStorageProviderFlags"/> nested enum.
+    /// Contains the <see cref="NCryptOpenStorageProviderFlags"/> nested type.
     /// </content>
     public partial class NCrypt
     {

--- a/src/NCrypt.Shared/NCrypt+NCryptSignHashFlags.cs
+++ b/src/NCrypt.Shared/NCrypt+NCryptSignHashFlags.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="NCryptSignHashFlags"/> nested enum.
+    /// Contains the <see cref="NCryptSignHashFlags"/> nested type.
     /// </content>
     public partial class NCrypt
     {

--- a/src/NCrypt.Shared/NCrypt+SECURITY_STATUS.cs
+++ b/src/NCrypt.Shared/NCrypt+SECURITY_STATUS.cs
@@ -4,7 +4,7 @@
 namespace PInvoke
 {
     /// <content>
-    /// Contains the <see cref="SECURITY_STATUS"/> nested enum.
+    /// Contains the <see cref="SECURITY_STATUS"/> nested type.
     /// </content>
     public partial class NCrypt
     {

--- a/src/NCrypt.Shared/NCrypt+SafeKeyHandle.cs
+++ b/src/NCrypt.Shared/NCrypt+SafeKeyHandle.cs
@@ -7,7 +7,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="SafeKeyHandle"/> nested class.
+    /// Contains the <see cref="SafeKeyHandle"/> nested type.
     /// </content>
     public static partial class NCrypt
     {

--- a/src/NCrypt.Shared/NCrypt+SafeProviderHandle.cs
+++ b/src/NCrypt.Shared/NCrypt+SafeProviderHandle.cs
@@ -7,7 +7,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="SafeProviderHandle"/> nested class.
+    /// Contains the <see cref="SafeProviderHandle"/> nested type.
     /// </content>
     public static partial class NCrypt
     {

--- a/src/NCrypt.Shared/NCrypt+SafeSecretHandle.cs
+++ b/src/NCrypt.Shared/NCrypt+SafeSecretHandle.cs
@@ -7,7 +7,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="SafeSecretHandle"/> nested class.
+    /// Contains the <see cref="SafeSecretHandle"/> nested type.
     /// </content>
     public partial class NCrypt
     {

--- a/src/NTDll.Desktop/NTDll+OBJECT_ATTRIBUTES.cs
+++ b/src/NTDll.Desktop/NTDll+OBJECT_ATTRIBUTES.cs
@@ -7,7 +7,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="OBJECT_ATTRIBUTES"/> nested struct.
+    /// Contains the <see cref="OBJECT_ATTRIBUTES"/> nested type.
     /// </content>
     public static partial class NTDll
     {

--- a/src/NTDll.Desktop/NTDll+UNICODE_STRING.cs
+++ b/src/NTDll.Desktop/NTDll+UNICODE_STRING.cs
@@ -9,7 +9,7 @@ namespace PInvoke
 #pragma warning disable SA1401 // Fields must be private
 
     /// <content>
-    /// Contains the <see cref="UNICODE_STRING"/> nested struct.
+    /// Contains the <see cref="UNICODE_STRING"/> nested type.
     /// </content>
     public static partial class NTDll
     {

--- a/src/SetupApi.Desktop/SetupApi+DeviceInterfaceDataFlags.cs
+++ b/src/SetupApi.Desktop/SetupApi+DeviceInterfaceDataFlags.cs
@@ -7,7 +7,7 @@ namespace PInvoke
     using System.Diagnostics.CodeAnalysis;
 
     /// <content>
-    /// Contains the <see cref="DeviceInterfaceDataFlags"/> nested enum.
+    /// Contains the <see cref="DeviceInterfaceDataFlags"/> nested type.
     /// </content>
     public partial class SetupApi
     {

--- a/src/SetupApi.Desktop/SetupApi+GetClassDevsFlags.cs
+++ b/src/SetupApi.Desktop/SetupApi+GetClassDevsFlags.cs
@@ -7,7 +7,7 @@ namespace PInvoke
     using System.Diagnostics.CodeAnalysis;
 
     /// <content>
-    /// Contains the <see cref="GetClassDevsFlags"/> nested enum.
+    /// Contains the <see cref="GetClassDevsFlags"/> nested type.
     /// </content>
     public partial class SetupApi
     {

--- a/src/SetupApi.Desktop/SetupApi+SP_DEVICE_INTERFACE_DATA.cs
+++ b/src/SetupApi.Desktop/SetupApi+SP_DEVICE_INTERFACE_DATA.cs
@@ -7,7 +7,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="SP_DEVICE_INTERFACE_DATA"/> nested struct.
+    /// Contains the <see cref="SP_DEVICE_INTERFACE_DATA"/> nested type.
     /// </content>
     public partial class SetupApi
     {

--- a/src/SetupApi.Desktop/SetupApi+SP_DEVINFO_DATA.cs
+++ b/src/SetupApi.Desktop/SetupApi+SP_DEVINFO_DATA.cs
@@ -8,7 +8,7 @@ namespace PInvoke
     using System.Runtime.InteropServices;
 
     /// <content>
-    /// Contains the <see cref="SP_DEVINFO_DATA" /> nested struct.
+    /// Contains the <see cref="SP_DEVINFO_DATA" /> nested type.
     /// </content>
     public partial class SetupApi
     {

--- a/src/SetupApi.Desktop/SetupApi+SafeDeviceInfoSetHandle.cs
+++ b/src/SetupApi.Desktop/SetupApi+SafeDeviceInfoSetHandle.cs
@@ -8,7 +8,7 @@ namespace PInvoke
     using static Kernel32;
 
     /// <content>
-    /// Contains the <see cref="SafeDeviceInfoSetHandle"/> nested class.
+    /// Contains the <see cref="SafeDeviceInfoSetHandle"/> nested type.
     /// </content>
     public partial class SetupApi
     {

--- a/src/User32.Desktop/User32+SetWindowLongFlags.cs
+++ b/src/User32.Desktop/User32+SetWindowLongFlags.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="SetWindowLongFlags"/> nested enum.
+    /// Contains the <see cref="SetWindowLongFlags"/> nested type.
     /// </content>
     public partial class User32
     {

--- a/src/User32.Desktop/User32+SetWindowPosFlags.cs
+++ b/src/User32.Desktop/User32+SetWindowPosFlags.cs
@@ -7,7 +7,7 @@ namespace PInvoke
     using System.Diagnostics.CodeAnalysis;
 
     /// <content>
-    /// Contains the <see cref="SetWindowPosFlags"/> nested enum.
+    /// Contains the <see cref="SetWindowPosFlags"/> nested type.
     /// </content>
     public partial class User32
     {

--- a/src/User32.Desktop/User32+SetWindowPosFlags.cs
+++ b/src/User32.Desktop/User32+SetWindowPosFlags.cs
@@ -4,6 +4,7 @@
 namespace PInvoke
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
 
     /// <content>
     /// Contains the <see cref="SetWindowPosFlags"/> nested enum.
@@ -11,10 +12,9 @@ namespace PInvoke
     public partial class User32
     {
         [Flags]
+        [SuppressMessage("ReSharper", "InconsistentNaming", Justification = "Original API names are used for consistency")]
         public enum SetWindowPosFlags : uint
         {
-            // ReSharper disable InconsistentNaming
-
             /// <summary>
             ///     If the calling thread and the thread that owns the window are attached to different input queues, the system posts the request to the thread that owns the window. This prevents the calling thread from blocking its execution while other threads process the request.
             /// </summary>
@@ -89,8 +89,6 @@ namespace PInvoke
             ///     Displays the window.
             /// </summary>
             SWP_SHOWWINDOW = 0x0040,
-
-            // ReSharper restore InconsistentNaming
         }
     }
 }

--- a/src/User32.Desktop/User32+WindowLongIndexFlags.cs
+++ b/src/User32.Desktop/User32+WindowLongIndexFlags.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="WindowLongIndexFlags"/> nested enum.
+    /// Contains the <see cref="WindowLongIndexFlags"/> nested type.
     /// </content>
     public partial class User32
     {

--- a/src/User32.Desktop/User32+WindowShowStyle.cs
+++ b/src/User32.Desktop/User32+WindowShowStyle.cs
@@ -4,7 +4,7 @@
 namespace PInvoke
 {
     /// <content>
-    /// Contains the <see cref="WindowShowStyle"/> nested enum.
+    /// Contains the <see cref="WindowShowStyle"/> nested type.
     /// </content>
     public partial class User32
     {


### PR DESCRIPTION
Fixes 2 small issues :
- Use attributes instead of comments to disable R# warnings in SetWindowPosFlags #242
- Use a consistent XML documentation text for nested types #241
