### PR TITLE
Add INPUT union memory alignment test

### DIFF
--- a/src/User32.Tests/User32Facts.cs
+++ b/src/User32.Tests/User32Facts.cs
@@ -35,4 +35,27 @@ public partial class User32Facts
         Assert.Equal(1, (int)i.Inputs.ki.wVk);
         Assert.Equal(1, i.Inputs.mi.dx);
     }
+
+    /// <summary>
+    /// Validates that the union fields are all exactly 4 bytes (or 8 bytes on x64)
+    /// after the start of the struct.i
+    /// </summary>
+    /// <devremarks>
+    /// From http://www.pinvoke.net/default.aspx/Structures/INPUT.html:
+    /// The last 3 fields are a union, which is why they are all at the same memory offset.
+    /// On 64-Bit systems, the offset of the <see cref="mi"/>, <see cref="ki"/> and <see cref="hi"/> fields is 8,
+    /// because the nested struct uses the alignment of its biggest member, which is 8
+    /// (due to the 64-bit pointer in <see cref="KEYBDINPUT.dwExtraInfo"/>).
+    /// By separating the union into its own structure, rather than placing the
+    /// <see cref="mi"/>, <see cref="ki"/> and <see cref="hi"/> fields directly in the INPUT structure,
+    /// we assure that the .NET structure will have the correct alignment on both 32 and 64 bit.
+    /// </devremarks>
+    [Fact]
+    public unsafe void INPUT_UnionMemoryAlignment()
+    {
+        INPUT input;
+        Assert.Equal(IntPtr.Size, (long)&input.Inputs.hi - (long)&input);
+        Assert.Equal(IntPtr.Size, (long)&input.Inputs.mi - (long)&input);
+        Assert.Equal(IntPtr.Size, (long)&input.Inputs.ki - (long)&input);
+    }
 }

--- a/src/User32.Tests/User32Facts.cs
+++ b/src/User32.Tests/User32Facts.cs
@@ -38,7 +38,7 @@ public partial class User32Facts
 
     /// <summary>
     /// Validates that the union fields are all exactly 4 bytes (or 8 bytes on x64)
-    /// after the start of the struct.i
+    /// after the start of the struct.
     /// </summary>
     /// <devremarks>
     /// From http://www.pinvoke.net/default.aspx/Structures/INPUT.html:


### PR DESCRIPTION
Add test that @vbfox prescribed in #310 

This doesn't make the tests run in both x86 and x64 configurations as that's a bigger change I don't have time for yet. But I've coded the test such that I believe it will pass on both architectures.