### PR TITLE
Fail builds on warnings, and package updates

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ configuration: Release
 environment:
   VisualStudioVersion: 14.0
   GeneratePInvokesTxt: true
+  TreatWarningsAsErrors: true
   NuGetApiKey:
     secure: Ql19CstT9GvFNeSIAjXvgHXZg+/pNaYJ2jVkzde4LT2vwSyjiQgQ+M332wVYtu+r
 cache:

--- a/src/CodeGeneration/project.json
+++ b/src/CodeGeneration/project.json
@@ -12,7 +12,7 @@
       "version": "0.10.48-beta-gea4a31bbc5",
       "suppressParent": "none"
     },
-    "StyleCop.Analyzers": "1.0.0-rc2"
+    "StyleCop.Analyzers": "1.0.0"
   },
   "frameworks": {
     ".NETFramework,Version=v4.6": { }

--- a/src/CodeGeneration/project.json
+++ b/src/CodeGeneration/project.json
@@ -5,7 +5,7 @@
       "suppressParent": "none"
     },
     "Nerdbank.GitVersioning": {
-      "version": "1.4.6",
+      "version": "1.4.19",
       "suppressParent": "none"
     },
     "Nuproj.Common": {

--- a/src/CodeGenerationAttributes.Net40/project.json
+++ b/src/CodeGenerationAttributes.Net40/project.json
@@ -12,7 +12,7 @@
       "version": "0.10.48-beta-gea4a31bbc5",
       "suppressParent": "none"
     },
-    "StyleCop.Analyzers": "1.0.0-rc2"
+    "StyleCop.Analyzers": "1.0.0"
   },
   "frameworks": {
     ".NETFramework,Version=v4.0": { }

--- a/src/CodeGenerationAttributes.Net40/project.json
+++ b/src/CodeGenerationAttributes.Net40/project.json
@@ -5,7 +5,7 @@
       "suppressParent": "none"
     },
     "Nerdbank.GitVersioning": {
-      "version": "1.4.6",
+      "version": "1.4.19",
       "suppressParent": "none"
     },
     "Nuproj.Common": {

--- a/src/CodeGenerationAttributes.Profile111/project.json
+++ b/src/CodeGenerationAttributes.Profile111/project.json
@@ -5,7 +5,7 @@
       "suppressParent": "none"
     },
     "Nerdbank.GitVersioning": {
-      "version": "1.4.6",
+      "version": "1.4.19",
       "suppressParent": "none"
     },
     "Nuproj.Common": {

--- a/src/CodeGenerationAttributes.Profile111/project.json
+++ b/src/CodeGenerationAttributes.Profile111/project.json
@@ -12,7 +12,7 @@
       "version": "0.10.48-beta-gea4a31bbc5",
       "suppressParent": "none"
     },
-    "StyleCop.Analyzers": "1.0.0-rc2"
+    "StyleCop.Analyzers": "1.0.0"
   },
   "frameworks": {
     ".NETPortable,Version=v4.5,Profile=Profile111": { }

--- a/src/CodeGenerationAttributes/project.json
+++ b/src/CodeGenerationAttributes/project.json
@@ -12,7 +12,7 @@
       "version": "0.10.48-beta-gea4a31bbc5",
       "suppressParent": "none"
     },
-    "StyleCop.Analyzers": "1.0.0-rc2"
+    "StyleCop.Analyzers": "1.0.0"
   },
   "frameworks": {
     ".NETPortable,Version=v4.0,Profile=Profile92": { }

--- a/src/CodeGenerationAttributes/project.json
+++ b/src/CodeGenerationAttributes/project.json
@@ -5,7 +5,7 @@
       "suppressParent": "none"
     },
     "Nerdbank.GitVersioning": {
-      "version": "1.4.6",
+      "version": "1.4.19",
       "suppressParent": "none"
     },
     "Nuproj.Common": {

--- a/src/EnlistmentInfo.props
+++ b/src/EnlistmentInfo.props
@@ -8,7 +8,7 @@
     <ProjectRoot>$(MSBuildThisFileDirectory)..\</ProjectRoot>
     <SolutionDir>$(MSBuildThisFileDirectory)</SolutionDir>
     <NuProjPath>$(UserProfile)\.nuget\packages\NuProj\0.10.48-beta-gea4a31bbc5\tools\</NuProjPath>
-    <NerdbankGitVersioningPath>$(UserProfile)\.nuget\packages\Nerdbank.GitVersioning\1.4.6\</NerdbankGitVersioningPath>
+    <NerdbankGitVersioningPath>$(UserProfile)\.nuget\packages\Nerdbank.GitVersioning\1.4.19\</NerdbankGitVersioningPath>
 
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/src/NuProj.Extra.targets
+++ b/src/NuProj.Extra.targets
@@ -1,8 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VersionDependsOn>$(VersionDependsOn);GetNuPkgVersion</VersionDependsOn>
-    <licenseUrl>https://raw.githubusercontent.com/AArnott/PInvoke/$CommitId$/LICENSE.txt</licenseUrl>
+    <LicenseUrl>https://raw.githubusercontent.com/AArnott/PInvoke/$GitCommitIdShort$/LICENSE.txt</LicenseUrl>
   </PropertyGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -11,12 +10,6 @@
     <Error Condition="!Exists('$(NerdbankGitVersioningPath)build\NerdBank.GitVersioning.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(NerdbankGitVersioningPath)build\NerdBank.GitVersioning.targets'))" />
   </Target>
   <Import Project="$(NerdbankGitVersioningPath)build\NerdBank.GitVersioning.targets" Condition="Exists('$(NerdbankGitVersioningPath)build\NerdBank.GitVersioning.targets')" />
-  <Target Name="GetNuPkgVersion" DependsOnTargets="GetBuildVersion">
-    <PropertyGroup>
-      <Version>$(NuGetPackageVersion)</Version>
-      <NuSpecProperties>$(NuGetProperties);CommitId=$(GitCommitIdShort)</NuSpecProperties>
-    </PropertyGroup>
-  </Target>
   <Target Name="CopyAssemblyToLibDotNetFolder" DependsOnTargets="ConvertItems" AfterTargets="ConvertItems" Condition="false">
     <ItemGroup>
       <File Include="@(File)"

--- a/src/Windows.Core.Profile111/project.json
+++ b/src/Windows.Core.Profile111/project.json
@@ -2,7 +2,7 @@
   "supports": { },
   "dependencies": {
     "Nerdbank.GitVersioning": {
-      "version": "1.4.6",
+      "version": "1.4.19",
       "suppressParent": "none"
     },
     "Nuproj": "0.10.48-beta-gea4a31bbc5",

--- a/src/Windows.Core.Profile111/project.json
+++ b/src/Windows.Core.Profile111/project.json
@@ -10,7 +10,7 @@
       "version": "0.10.48-beta-gea4a31bbc5",
       "suppressParent": "none"
     },
-    "StyleCop.Analyzers": "1.0.0-rc2"
+    "StyleCop.Analyzers": "1.0.0"
   },
   "frameworks": {
     ".NETPortable,Version=v4.5,Profile=Profile111": { }

--- a/src/Windows.Core/project.json
+++ b/src/Windows.Core/project.json
@@ -2,7 +2,7 @@
   "supports": { },
   "dependencies": {
     "Nerdbank.GitVersioning": {
-      "version": "1.4.6",
+      "version": "1.4.19",
       "suppressParent": "none"
     },
     "Nuproj": "0.10.48-beta-gea4a31bbc5",

--- a/src/Windows.Core/project.json
+++ b/src/Windows.Core/project.json
@@ -10,7 +10,7 @@
       "version": "0.10.48-beta-gea4a31bbc5",
       "suppressParent": "none"
     },
-    "StyleCop.Analyzers": "1.0.0-rc2"
+    "StyleCop.Analyzers": "1.0.0"
   },
   "frameworks": {
     ".NETPortable,Version=v4.0,Profile=Profile92": { }


### PR DESCRIPTION
Set appveyor builds to fail for any build warning. This should make it readily apparent when PRs should not yet be merged since we are and wish to remain warning clean.

Also update StyleCop.Analyzers, and NB.GV
