### PR TITLE
Make 2-dimensional array accessible in Magnification structs

### DIFF
--- a/src/Magnification.Tests/MagnificationFacts.cs
+++ b/src/Magnification.Tests/MagnificationFacts.cs
@@ -23,8 +23,48 @@ public class MagnificationFacts
     }
 
     [Fact]
+    public void MAGCOLOREFFECT_MultidimensionalArray()
+    {
+        var effect = default(MAGCOLOREFFECT);
+        Assert.Throws<ArgumentOutOfRangeException>(() => effect[5, 0]);
+        Assert.Throws<ArgumentOutOfRangeException>(() => effect[0, 5]);
+        Assert.Throws<ArgumentOutOfRangeException>(() => effect[5, 0] = 0);
+        Assert.Throws<ArgumentOutOfRangeException>(() => effect[0, 5] = 0);
+
+        effect[0, 0] = 10.0f;
+        effect[0, 1] = 10.1f;
+        effect[1, 2] = 11.2f;
+        effect[4, 4] = 14.4f;
+
+        Assert.Equal(10.0f, effect[0, 0]);
+        Assert.Equal(10.1f, effect[0, 1]);
+        Assert.Equal(11.2f, effect[1, 2]);
+        Assert.Equal(14.4f, effect[4, 4]);
+    }
+
+    [Fact]
     public void MAGTRANSFORM_IsRightSize()
     {
         Assert.Equal(sizeof(float) * 3 * 3, Marshal.SizeOf<MAGTRANSFORM>());
+    }
+
+    [Fact]
+    public void MAGTRANSFORM_MultidimensionalArray()
+    {
+        var effect = default(MAGTRANSFORM);
+        Assert.Throws<ArgumentOutOfRangeException>(() => effect[3, 0]);
+        Assert.Throws<ArgumentOutOfRangeException>(() => effect[0, 3]);
+        Assert.Throws<ArgumentOutOfRangeException>(() => effect[3, 0] = 0);
+        Assert.Throws<ArgumentOutOfRangeException>(() => effect[0, 3] = 0);
+
+        effect[0, 0] = 10.0f;
+        effect[0, 1] = 10.1f;
+        effect[1, 2] = 11.2f;
+        effect[2, 2] = 12.2f;
+
+        Assert.Equal(10.0f, effect[0, 0]);
+        Assert.Equal(10.1f, effect[0, 1]);
+        Assert.Equal(11.2f, effect[1, 2]);
+        Assert.Equal(12.2f, effect[2, 2]);
     }
 }

--- a/src/Magnification/Magnification+MAGCOLOREFFECT.cs
+++ b/src/Magnification/Magnification+MAGCOLOREFFECT.cs
@@ -18,9 +18,38 @@ namespace PInvoke
         public unsafe struct MAGCOLOREFFECT
         {
             /// <summary>
+            /// Gets the length of each dimension in the flattened array.
+            /// </summary>
+            private const int OneDimensionLength = 5;
+
+            /// <summary>
             /// The transformation matrix. Always 5x5.
             /// </summary>
-            private fixed float transform[5 * 5];
+            private fixed float transform[OneDimensionLength * OneDimensionLength];
+
+            /// <summary>Gets or sets a value of the <see cref="transform" /> field of this struct.</summary>
+            /// <param name="x">The index into the first dimension of the array.</param>
+            /// <param name="y">The index into the second dimension of the array.</param>
+            public float this[int x, int y]
+            {
+                get
+                {
+                    CheckArrayRange(x, y, OneDimensionLength);
+                    fixed (float* array = this.transform)
+                    {
+                        return array[IndexIntoTwoDimensionalArray(x, y, OneDimensionLength)];
+                    }
+                }
+
+                set
+                {
+                    CheckArrayRange(x, y, OneDimensionLength);
+                    fixed (float* array = this.transform)
+                    {
+                        array[IndexIntoTwoDimensionalArray(x, y, OneDimensionLength)] = value;
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Magnification/Magnification+MAGCOLOREFFECT.cs
+++ b/src/Magnification/Magnification+MAGCOLOREFFECT.cs
@@ -18,14 +18,15 @@ namespace PInvoke
         public unsafe struct MAGCOLOREFFECT
         {
             /// <summary>
+            /// The transformation matrix. Represents a 2 dimensional array that is always 5x5 in size.
+            /// Use the indexer on the declaring struct for convenient 2D indexing into the array.
+            /// </summary>
+            public fixed float transform[OneDimensionLength * OneDimensionLength];
+
+            /// <summary>
             /// Gets the length of each dimension in the flattened array.
             /// </summary>
             private const int OneDimensionLength = 5;
-
-            /// <summary>
-            /// The transformation matrix. Always 5x5.
-            /// </summary>
-            private fixed float transform[OneDimensionLength * OneDimensionLength];
 
             /// <summary>Gets or sets a value of the <see cref="transform" /> field of this struct.</summary>
             /// <param name="x">The index into the first dimension of the array.</param>

--- a/src/Magnification/Magnification+MAGTRANSFORM.cs
+++ b/src/Magnification/Magnification+MAGTRANSFORM.cs
@@ -18,9 +18,38 @@ namespace PInvoke
         public unsafe struct MAGTRANSFORM
         {
             /// <summary>
+            /// Gets the length of each dimension in the flattened array.
+            /// </summary>
+            private const int OneDimensionLength = 3;
+
+            /// <summary>
             /// The transformation matrix. Always 3x3.
             /// </summary>
-            private fixed float v[3 * 3];
+            private fixed float v[OneDimensionLength * OneDimensionLength];
+
+            /// <summary>Gets or sets a value of the <see cref="v" /> field of this struct.</summary>
+            /// <param name="x">The index into the first dimension of the array.</param>
+            /// <param name="y">The index into the second dimension of the array.</param>
+            public float this[int x, int y]
+            {
+                get
+                {
+                    CheckArrayRange(x, y, OneDimensionLength);
+                    fixed (float* array = this.v)
+                    {
+                        return array[IndexIntoTwoDimensionalArray(x, y, OneDimensionLength)];
+                    }
+                }
+
+                set
+                {
+                    CheckArrayRange(x, y, OneDimensionLength);
+                    fixed (float* array = this.v)
+                    {
+                        array[IndexIntoTwoDimensionalArray(x, y, OneDimensionLength)] = value;
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Magnification/Magnification+MAGTRANSFORM.cs
+++ b/src/Magnification/Magnification+MAGTRANSFORM.cs
@@ -18,14 +18,15 @@ namespace PInvoke
         public unsafe struct MAGTRANSFORM
         {
             /// <summary>
+            /// The transformation matrix. Represents a 2 dimensional array that is always 3x3 in size.
+            /// Use the indexer on the declaring struct for convenient 2D indexing into the array.
+            /// </summary>
+            public fixed float v[OneDimensionLength * OneDimensionLength];
+
+            /// <summary>
             /// Gets the length of each dimension in the flattened array.
             /// </summary>
             private const int OneDimensionLength = 3;
-
-            /// <summary>
-            /// The transformation matrix. Always 3x3.
-            /// </summary>
-            private fixed float v[OneDimensionLength * OneDimensionLength];
 
             /// <summary>Gets or sets a value of the <see cref="v" /> field of this struct.</summary>
             /// <param name="x">The index into the first dimension of the array.</param>

--- a/src/Magnification/Magnification.Helpers.cs
+++ b/src/Magnification/Magnification.Helpers.cs
@@ -16,5 +16,36 @@ namespace PInvoke
         // For example, if a P/Invoke method requires allocating unmanaged memory
         // and freeing it up after the call, a helper method in this file would
         // make "P/Invoking" for most callers much easier and is a welcome addition.
+
+        /// <summary>
+        /// Gets the index into a one dimensional array that emulates a two dimensional array.
+        /// </summary>
+        /// <param name="x">The index into the first dimension.</param>
+        /// <param name="y">The index into the second dimension.</param>
+        /// <param name="dimensionLength">The length of the <paramref name="y" /> dimension.</param>
+        /// <returns>The index into a one-dimensional array that is equivalent to the specified two-dimensional indexes.</returns>
+        private static unsafe int IndexIntoTwoDimensionalArray(int x, int y, int dimensionLength)
+        {
+            return (x * dimensionLength) + y;
+        }
+
+        /// <summary>
+        /// Throws <see cref="ArgumentOutOfRangeException" /> if array indexers are out of range.
+        /// </summary>
+        /// <param name="x">The index into the first dimension of the array.</param>
+        /// <param name="y">The index into the second dimension of the array.</param>
+        /// <param name="dimensionLength">The length of both dimensions of the array.</param>
+        private static void CheckArrayRange(int x, int y, int dimensionLength)
+        {
+            if (x < 0 || x >= dimensionLength)
+            {
+                throw new ArgumentOutOfRangeException(nameof(x));
+            }
+
+            if (y < 0 || y >= dimensionLength)
+            {
+                throw new ArgumentOutOfRangeException(nameof(y));
+            }
+        }
     }
 }

--- a/src/Magnification/PublicAPI.Unshipped.txt
+++ b/src/Magnification/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 PInvoke.Magnification.MAGCOLOREFFECT.this[int x, int y].get -> float
 PInvoke.Magnification.MAGCOLOREFFECT.this[int x, int y].set -> void
+PInvoke.Magnification.MAGCOLOREFFECT.transform -> float*
 PInvoke.Magnification.MAGTRANSFORM.this[int x, int y].get -> float
 PInvoke.Magnification.MAGTRANSFORM.this[int x, int y].set -> void
+PInvoke.Magnification.MAGTRANSFORM.v -> float*

--- a/src/Magnification/PublicAPI.Unshipped.txt
+++ b/src/Magnification/PublicAPI.Unshipped.txt
@@ -1,0 +1,4 @@
+PInvoke.Magnification.MAGCOLOREFFECT.this[int x, int y].get -> float
+PInvoke.Magnification.MAGCOLOREFFECT.this[int x, int y].set -> void
+PInvoke.Magnification.MAGTRANSFORM.this[int x, int y].get -> float
+PInvoke.Magnification.MAGTRANSFORM.this[int x, int y].set -> void


### PR DESCRIPTION
I expose these 2-dimensional arrays as an indexer property instead of a 2-dimensional array off a named property. This is a divergence from our typical pattern of keeping to the names used in the header files. 
The reason is the multi-dimensional array has a fixed length and must be allocated within the struct. As such, it cannot be exposed as an array (much less a multi-dimensional one) to the outside (at least as far as I have been able to determine).
So instead, I could offer accessor methods to index into it, or I could expose the one-dimensional fixed array and leave it to callers to figure out how to index into it. I'm siding with aiding with the indexing. And a C# indexer seems more friendly and natural than methods.

I'm open to other ideas if I missed any.