### PR TITLE
Update User32::WinEventProc and MSCorEE::GetVersionFromProcess

### DIFF
--- a/src/MSCorEE/MSCorEE.Helpers.cs
+++ b/src/MSCorEE/MSCorEE.Helpers.cs
@@ -73,14 +73,19 @@ namespace PInvoke
         /// <remarks>
         /// .NET Framework Versions: 4.5, 4, 3.5 SP1, 3.5, 3.0 SP1, 3.0, 2.0 SP1, 2.0
         /// </remarks>
-        public static string GetVersionFromProcess(SafeHandle hProcess)
+        public static unsafe string GetVersionFromProcess(SafeHandle hProcess)
         {
             const int insaneSize = 256 * 1024;
             char[] versionChars = new char[32];
             while (true)
             {
                 int dwLength;
-                HResult hr = GetVersionFromProcess(hProcess, versionChars, versionChars.Length, out dwLength);
+                HResult hr = -1;
+                fixed (char* versionCharsPtr = versionChars)
+                {
+                    hr = GetVersionFromProcess(hProcess, versionCharsPtr, versionChars.Length, out dwLength);
+                }
+
                 if (hr.Succeeded)
                 {
                     return new string(versionChars, 0, dwLength);

--- a/src/MSCorEE/MSCorEE.Helpers.cs
+++ b/src/MSCorEE/MSCorEE.Helpers.cs
@@ -73,19 +73,14 @@ namespace PInvoke
         /// <remarks>
         /// .NET Framework Versions: 4.5, 4, 3.5 SP1, 3.5, 3.0 SP1, 3.0, 2.0 SP1, 2.0
         /// </remarks>
-        public static unsafe string GetVersionFromProcess(SafeHandle hProcess)
+        public static string GetVersionFromProcess(SafeHandle hProcess)
         {
             const int insaneSize = 256 * 1024;
             char[] versionChars = new char[32];
             while (true)
             {
                 int dwLength;
-                HResult hr = -1;
-                fixed (char* versionCharsPtr = versionChars)
-                {
-                    hr = GetVersionFromProcess(hProcess, versionCharsPtr, versionChars.Length, out dwLength);
-                }
-
+                HResult hr = GetVersionFromProcess(hProcess, versionChars, versionChars.Length, out dwLength);
                 if (hr.Succeeded)
                 {
                     return new string(versionChars, 0, dwLength);

--- a/src/User32/User32.cs
+++ b/src/User32/User32.cs
@@ -162,7 +162,7 @@ namespace PInvoke
         /// <param name="dwmsEventTime">Specifies the time, in milliseconds, that the event was generated.</param>
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         public delegate void WinEventProc(
-            SafeEventHookHandle hWinEventHook,
+            IntPtr hWinEventHook,
             WindowsEventHookType @event,
             IntPtr hwnd,
             int idObject,


### PR DESCRIPTION
User32: Update WinEventProc - Runtime Issue
- Param 1 is IntPtr - Income parm should be be SafeEvent...
MSCorEE: Update GetVersionFromProcess - Compile Issue
- Can't cast [] to * without marking method unsafe and using a 'fixed' scope block.
