### PR TITLE
add note to CONTRIBUTING.md about needing optional .NET Core 1.0-1.1 component

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ Please send pull requests to add what you've come up with.
   * Desktop development with C++
   * .NET desktop development
   * .NET Core cross-platform development
+    * plus the optional component ".NET Core 1.0 - 1.1 development tools for Desktop"
 
 ## Guidelines
 


### PR DESCRIPTION
Without the optional ".NET Core 1.0-1.1 development tools for Web" component installed in VS 2017, you'll get a -2147450749 error from dotnet when building. This PR adds a note to CONTRIBUTING.md about this requirement.