### PR TITLE
Add missing enum values

### DIFF
--- a/src/AdvApi32.Desktop/AdvApi32+SECURITY_INFORMATION.cs
+++ b/src/AdvApi32.Desktop/AdvApi32+SECURITY_INFORMATION.cs
@@ -14,7 +14,7 @@ namespace PInvoke
         /// Identifies the object-related security information being set or queried.
         /// </summary>
         [Flags]
-        public enum SECURITY_INFORMATION
+        public enum SECURITY_INFORMATION : uint
         {
             /// <summary>
             ///     The resource properties of the object being referenced. The resource properties are stored in
@@ -24,7 +24,7 @@ namespace PInvoke
             ///     Windows Server 2008 R2, Windows 7, Windows Server 2008, Windows Vista, Windows Server 2003, and Windows XP:
             ///     This bit flag is not available.
             /// </remarks>
-            ATTRIBUTE_SECURITY_INFORMATION,
+            ATTRIBUTE_SECURITY_INFORMATION = 0x00000020,
 
             /// <summary>
             ///     All parts of the security descriptor. This is useful for backup and restore software that needs to preserve
@@ -34,32 +34,32 @@ namespace PInvoke
             ///     Windows Server 2008 R2, Windows 7, Windows Server 2008, Windows Vista, Windows Server 2003, and Windows XP:
             ///     This bit flag is not available.
             /// </remarks>
-            BACKUP_SECURITY_INFORMATION,
+            BACKUP_SECURITY_INFORMATION = 0x00010000,
 
             /// <summary>The DACL of the object is being referenced.</summary>
-            DACL_SECURITY_INFORMATION,
+            DACL_SECURITY_INFORMATION = 0x00000004,
 
             /// <summary>The primary group identifier of the object is being referenced.</summary>
-            GROUP_SECURITY_INFORMATION,
+            GROUP_SECURITY_INFORMATION = 0x00000002,
 
             /// <summary>
             ///     The mandatory integrity label is being referenced. The mandatory integrity label is an ACE in the SACL of the
             ///     object.
             /// </summary>
             /// <remarks>Windows Server 2003 and Windows XP:  This bit flag is not available.</remarks>
-            LABEL_SECURITY_INFORMATION,
+            LABEL_SECURITY_INFORMATION = 0x00000010,
 
             /// <summary>The owner identifier of the object is being referenced.</summary>
-            OWNER_SECURITY_INFORMATION,
+            OWNER_SECURITY_INFORMATION = 0x00000001,
 
             /// <summary>The DACL cannot inherit access control entries (ACEs).</summary>
-            PROTECTED_DACL_SECURITY_INFORMATION,
+            PROTECTED_DACL_SECURITY_INFORMATION = 0x80000000,
 
             /// <summary>The SACL cannot inherit ACEs.</summary>
-            PROTECTED_SACL_SECURITY_INFORMATION,
+            PROTECTED_SACL_SECURITY_INFORMATION = 0x40000000,
 
             /// <summary>The SACL of the object is being referenced.</summary>
-            SACL_SECURITY_INFORMATION,
+            SACL_SECURITY_INFORMATION = 0x00000008,
 
             /// <summary>
             ///     The Central Access Policy (CAP) identifier applicable on the object that is being referenced. Each CAP
@@ -69,13 +69,15 @@ namespace PInvoke
             ///     Windows Server 2008 R2, Windows 7, Windows Server 2008, Windows Vista, Windows Server 2003, and Windows XP:
             ///     This bit flag is not available.
             /// </remarks>
-            SCOPE_SECURITY_INFORMATION,
+            SCOPE_SECURITY_INFORMATION = 0x00000040,
 
             /// <summary>The DACL inherits ACEs from the parent object.</summary>
-            UNPROTECTED_DACL_SECURITY_INFORMATION,
+            UNPROTECTED_DACL_SECURITY_INFORMATION = 0x20000000,
 
             /// <summary>The SACL inherits ACEs from the parent object.</summary>
-            UNPROTECTED_SACL_SECURITY_INFORMATION
+            UNPROTECTED_SACL_SECURITY_INFORMATION = 0x10000000,
+
+            PROCESS_TRUST_LABEL_SECURITY_INFORMATION = 0x00000080
         }
     }
 }

--- a/src/User32.Desktop/User32+MenuItemFlags.cs
+++ b/src/User32.Desktop/User32+MenuItemFlags.cs
@@ -74,7 +74,34 @@ namespace PInvoke
             ///     Does not place a check mark next to the item (default). If the application supplies check-mark bitmaps (see
             ///     SetMenuItemBitmaps), this flag displays the clear bitmap next to the menu item.
             /// </summary>
-            MF_UNCHECKED = 0x00000000
+            MF_UNCHECKED = 0x00000000,
+
+            /// <summary>Indicates that the menu item is identified by it's command.</summary>
+            MF_BYCOMMAND = 0x00000000,
+
+            /// <summary>Indicates that the menu item is identified by it's zero-based relative position.</summary>
+            MF_BYPOSITION = 0x00000400,
+
+            /// <summary>Removes highlighting from the menu item.</summary>
+            MF_UNHILITE = 0x00000000,
+
+            /// <summary>Highlights the menu item</summary>
+            MF_HILITE = 0x00000080,
+
+            /// <summary>Obsolete -- only used by old RES files</summary>
+            MF_END = 0x00000080,
+
+            MF_USECHECKBITMAPS = 0x00000200,
+            MF_INSERT = 0x00000000,
+            MF_CHANGE = 0x00000080,
+            MF_APPEND = 0x00000100,
+            MF_DELETE = 0x00000200,
+            MF_REMOVE = 0x00001000,
+            MF_DEFAULT = 0x00001000,
+            MF_SYSMENU = 0x00002000,
+            MF_HELP = 0x00004000,
+            MF_RIGHTJUSTIFY = 0x00004000,
+            MF_MOUSESELECT = 0x00008000
         }
     }
 }

--- a/src/User32.Desktop/User32+MenuItemState.cs
+++ b/src/User32.Desktop/User32+MenuItemState.cs
@@ -3,49 +3,52 @@
 
 namespace PInvoke
 {
+    using System;
+
     /// <content>
     /// Contains the <see cref="MenuItemState"/> nested type.
     /// </content>
     public partial class User32
     {
         /// <summary>The menu item state in <see cref="MENUITEMINFO" />.</summary>
+        [Flags]
         public enum MenuItemState
         {
             /// <summary>
             ///     Checks the menu item. For more information about selected menu items, see the
             ///     <see cref="MENUITEMINFO.hbmpChecked" /> member.
             /// </summary>
-            MFS_CHECKED,
+            MFS_CHECKED = MenuItemFlags.MF_CHECKED,
 
             /// <summary>
             ///     Specifies that the menu item is the default. A menu can contain only one default menu item, which is displayed
             ///     in bold.
             /// </summary>
-            MFS_DEFAULT,
+            MFS_DEFAULT = MenuItemFlags.MF_DEFAULT,
 
             /// <summary>
             ///     Disables the menu item and grays it so that it cannot be selected. This is equivalent to
             ///     <see cref="MFS_GRAYED" />.
             /// </summary>
-            MFS_DISABLED,
+            MFS_DISABLED = MFS_GRAYED,
 
             /// <summary>Enables the menu item so that it can be selected. This is the default state.</summary>
-            MFS_ENABLED,
+            MFS_ENABLED = MenuItemFlags.MF_ENABLED,
 
             /// <summary>
             ///     Disables the menu item and grays it so that it cannot be selected. This is equivalent to
             ///     <see cref="MFS_DISABLED" />.
             /// </summary>
-            MFS_GRAYED,
+            MFS_GRAYED = 0x00000003,
 
             /// <summary>Highlights the menu item.</summary>
-            MFS_HILITE,
+            MFS_HILITE = MenuItemFlags.MF_HILITE,
 
             /// <summary>Unchecks the menu item. For more information about clear menu items, see the hbmpChecked member.</summary>
-            MFS_UNCHECKED,
+            MFS_UNCHECKED = MenuItemFlags.MF_UNCHECKED,
 
             /// <summary>Removes the highlight from the menu item. This is the default state.</summary>
-            MFS_UNHILITE
+            MFS_UNHILITE = MenuItemFlags.MF_UNHILITE
         }
     }
 }


### PR DESCRIPTION
Fixes #278

---

_Note_: No idea if it build as my work PC can't build the solution at the moment, showing :

> The package 'StyleCop.Analyzers/1.0.0' could not be found in the libraries section of the lock file. This may indicate your lock file is corrupted.

So i'll let appveyor decide :)
