### PR TITLE
Update CodeGeneration.Roslyn

### DIFF
--- a/src/CodeGeneration/CodeGeneration.csproj
+++ b/src/CodeGeneration/CodeGeneration.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>netstandard1.5</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\CodeGenerationAttributes\FriendlyFlags.cs">

--- a/src/CodeGeneration/OfferFriendlyOverloadsGenerator.cs
+++ b/src/CodeGeneration/OfferFriendlyOverloadsGenerator.cs
@@ -61,8 +61,10 @@ namespace PInvoke
         }
 
         /// <inheritdoc />
-        public Task<SyntaxList<MemberDeclarationSyntax>> GenerateAsync(MemberDeclarationSyntax applyTo, CSharpCompilation compilation, IProgress<Diagnostic> progress, CancellationToken cancellationToken)
+        public Task<SyntaxList<MemberDeclarationSyntax>> GenerateAsync(TransformationContext context, IProgress<Diagnostic> progress, CancellationToken cancellationToken)
         {
+            var applyTo = context.ProcessingMember;
+            var compilation = context.Compilation;
             var semanticModel = compilation.GetSemanticModel(applyTo.SyntaxTree);
             var type = (ClassDeclarationSyntax)applyTo;
             var generatedType = type

--- a/src/CodeGeneration/OfferIntPtrPropertyAccessorsGenerator.cs
+++ b/src/CodeGeneration/OfferIntPtrPropertyAccessorsGenerator.cs
@@ -33,8 +33,10 @@ namespace PInvoke
         }
 
         /// <inheritdoc />
-        public Task<SyntaxList<MemberDeclarationSyntax>> GenerateAsync(MemberDeclarationSyntax applyTo, CSharpCompilation compilation, IProgress<Diagnostic> progress, CancellationToken cancellationToken)
+        public Task<SyntaxList<MemberDeclarationSyntax>> GenerateAsync(TransformationContext context, IProgress<Diagnostic> progress, CancellationToken cancellationToken)
         {
+            var applyTo = context.ProcessingMember;
+            var compilation = context.Compilation;
             var applyToStruct = applyTo as StructDeclarationSyntax;
             var applyToClass = applyTo as ClassDeclarationSyntax;
             var applyToType = applyTo as TypeDeclarationSyntax;

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -70,7 +70,7 @@
   <ItemGroup>
     <PackageReference Include="MSBuild.Sdk.Extras" Version="1.0.0-rc4.25" PrivateAssets="all" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="$(NerdbankGitVersioningPackageVersion)" PrivateAssets="all" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.0.0" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup Condition=" '$(IsCodeGenerationProject)' != 'true' ">
     <PackageReference Include="CodeGeneration.Roslyn.BuildTime" Version="$(CodeGenerationPackageVersion)" PrivateAssets="all" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -30,7 +30,7 @@
     <IsPInvokeProject Condition=" '$(IsTestProject)' != 'true' and '$(IsCodeGenerationProject)' != 'true' ">true</IsPInvokeProject>
     <IsPackable Condition=" '$(IsTestProject)' == 'true' or '$(IsCodeGenerationProject)' == 'true' ">false</IsPackable>
 
-    <CodeGenerationPackageVersion>0.3.1</CodeGenerationPackageVersion>
+    <CodeGenerationPackageVersion>0.4.6</CodeGenerationPackageVersion>
     <NerdbankGitVersioningPackageVersion>1.6.21</NerdbankGitVersioningPackageVersion>
   </PropertyGroup>
 
@@ -40,7 +40,7 @@
 
   <PropertyGroup Condition=" '$(IsCodeGenerationProject)' != 'true' ">
     <RootNamespace>PInvoke</RootNamespace>
-    <AssemblyName >PInvoke.$(MSBuildProjectName)</AssemblyName>
+    <AssemblyName>PInvoke.$(MSBuildProjectName)</AssemblyName>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(IsTestProject)' == 'true' ">
@@ -61,7 +61,7 @@
   </ItemDefinitionGroup>
 
   <ItemGroup>
-    <GeneratorAssemblySearchPaths Include="$(MSBuildThisFileDirectory)..\bin\$(Configuration)\net46\" />
+    <GeneratorAssemblySearchPaths Include="$(MSBuildThisFileDirectory)..\bin\$(Configuration)\netstandard1.5\" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json"/>
     <None Include="$(MSBuildProjectName).exports.txt" Condition=" Exists('$(MSBuildProjectName).exports.txt') and '$(TargetFramework)' == 'net45' ">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -74,6 +74,7 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(IsCodeGenerationProject)' != 'true' ">
     <PackageReference Include="CodeGeneration.Roslyn.BuildTime" Version="$(CodeGenerationPackageVersion)" PrivateAssets="all" />
+    <DotNetCliToolReference Include="dotnet-codegen" Version="$(CodeGenerationPackageVersion)" />
     <ProjectReference Include="..\CodeGenerationAttributes\CodeGenerationAttributes.csproj" PrivateAssets="all" />
     <ProjectReference Include="..\CodeGeneration\CodeGeneration.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -8,5 +8,6 @@
     <add key="myget.org/F/aarnott" value="https://www.myget.org/F/aarnott/api/v3/index.json" />
     <add key="CodeGeneration.Roslyn CI" value="https://ci.appveyor.com/nuget/codegeneration-roslyn" />
     <add key="MSBuildSdkExtras CI" value="https://www.myget.org/F/msbuildsdkextras/api/v3/index.json" />
+    <add key="corefxlab" value="https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
This should help PInvoke be buildable on newer versions of VS2017