### PR TITLE
Make NCryptIsKeyHandle public

### DIFF
--- a/src/NCrypt.Desktop/NCrypt.cs
+++ b/src/NCrypt.Desktop/NCrypt.cs
@@ -35,6 +35,6 @@ namespace PInvoke
         /// <returns>Returns a nonzero value if the handle is a key handle or zero otherwise.</returns>
         [DllImport(nameof(NCrypt))]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool NCryptIsKeyHandle(IntPtr hKey);
+        public static extern bool NCryptIsKeyHandle(IntPtr hKey);
     }
 }


### PR DESCRIPTION
There is no reason to keep this method private (not sure why it was in the first place) and we have a request to make it public.
