### PR TITLE
Workaround for .NET Native toolchain issue

### DIFF
--- a/src/Kernel32/Kernel32.cs
+++ b/src/Kernel32/Kernel32.cs
@@ -94,7 +94,7 @@ namespace PInvoke
         /// If the function succeeds, the return value is a search handle used in a subsequent call to FindNextFile or FindClose, and the lpFindFileData parameter contains information about the first file or directory found.
         /// If the function fails or fails to locate files from the search string in the lpFileName parameter, the return value is INVALID_HANDLE_VALUE and the contents of lpFindFileData are indeterminate.To get extended error information, call the <see cref="GetLastError"/> function.
         /// </returns>
-        [DllImport(api_ms_win_core_file_l1_2_0, CharSet = CharSet.Unicode)]
+        [DllImport(api_ms_win_core_file_l1_2_0, EntryPoint = "FindFirstFileExW", ExactSpelling = true, CharSet = CharSet.Unicode)]
         public static unsafe extern SafeFindFilesHandle FindFirstFileEx(string lpFileName, FINDEX_INFO_LEVELS fInfoLevelId, out WIN32_FIND_DATA lpFindFileData, FINDEX_SEARCH_OPS fSearchOp, void* lpSearchFilter, FindFirstFileExFlags dwAdditionalFlags);
 
         /// <summary>
@@ -141,7 +141,7 @@ namespace PInvoke
         /// If the function succeeds, the return value is the number of TCHARs stored in the output buffer, excluding the terminating null character.
         /// If the function fails, the return value is zero. To get extended error information, call <see cref="GetLastError"/>.
         /// </returns>
-        [DllImport(api_ms_win_core_localization_l1_2_0, CharSet = CharSet.Unicode, SetLastError = true)]
+        [DllImport(api_ms_win_core_localization_l1_2_0, CharSet = CharSet.Unicode, EntryPoint = "FormatMessageW", ExactSpelling = true, SetLastError = true)]
         public static unsafe extern int FormatMessage(FormatMessageFlags dwFlags, void* lpSource, int dwMessageId, int dwLanguageId, StringBuilder lpBuffer, int nSize, IntPtr[] Arguments);
 
         /// <summary>
@@ -483,7 +483,7 @@ namespace PInvoke
         /// If the function fails, the return value is NULL. To get extended error information, call GetLastError.
         /// If the mutex is a named mutex and the object existed before this function call, the return value is a handle to the existing object, GetLastError returns ERROR_ALREADY_EXISTS, bInitialOwner is ignored, and the calling thread is not granted ownership. However, if the caller has limited access rights, the function will fail with ERROR_ACCESS_DENIED and the caller should use the OpenMutex function.
         /// </returns>
-        [DllImport(api_ms_win_core_synch_l1_2_0, CharSet = CharSet.Unicode, SetLastError = true)]
+        [DllImport(api_ms_win_core_synch_l1_2_0, EntryPoint = "CreateMutexW", ExactSpelling = true, CharSet = CharSet.Unicode, SetLastError = true)]
         public static extern unsafe SafeObjectHandle CreateMutex(
             [Friendly(FriendlyFlags.Optional | FriendlyFlags.In)] SECURITY_ATTRIBUTES* lpMutexAttributes,
             [MarshalAs(UnmanagedType.Bool)] bool bInitialOwner,


### PR DESCRIPTION
The issue is that SupportedAPIs-x86.xml and SupportedAPIs-x64.xml file, as found at
C:\Program Files (x86)\Windows Kits\10\App Certification Kit\SupportedAPIs-x??.xml
claim that some encoding-neutral methods are actually exported by Windows.
This leads .NET Native to generate bindings against them when they don't exist.

Until the Windows SDK is fixed, we workaround it by specifying the W unicode
suffix for the relevant methods directly.

Specifically changed are these methods:

* FirstFirstFileEx
* CreateMutex
* FormatMessage

Closes #377 by workaround