### PR TITLE
Adding support for .Net Standard 2.0 (which includes all APIs - i.e. even store banned APIs)

### DIFF
--- a/src/AdvApi32/AdvApi32.cs
+++ b/src/AdvApi32/AdvApi32.cs
@@ -23,17 +23,7 @@ namespace PInvoke
         public const uint SERVICE_NO_CHANGE = 0xFFFFFFFF;
 
 #pragma warning disable SA1303 // Const field names must begin with upper-case letter
-#if APISets
-        private const string api_ms_win_service_core_l1_1_1 = ApiSets.api_ms_win_service_core_l1_1_1;
-        private const string api_ms_win_service_management_l1_1_0 = ApiSets.api_ms_win_service_management_l1_1_0;
-        private const string api_ms_win_service_management_l2_1_0 = ApiSets.api_ms_win_service_management_l2_1_0;
-        private const string api_ms_win_core_processthreads_l1_1_1 = ApiSets.api_ms_win_core_processthreads_l1_1_1;
-        private const string api_ms_win_security_base_l1_2_0 = ApiSets.api_ms_win_security_base_l1_2_0;
-        private const string api_ms_win_service_winsvc_l1_2_0 = ApiSets.api_ms_win_service_winsvc_l1_2_0;
-        private const string api_ms_win_security_sddl_l1_1_0 = ApiSets.api_ms_win_security_sddl_l1_1_0;
-        private const string api_ms_win_core_processthreads_l1_1_2 = ApiSets.api_ms_win_core_processthreads_l1_1_2;
-        private const string api_ms_win_core_registry_l1_1_0 = ApiSets.api_ms_win_core_registry_l1_1_0;
-#else
+#if DESKTOP
         private const string api_ms_win_service_core_l1_1_1 = nameof(AdvApi32);
         private const string api_ms_win_service_management_l1_1_0 = nameof(AdvApi32);
         private const string api_ms_win_service_management_l2_1_0 = nameof(AdvApi32);
@@ -43,6 +33,16 @@ namespace PInvoke
         private const string api_ms_win_security_sddl_l1_1_0 = nameof(AdvApi32);
         private const string api_ms_win_core_processthreads_l1_1_2 = nameof(AdvApi32);
         private const string api_ms_win_core_registry_l1_1_0 = nameof(AdvApi32);
+#else
+        private const string api_ms_win_service_core_l1_1_1 = ApiSets.api_ms_win_service_core_l1_1_1;
+        private const string api_ms_win_service_management_l1_1_0 = ApiSets.api_ms_win_service_management_l1_1_0;
+        private const string api_ms_win_service_management_l2_1_0 = ApiSets.api_ms_win_service_management_l2_1_0;
+        private const string api_ms_win_core_processthreads_l1_1_1 = ApiSets.api_ms_win_core_processthreads_l1_1_1;
+        private const string api_ms_win_security_base_l1_2_0 = ApiSets.api_ms_win_security_base_l1_2_0;
+        private const string api_ms_win_service_winsvc_l1_2_0 = ApiSets.api_ms_win_service_winsvc_l1_2_0;
+        private const string api_ms_win_security_sddl_l1_1_0 = ApiSets.api_ms_win_security_sddl_l1_1_0;
+        private const string api_ms_win_core_processthreads_l1_1_2 = ApiSets.api_ms_win_core_processthreads_l1_1_2;
+        private const string api_ms_win_core_registry_l1_1_0 = ApiSets.api_ms_win_core_registry_l1_1_0;
 #endif
 #pragma warning restore SA1303 // Const field names must begin with upper-case letter
 

--- a/src/AdvApi32/AdvApi32.cs
+++ b/src/AdvApi32/AdvApi32.cs
@@ -1157,7 +1157,7 @@ namespace PInvoke
         /// privilege set.</param>
         /// <param name="ImpersonationLevel">Specifies a value from the <see cref="SECURITY_IMPERSONATION_LEVEL"/>
         /// enumeration that indicates the impersonation level of the new token.</param>
-        /// <param name="TokenType">pecifies one of the following values from the <see cref="TokenType"/> enumeration.</param>
+        /// <param name="TokenType">pecifies one of the following values from the <see cref="TOKEN_TYPE"/> enumeration.</param>
         /// <param name="phNewToken">A pointer to a <see cref="SafeObjectHandle"/> variable that receives the new token.</param>
         /// <returns>If the function succeeds, the function returns a nonzero value.
         /// If the function fails, it returns zero.To get extended error information, call GetLastError.</returns>

--- a/src/AdvApi32/AdvApi32.csproj
+++ b/src/AdvApi32/AdvApi32.csproj
@@ -5,6 +5,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Kernel32\Kernel32.csproj" />
     <ProjectReference Include="..\Windows.Core\Windows.Core.csproj" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
   </ItemGroup>
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
     <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)..\obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
     <OutputPath>$(MSBuildThisFileDirectory)..\bin\$(Configuration)\</OutputPath>
 
-    <DesktopOnlyFrameworks>net45;net40;net20</DesktopOnlyFrameworks>
+    <DesktopOnlyFrameworks>netstandard2.0;net45;net40;net20</DesktopOnlyFrameworks>
     <PortableOnlyFrameworks>netstandard1.1;portable-net40+win8+wpa81;portable-net45+win8+wpa81</PortableOnlyFrameworks>
     <DesktopAndPortableFrameworks>$(PortableOnlyFrameworks);$(DesktopOnlyFrameworks)</DesktopAndPortableFrameworks>
 
@@ -24,7 +24,7 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)opensource.snk</AssemblyOriginatorKeyFile>
     <DebugType>portable</DebugType>
 
-    <TargetsDesktop Condition=" '$(TargetFramework)' == 'net20' or '$(TargetFramework)' == 'net40' or '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46' ">true</TargetsDesktop>
+    <TargetsDesktop Condition=" '$(TargetFramework)' == 'net20' or '$(TargetFramework)' == 'net40' or '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard2.0' ">true</TargetsDesktop>
     <IsTestProject>$(MSBuildProjectName.Contains('Test'))</IsTestProject>
     <IsCodeGenerationProject Condition=" $(MSBuildProjectName.Contains('CodeGeneration')) ">true</IsCodeGenerationProject>
     <IsPInvokeProject Condition=" '$(IsTestProject)' != 'true' and '$(IsCodeGenerationProject)' != 'true' ">true</IsPInvokeProject>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -30,14 +30,10 @@
     <IsPInvokeProject Condition=" '$(IsTestProject)' != 'true' and '$(IsCodeGenerationProject)' != 'true' ">true</IsPInvokeProject>
     <IsPackable Condition=" '$(IsTestProject)' == 'true' or '$(IsCodeGenerationProject)' == 'true' ">false</IsPackable>
 
-    <DefineConstants Condition=" '$(TargetsDesktop)' != 'true' ">$(DefineConstants);APISets</DefineConstants>
+    <DefineConstants Condition=" '$(TargetsDesktop)' == 'true' ">$(DefineConstants);DESKTOP</DefineConstants>
 
     <CodeGenerationPackageVersion>0.4.65</CodeGenerationPackageVersion>
     <NerdbankGitVersioningPackageVersion>2.2.13</NerdbankGitVersioningPackageVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetsDesktop)' == 'true' ">
-    <DefineConstants>$(DefineConstants);DESKTOP</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(IsCodeGenerationProject)' != 'true' ">

--- a/src/DwmApi/DwmApi.csproj
+++ b/src/DwmApi/DwmApi.csproj
@@ -5,6 +5,7 @@
   <ItemGroup>
     <ProjectReference Include="..\UxTheme\UxTheme.csproj" />
     <ProjectReference Include="..\Windows.Core\Windows.Core.csproj" />
+    <PackageReference Include="System.Drawing.Common" Version="4.5.0" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
   </ItemGroup>
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/src/Kernel32/Kernel32.cs
+++ b/src/Kernel32/Kernel32.cs
@@ -29,22 +29,7 @@ namespace PInvoke
         public static readonly IntPtr INVALID_HANDLE_VALUE = new IntPtr(-1);
 
 #pragma warning disable SA1303 // Const field names must begin with upper-case letter
-#if APISets
-        private const string api_ms_win_core_localization_l1_2_0 = ApiSets.api_ms_win_core_localization_l1_2_0;
-        private const string api_ms_win_core_processthreads_l1_1_1 = ApiSets.api_ms_win_core_processthreads_l1_1_1;
-        private const string api_ms_win_core_io_l1_1_1 = ApiSets.api_ms_win_core_io_l1_1_1;
-        private const string api_ms_win_core_file_l1_2_0 = ApiSets.api_ms_win_core_file_l1_2_0;
-        private const string api_ms_win_core_synch_l1_2_0 = ApiSets.api_ms_win_core_synch_l1_2_0;
-        private const string api_ms_win_core_handle_l1_1_0 = ApiSets.api_ms_win_core_handle_l1_1_0;
-        private const string api_ms_win_core_console_l1_1_0 = ApiSets.api_ms_win_core_console_l1_1_0;
-        private const string api_ms_win_core_console_l2_1_0 = ApiSets.api_ms_win_core_console_l2_1_0;
-        private const string api_ms_win_core_psapi_l1_1_0 = ApiSets.api_ms_win_core_psapi_l1_1_0;
-        private const string api_ms_win_core_namedpipe_l1_2_0 = ApiSets.api_ms_win_core_namedpipe_l1_2_0;
-        private const string api_ms_win_core_libraryloader_l1_1_1 = ApiSets.api_ms_win_core_libraryloader_l1_1_1;
-        private const string api_ms_win_core_sysinfo_l1_2_1 = ApiSets.api_ms_win_core_sysinfo_l1_2_1;
-        private const string api_ms_win_core_sysinfo_l1_2_0 = ApiSets.api_ms_win_core_sysinfo_l1_2_0;
-        private const string api_ms_win_core_errorhandling_l1_1_1 = ApiSets.api_ms_win_core_errorhandling_l1_1_1;
-#else
+#if DESKTOP
         private const string api_ms_win_core_localization_l1_2_0 = nameof(Kernel32);
         private const string api_ms_win_core_processthreads_l1_1_1 = nameof(Kernel32);
         private const string api_ms_win_core_io_l1_1_1 = nameof(Kernel32);
@@ -59,6 +44,21 @@ namespace PInvoke
         private const string api_ms_win_core_sysinfo_l1_2_1 = nameof(Kernel32);
         private const string api_ms_win_core_sysinfo_l1_2_0 = nameof(Kernel32);
         private const string api_ms_win_core_errorhandling_l1_1_1 = nameof(Kernel32);
+#else
+        private const string api_ms_win_core_localization_l1_2_0 = ApiSets.api_ms_win_core_localization_l1_2_0;
+        private const string api_ms_win_core_processthreads_l1_1_1 = ApiSets.api_ms_win_core_processthreads_l1_1_1;
+        private const string api_ms_win_core_io_l1_1_1 = ApiSets.api_ms_win_core_io_l1_1_1;
+        private const string api_ms_win_core_file_l1_2_0 = ApiSets.api_ms_win_core_file_l1_2_0;
+        private const string api_ms_win_core_synch_l1_2_0 = ApiSets.api_ms_win_core_synch_l1_2_0;
+        private const string api_ms_win_core_handle_l1_1_0 = ApiSets.api_ms_win_core_handle_l1_1_0;
+        private const string api_ms_win_core_console_l1_1_0 = ApiSets.api_ms_win_core_console_l1_1_0;
+        private const string api_ms_win_core_console_l2_1_0 = ApiSets.api_ms_win_core_console_l2_1_0;
+        private const string api_ms_win_core_psapi_l1_1_0 = ApiSets.api_ms_win_core_psapi_l1_1_0;
+        private const string api_ms_win_core_namedpipe_l1_2_0 = ApiSets.api_ms_win_core_namedpipe_l1_2_0;
+        private const string api_ms_win_core_libraryloader_l1_1_1 = ApiSets.api_ms_win_core_libraryloader_l1_1_1;
+        private const string api_ms_win_core_sysinfo_l1_2_1 = ApiSets.api_ms_win_core_sysinfo_l1_2_1;
+        private const string api_ms_win_core_sysinfo_l1_2_0 = ApiSets.api_ms_win_core_sysinfo_l1_2_0;
+        private const string api_ms_win_core_errorhandling_l1_1_1 = ApiSets.api_ms_win_core_errorhandling_l1_1_1;
 #endif
 #pragma warning restore SA1303 // Const field names must begin with upper-case letter
 

--- a/src/Kernel32/Kernel32.csproj
+++ b/src/Kernel32/Kernel32.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Windows.Core\Windows.Core.csproj" />
+    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
   </ItemGroup>
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>


### PR DESCRIPTION
Addressing Issue #382.
Also, fixed a small typo in XML documentation and consolidates APISets & DESKTOP preprocessing constatns
