### PR TITLE
Build Windows.Core for net35

### DIFF
--- a/src/Windows.Core/Windows.Core.csproj
+++ b/src/Windows.Core/Windows.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(PortableOnlyFrameworks);net20</TargetFrameworks>
+    <TargetFrameworks>$(PortableOnlyFrameworks);net20;net35</TargetFrameworks>
     <Summary>P/Invoke types for common Windows APIs.</Summary>
     <Description>P/Invoke types for common Windows APIs.</Description>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #331 since the C# compiler has no need to embed the `ExtensionAttribute` into the assembly in net35.