### PR TITLE
`EndPaint` take a `ref` second parameter

### DIFF
--- a/src/User32.Desktop/User32.cs
+++ b/src/User32.Desktop/User32.cs
@@ -2608,7 +2608,7 @@ namespace PInvoke
         [return:MarshalAs(UnmanagedType.Bool)]
         public static extern unsafe bool EndPaint(
             IntPtr hWnd,
-            [Friendly(FriendlyFlags.In)] PAINTSTRUCT* lpPaint);
+            [Friendly(FriendlyFlags.Bidirectional)] PAINTSTRUCT* lpPaint);
 
         /// <summary>
         /// The BeginPaint function prepares the specified window for painting and fills a <see cref="PAINTSTRUCT"/> structure with information about the painting.


### PR DESCRIPTION
Andrew,

This patch fixes #298, which is:

> User32.EndPaint(System.IntPtr hWnd, PInvoke.User32.PAINTSTRUCT lpPaint) function should pass its second argument as a ref. I noticed this while updating a project to 0.3.152. The associated pull request works around the problem by changing the Friendly attribute from FriendlyFlag.In to FriendlyFlag.Bidirectional.

Regards,
David
