### PR TITLE
Stop building to API Sets when targeting .NET Framework 2.0

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,7 +17,7 @@
     <Copyright>Copyright © $(Authors)</Copyright>
     <Tags>pinvoke .net pcl</Tags>
 
-    <DefineConstants Condition=" '$(TargetFramework)' != 'net40' ">$(DefineConstants);APISets</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFramework)' != 'net40' and '$(TargetFramework)' != 'net20' ">$(DefineConstants);APISets</DefineConstants>
     <NoWarn>CS1591</NoWarn>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)PInvoke.ruleset</CodeAnalysisRuleSet>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
If the folks on #350 are targeting .NET 2.0, this would fix that.