### PR TITLE
Add newer .NET Standard target frameworks

### DIFF
--- a/src/AdvApi32/AdvApi32.Helpers.cs
+++ b/src/AdvApi32/AdvApi32.Helpers.cs
@@ -77,10 +77,18 @@ namespace PInvoke
 
                     var result = new ENUM_SERVICE_STATUS[numServicesReturned];
                     byte* position = buffer;
+#if NETSTANDARD1_3_ORLATER
+                    int structSize = Marshal.SizeOf<ENUM_SERVICE_STATUS>();
+#else
                     int structSize = Marshal.SizeOf(typeof(ENUM_SERVICE_STATUS));
+#endif
                     for (int i = 0; i < numServicesReturned; i++)
                     {
+#if NETSTANDARD1_3_ORLATER
+                        result[i] = (ENUM_SERVICE_STATUS)Marshal.PtrToStructure<ENUM_SERVICE_STATUS>(new IntPtr(position));
+#else
                         result[i] = (ENUM_SERVICE_STATUS)Marshal.PtrToStructure(new IntPtr(position), typeof(ENUM_SERVICE_STATUS));
+#endif
                         position += structSize;
                     }
 
@@ -253,7 +261,11 @@ namespace PInvoke
                         lpDescription = lpDescription
                     };
 
-                    fixed (void* lpInfo = new byte[Marshal.SizeOf(descriptionStruct)])
+#if NETSTANDARD1_3_ORLATER
+                    fixed (void* lpInfo = new byte[Marshal.SizeOf<ServiceDescription>()])
+#else
+                    fixed (void* lpInfo = new byte[Marshal.SizeOf(typeof(ServiceDescription))])
+#endif
                     {
                         Marshal.StructureToPtr(descriptionStruct, new IntPtr(lpInfo), false);
                         if (!ChangeServiceConfig2(svcHandle, ServiceInfoLevel.SERVICE_CONFIG_DESCRIPTION, lpInfo))
@@ -261,7 +273,11 @@ namespace PInvoke
                             throw new Win32Exception();
                         }
 
+#if NETSTANDARD1_3_ORLATER
+                        Marshal.DestroyStructure<ServiceDescription>(new IntPtr(lpInfo));
+#else
                         Marshal.DestroyStructure(new IntPtr(lpInfo), typeof(ServiceDescription));
+#endif
                     }
                 }
             }

--- a/src/AdvApi32/AdvApi32.Helpers.cs
+++ b/src/AdvApi32/AdvApi32.Helpers.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
     using System.Collections.Generic;
     using System.Runtime.InteropServices;
-#if !(NETSTANDARD1_1 || PROFILE92 || PROFILE111)
+#if !(NETSTANDARD1_1 || NETPORTABLE)
     using System.Security.AccessControl;
 #endif
     using static Kernel32;
@@ -89,7 +89,7 @@ namespace PInvoke
             }
         }
 
-#if !(NETSTANDARD1_1 || PROFILE92 || PROFILE111)
+#if NETFRAMEWORK || NETSTANDARD1_6_ORLATER
 
         /// <summary>
         ///     Retrieves a copy of the security descriptor associated with a service object. You can also use the

--- a/src/AdvApi32/AdvApi32.csproj
+++ b/src/AdvApi32/AdvApi32.csproj
@@ -1,11 +1,15 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>$(PlatformAndPortableFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(PlatformAndPortableFrameworks);netstandard1.6</TargetFrameworks>
     <StoreBanned>true</StoreBanned>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Kernel32\Kernel32.csproj" />
     <ProjectReference Include="..\Windows.Core\Windows.Core.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />
+    <PackageReference Include="System.Security.AccessControl" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/AdvApi32/SafeRegistryHandle.cs
+++ b/src/AdvApi32/SafeRegistryHandle.cs
@@ -1,7 +1,16 @@
 // Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NET20 || NETSTANDARD1_1 || PROFILE92 || PROFILE111
+#if NET40_ORLATER || NETSTANDARD1_6_ORLATER
+
+// We must type forward so that folks who compiled against a PInvoke library that defines this type,
+// it can still run when linking against a PInvoke library at runtime that doesn't define it.
+using System.Runtime.CompilerServices;
+using Microsoft.Win32.SafeHandles;
+
+[assembly: TypeForwardedTo(typeof(SafeRegistryHandle))]
+
+#else
 
 namespace Microsoft.Win32.SafeHandles
 {
@@ -30,14 +39,5 @@ namespace Microsoft.Win32.SafeHandles
         }
     }
 }
-
-#else
-
-// We must type forward so that folks who compiled against our net20 library
-// can still run when linking against a net40 library at runtime.
-using System.Runtime.CompilerServices;
-using Microsoft.Win32.SafeHandles;
-
-[assembly: TypeForwardedTo(typeof(SafeRegistryHandle))]
 
 #endif

--- a/src/AssemblyAttributes.cs
+++ b/src/AssemblyAttributes.cs
@@ -1,13 +1,13 @@
 // Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NET20 || NET40 || NET45 || NETSTANDARD1_1 || PROFILE111
+#if NETFRAMEWORK || NETSTANDARD || PROFILE111
 
 using System.Runtime.InteropServices;
 
 [module: DefaultCharSet(CharSet.Unicode)]
 
-#if NET45 || NETSTANDARD1_1 || PROFILE111
+#if NET45_ORLATER || NETSTANDARD || PROFILE111
 
 [assembly: DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,7 +6,7 @@
 
     <DesktopOnlyFrameworks>net45;net40;net20</DesktopOnlyFrameworks>
     <PlatformSpecificFrameworks>$(DesktopOnlyFrameworks);win8</PlatformSpecificFrameworks>
-    <PortableOnlyFrameworks>netstandard1.1;portable-net40+win8+wpa81;portable-net45+win8+wpa81</PortableOnlyFrameworks>
+    <PortableOnlyFrameworks>netstandard2.0;netstandard1.1;portable-net40+win8+wpa81;portable-net45+win8+wpa81</PortableOnlyFrameworks>
     <PlatformAndPortableFrameworks>$(PortableOnlyFrameworks);$(PlatformSpecificFrameworks)</PlatformAndPortableFrameworks>
 
     <TargetPlatformMinVersion Condition=" '$(TargetFramework)' == 'win8' ">8.0</TargetPlatformMinVersion>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,7 +6,8 @@
 
     <DesktopOnlyFrameworks>net45;net40;net20</DesktopOnlyFrameworks>
     <PlatformSpecificFrameworks>$(DesktopOnlyFrameworks);win8</PlatformSpecificFrameworks>
-    <PortableOnlyFrameworks>netstandard2.0;netstandard1.1;portable-net40+win8+wpa81;portable-net45+win8+wpa81</PortableOnlyFrameworks>
+    <!-- Target frameworks beyond .NET Standard 1.1 are added to individual projects on an as-needed basis. -->
+    <PortableOnlyFrameworks>netstandard1.1;portable-net40+win8+wpa81;portable-net45+win8+wpa81</PortableOnlyFrameworks>
     <PlatformAndPortableFrameworks>$(PortableOnlyFrameworks);$(PlatformSpecificFrameworks)</PlatformAndPortableFrameworks>
 
     <TargetPlatformMinVersion Condition=" '$(TargetFramework)' == 'win8' ">8.0</TargetPlatformMinVersion>
@@ -27,20 +28,13 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)opensource.snk</AssemblyOriginatorKeyFile>
     <DebugType>portable</DebugType>
 
-    <TargetsDesktop Condition=" '$(TargetFramework)' == 'net20' or '$(TargetFramework)' == 'net40' or '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46' ">true</TargetsDesktop>
     <IsTestProject>$(MSBuildProjectName.Contains('Test'))</IsTestProject>
     <IsCodeGenerationProject Condition=" $(MSBuildProjectName.Contains('CodeGeneration')) ">true</IsCodeGenerationProject>
     <IsPInvokeProject Condition=" '$(IsTestProject)' != 'true' and '$(IsCodeGenerationProject)' != 'true' ">true</IsPInvokeProject>
     <IsPackable Condition=" '$(IsTestProject)' == 'true' or '$(IsCodeGenerationProject)' == 'true' ">false</IsPackable>
 
-    <DefineConstants Condition=" '$(TargetsDesktop)' != 'true' ">$(DefineConstants);APISets</DefineConstants>
-
     <CodeGenerationPackageVersion>0.4.74</CodeGenerationPackageVersion>
     <NerdbankGitVersioningPackageVersion>2.2.13</NerdbankGitVersioningPackageVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetsDesktop)' == 'true' ">
-    <DefineConstants>$(DefineConstants);DESKTOP</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(IsCodeGenerationProject)' != 'true' ">

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -3,6 +3,14 @@
     <RootNamespace Condition=" '$(IsTestProject)' == 'true' " />
     <ExcludeStoreBannedAPIs Condition=" '$(TargetPlatformIdentifier)' == 'Windows' and '$(TargetPlatformVersion)' >= 8.0 ">true</ExcludeStoreBannedAPIs>
     <DefineConstants Condition=" '$(ExcludeStoreBannedAPIs)' != 'true' ">$(DefineConstants);IncludeStoreBannedAPIs</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' or ('$(TargetFrameworkIdentifier)' == '.NETStandard' and '$(_TargetFrameworkVersionWithoutV)' >= 2.0) ">$(DefineConstants);Serialization</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFrameworkIdentifier)' == '.NETStandard' and '$(_TargetFrameworkVersionWithoutV)' >= 1.3 ">$(DefineConstants);NETSTANDARD1_3_ORLATER</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFrameworkIdentifier)' == '.NETStandard' and '$(_TargetFrameworkVersionWithoutV)' >= 1.6 ">$(DefineConstants);NETSTANDARD1_6_ORLATER</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFrameworkIdentifier)' == '.NETStandard' and '$(_TargetFrameworkVersionWithoutV)' >= 2.0 ">$(DefineConstants);NETSTANDARD2_0_ORLATER</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(_TargetFrameworkVersionWithoutV)' >= 4.0 ">$(DefineConstants);NET40_ORLATER</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(_TargetFrameworkVersionWithoutV)' >= 4.5 ">$(DefineConstants);NET45_ORLATER</DefineConstants>
+
+    <DefineConstants Condition=" '$(TargetFrameworkIdentifier)' != '.NETFramework' ">$(DefineConstants);APISets</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DwmApi/DwmApi+DWM_BLURBEHIND.cs
+++ b/src/DwmApi/DwmApi+DWM_BLURBEHIND.cs
@@ -47,7 +47,7 @@ namespace PInvoke
                 set { this.fEnable = value ? (byte)1 : (byte)0; }
             }
 
-#if !(NETSTANDARD1_1 || PROFILE92 || PROFILE111)
+#if NETFRAMEWORK || NETSTANDARD2_0_ORLATER
 
             /// <summary>
             /// Gets a <see cref="Region"/> object from the <see cref="hRgnBlur"/> handle.

--- a/src/DwmApi/DwmApi.csproj
+++ b/src/DwmApi/DwmApi.csproj
@@ -1,10 +1,13 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>$(PlatformAndPortableFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(PlatformAndPortableFrameworks);netstandard2.0</TargetFrameworks>
     <StoreBanned>true</StoreBanned>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\UxTheme\UxTheme.csproj" />
     <ProjectReference Include="..\Windows.Core\Windows.Core.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Drawing.Common" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/src/Kernel32.Tests/Kernel32.Tests.csproj
+++ b/src/Kernel32.Tests/Kernel32.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net46</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Kernel32\Kernel32.csproj" />

--- a/src/Kernel32.Tests/Kernel32ExtensionsFacts.cs
+++ b/src/Kernel32.Tests/Kernel32ExtensionsFacts.cs
@@ -42,7 +42,7 @@ public partial class Kernel32ExtensionsFacts
         }
         catch (NTStatusException ex)
         {
-#if DESKTOP
+#if NETFRAMEWORK
             Assert.Equal("The remote procedure call failed (NT_STATUS error: RPC_NT_CALL_FAILED (0xC002001B))", ex.Message);
 #else
             Assert.Equal("NT_STATUS error: RPC_NT_CALL_FAILED (0xC002001B)", ex.Message);

--- a/src/Kernel32.Tests/NTStatusExceptionFacts.cs
+++ b/src/Kernel32.Tests/NTStatusExceptionFacts.cs
@@ -24,7 +24,7 @@ public partial class NTStatusExceptionFacts
     {
         NTSTATUS error = NTSTATUS.Code.EPT_NT_INVALID_ENTRY;
         var ex = new NTStatusException(error);
-#if DESKTOP
+#if NETFRAMEWORK
         Assert.Equal("The entry is invalid (NT_STATUS error: EPT_NT_INVALID_ENTRY (0xC0020034))", ex.Message);
 #else
         Assert.Equal("NT_STATUS error: EPT_NT_INVALID_ENTRY (0xC0020034)", ex.Message);
@@ -37,7 +37,7 @@ public partial class NTStatusExceptionFacts
     {
         NTSTATUS error = NTSTATUS.Code.STATUS_BUFFER_OVERFLOW;
         var ex = new NTStatusException(error);
-#if DESKTOP
+#if NETFRAMEWORK
         Assert.Equal("{Buffer Overflow}\r\nThe data was too large to fit into the specified buffer (NT_STATUS warning: STATUS_BUFFER_OVERFLOW (0x80000005))", ex.Message);
 #else
         Assert.Equal("NT_STATUS warning: STATUS_BUFFER_OVERFLOW (0x80000005)", ex.Message);
@@ -50,7 +50,7 @@ public partial class NTStatusExceptionFacts
     {
         NTSTATUS error = NTSTATUS.Code.STATUS_WAKE_SYSTEM;
         var ex = new NTStatusException(error);
-#if DESKTOP
+#if NETFRAMEWORK
         Assert.Equal("The system has awoken (NT_STATUS information: STATUS_WAKE_SYSTEM (0x40000294))", ex.Message);
 #else
         Assert.Equal("NT_STATUS information: STATUS_WAKE_SYSTEM (0x40000294)", ex.Message);
@@ -63,7 +63,7 @@ public partial class NTStatusExceptionFacts
     {
         NTSTATUS error = NTSTATUS.Code.STATUS_PENDING;
         var ex = new NTStatusException(error);
-#if DESKTOP
+#if NETFRAMEWORK
         Assert.Equal("The operation that was requested is pending completion (NT_STATUS success: STATUS_PENDING (0x00000103))", ex.Message);
 #else
         Assert.Equal("NT_STATUS success: STATUS_PENDING (0x00000103)", ex.Message);

--- a/src/Kernel32.Tests/UseCultureAttribute.cs
+++ b/src/Kernel32.Tests/UseCultureAttribute.cs
@@ -70,7 +70,7 @@ internal class UseCultureAttribute : BeforeAfterTestAttribute
         this.originalCulture = CultureInfo.CurrentCulture;
         this.originalUICulture = CultureInfo.CurrentUICulture;
 
-#if DESKTOP
+#if NETFRAMEWORK || NETSTANDARD2_0_ORLATER
         Thread.CurrentThread.CurrentCulture = this.Culture;
         Thread.CurrentThread.CurrentUICulture = this.UICulture;
 #else
@@ -86,7 +86,7 @@ internal class UseCultureAttribute : BeforeAfterTestAttribute
     /// <param name="methodUnderTest">The method under test</param>
     public override void After(MethodInfo methodUnderTest)
     {
-#if DESKTOP
+#if NETFRAMEWORK || NETSTANDARD2_0_ORLATER
         Thread.CurrentThread.CurrentCulture = this.originalCulture;
         Thread.CurrentThread.CurrentUICulture = this.originalUICulture;
 #else

--- a/src/Kernel32.Tests/storebanned/IgnoreOnOsVersionUnderFactAttribute.cs
+++ b/src/Kernel32.Tests/storebanned/IgnoreOnOsVersionUnderFactAttribute.cs
@@ -16,7 +16,7 @@ internal class IgnoreOnOsVersionUnderFactAttribute : FactAttribute
     /// <summary>Initializes a new instance of the <see cref="IgnoreOnOsVersionUnderFactAttribute" /> class.</summary>
     /// <param name="minimumVersion">
     ///     The minimum version required for this <see cref="FactAttribute" /> in a format usable by
-    ///     <see cref="Version.Parse" />.
+    ///     <see cref="Version.Parse(string)" />.
     /// </param>
     public IgnoreOnOsVersionUnderFactAttribute(string minimumVersion)
     {

--- a/src/Kernel32.Tests/storebanned/Kernel32Facts.cs
+++ b/src/Kernel32.Tests/storebanned/Kernel32Facts.cs
@@ -174,7 +174,7 @@ public partial class Kernel32Facts
                 FormatMessageFlags.FORMAT_MESSAGE_FROM_HMODULE,
                 ntdll.DangerousGetHandle(),
                 (int)NTSTATUS.Code.DBG_REPLY_LATER,
-#if DESKTOP
+#if NETFRAMEWORK || NETSTANDARD2_0_ORLATER
                 CultureInfo.CurrentCulture.LCID,
 #else
                 0,

--- a/src/Kernel32/Kernel32+SECURITY_ATTRIBUTES.cs
+++ b/src/Kernel32/Kernel32+SECURITY_ATTRIBUTES.cs
@@ -49,7 +49,11 @@ namespace PInvoke
             {
                 return new SECURITY_ATTRIBUTES
                 {
+#if NETSTANDARD1_3_ORLATER
+                    nLength = Marshal.SizeOf<SECURITY_ATTRIBUTES>(),
+#else
                     nLength = Marshal.SizeOf(typeof(SECURITY_ATTRIBUTES)),
+#endif
                 };
             }
         }

--- a/src/Kernel32/Kernel32.csproj
+++ b/src/Kernel32/Kernel32.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>$(PlatformAndPortableFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(PlatformAndPortableFrameworks);netstandard1.3;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Windows.Core\Windows.Core.csproj" />

--- a/src/Kernel32/Kernel32Extensions.cs
+++ b/src/Kernel32/Kernel32Extensions.cs
@@ -26,7 +26,7 @@ namespace PInvoke
         {
             int dwLanguageId = 0;
 
-#if DESKTOP
+#if NETFRAMEWORK || NETSTANDARD2_0_ORLATER
             dwLanguageId = CultureInfo.CurrentCulture.LCID;
 #endif
 

--- a/src/Kernel32/NTStatusException.cs
+++ b/src/Kernel32/NTStatusException.cs
@@ -4,7 +4,7 @@
 namespace PInvoke
 {
     using System;
-#if DESKTOP
+#if Serialization
     using System.Runtime.Serialization;
 #endif
     using static PInvoke.Kernel32;
@@ -12,7 +12,7 @@ namespace PInvoke
     /// <summary>
     /// An exception thrown for a failure described by a <see cref="NTSTATUS"/>.
     /// </summary>
-#if DESKTOP
+#if Serialization
     [Serializable]
 #endif
     public class NTStatusException : Exception
@@ -48,7 +48,7 @@ namespace PInvoke
             this.NativeErrorCode = statusCode;
         }
 
-#if DESKTOP
+#if Serialization
         /// <summary>
         /// Initializes a new instance of the <see cref="NTStatusException"/> class
         /// for deserialization.
@@ -67,7 +67,7 @@ namespace PInvoke
         /// </summary>
         public NTSTATUS NativeErrorCode { get; }
 
-#if DESKTOP
+#if Serialization
         /// <inheritdoc />
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
@@ -90,7 +90,7 @@ namespace PInvoke
                 : hexCode;
             string insert = $"NT_STATUS {GetSeverityString(status)}: {statusAsString}";
             string message = null;
-#if DESKTOP
+#if !WINDOWS8
             message = status.GetMessage();
 #endif
 

--- a/src/Kernel32/SafeWaitHandle.cs
+++ b/src/Kernel32/SafeWaitHandle.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NETSTANDARD1_1 || PROFILE92 || PROFILE111 || WINDOWS8
+#if NETSTANDARD1_1 || NETPORTABLE || WINDOWS8
 
 namespace Microsoft.Win32.SafeHandles
 {

--- a/src/Kernel32/Win32Exception.cs
+++ b/src/Kernel32/Win32Exception.cs
@@ -1,11 +1,15 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK || NETSTANDARD1_3_ORLATER
+#define Win32ExceptionDefined
+#endif
+
 namespace PInvoke
 {
     using System;
     using System.Runtime.InteropServices;
-#if DESKTOP
+#if Serialization
     using System.Runtime.Serialization;
 #endif
     using static Kernel32;
@@ -13,17 +17,17 @@ namespace PInvoke
     /// <summary>
     /// An exception thrown for a failure described by a <see cref="Win32ErrorCode"/>.
     /// </summary>
-#if DESKTOP
+#if Serialization
     [Serializable]
 #endif
     public class Win32Exception
-#if DESKTOP
+#if Win32ExceptionDefined
         : System.ComponentModel.Win32Exception
 #else
         : Exception
 #endif
     {
-#if !DESKTOP
+#if !Win32ExceptionDefined
         /// <summary>
         /// The original Win32 error code that resulted in this exception.
         /// </summary>
@@ -34,7 +38,7 @@ namespace PInvoke
         /// Initializes a new instance of the <see cref="Win32Exception"/> class.
         /// </summary>
         public Win32Exception()
-#if DESKTOP
+#if Win32ExceptionDefined
             : base()
 #else
             : this(Marshal.GetLastWin32Error())
@@ -47,7 +51,7 @@ namespace PInvoke
         /// </summary>
         /// <param name="error">The Win32 error code associated with this exception.</param>
         public Win32Exception(Win32ErrorCode error)
-#if DESKTOP
+#if Win32ExceptionDefined
             : base((int)error)
 #else
             : this(error, error.GetMessage() ?? $"Unknown error (0x{(int)error:x8})")
@@ -70,18 +74,18 @@ namespace PInvoke
         /// <param name="error">The Win32 error code associated with this exception.</param>
         /// <param name="message">The message for this exception.</param>
         public Win32Exception(Win32ErrorCode error, string message)
-#if DESKTOP
+#if Win32ExceptionDefined
             : base((int)error, message)
 #else
             : base(message)
 #endif
         {
-#if !DESKTOP
+#if !Win32ExceptionDefined
             this.nativeErrorCode = error;
 #endif
         }
 
-#if DESKTOP
+#if Serialization
         /// <summary>
         /// Initializes a new instance of the <see cref="Win32Exception"/> class
         /// for deserialization.
@@ -101,7 +105,7 @@ namespace PInvoke
         /// We must define this so that our own assembly on desktop is not a subset
         /// of what portable offers (lest runtime errors in our users occur).
         /// </devremarks>
-#if DESKTOP
+#if Win32ExceptionDefined
         public new Win32ErrorCode NativeErrorCode => (Win32ErrorCode)base.NativeErrorCode;
 #else
         public Win32ErrorCode NativeErrorCode => this.nativeErrorCode;

--- a/src/Kernel32/storebanned/Kernel32+MODULEENTRY32.cs
+++ b/src/Kernel32/storebanned/Kernel32+MODULEENTRY32.cs
@@ -112,7 +112,11 @@ namespace PInvoke
             {
                 return new MODULEENTRY32
                 {
+#if NETSTANDARD1_3_ORLATER
+                    dwSize = Marshal.SizeOf<MODULEENTRY32>(),
+#else
                     dwSize = Marshal.SizeOf(typeof(MODULEENTRY32)),
+#endif
                     th32ModuleID = 1,
                 };
             }

--- a/src/Kernel32/storebanned/Kernel32+PROCESSENTRY32.cs
+++ b/src/Kernel32/storebanned/Kernel32+PROCESSENTRY32.cs
@@ -109,7 +109,11 @@ namespace PInvoke
             {
                 return new PROCESSENTRY32
                 {
+#if NETSTANDARD1_3_ORLATER
+                    dwSize = Marshal.SizeOf<PROCESSENTRY32>(),
+#else
                     dwSize = Marshal.SizeOf(typeof(PROCESSENTRY32)),
+#endif
                 };
             }
         }

--- a/src/Kernel32/storebanned/Kernel32+StartupInfo.cs
+++ b/src/Kernel32/storebanned/Kernel32+StartupInfo.cs
@@ -128,7 +128,11 @@ namespace PInvoke
             {
                 return new STARTUPINFO
                 {
+#if NETSTANDARD1_3_ORLATER
+                    cb = Marshal.SizeOf<STARTUPINFO>(),
+#else
                     cb = Marshal.SizeOf(typeof(STARTUPINFO)),
+#endif
                     hStdInput = SafeObjectHandle.Null,
                     hStdOutput = SafeObjectHandle.Null,
                     hStdError = SafeObjectHandle.Null,

--- a/src/Kernel32/storebanned/Kernel32Extensions.cs
+++ b/src/Kernel32/storebanned/Kernel32Extensions.cs
@@ -21,7 +21,7 @@ namespace PInvoke
             using (var ntdll = LoadLibrary("ntdll.dll"))
             {
                 int dwLanguageId = 0;
-#if DESKTOP
+#if NETFRAMEWORK || NETSTANDARD2_0
                 dwLanguageId = CultureInfo.CurrentCulture.LCID;
 #endif
 

--- a/src/NCrypt.Tests/SecurityStatusExceptionFacts.cs
+++ b/src/NCrypt.Tests/SecurityStatusExceptionFacts.cs
@@ -26,7 +26,7 @@ public class SecurityStatusExceptionFacts
     {
         SECURITY_STATUS error = SECURITY_STATUS.NTE_BAD_DATA;
         var ex = new SecurityStatusException(error);
-#if DESKTOP
+#if NETFRAMEWORK
         Assert.Equal("Bad Data (SECURITY_STATUS error: NTE_BAD_DATA (0x80090005))", ex.Message);
 #else
         Assert.Equal("SECURITY_STATUS error: NTE_BAD_DATA (0x80090005)", ex.Message);
@@ -39,7 +39,7 @@ public class SecurityStatusExceptionFacts
     {
         SECURITY_STATUS error = SECURITY_STATUS.ERROR_SUCCESS;
         var ex = new SecurityStatusException(error);
-#if DESKTOP
+#if NETFRAMEWORK
         Assert.Equal("The operation completed successfully (SECURITY_STATUS success: ERROR_SUCCESS (0x00000000))", ex.Message);
 #else
         Assert.Equal("SECURITY_STATUS success: ERROR_SUCCESS (0x00000000)", ex.Message);

--- a/src/NCrypt/NCrypt.csproj
+++ b/src/NCrypt/NCrypt.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>$(PlatformAndPortableFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(PlatformAndPortableFrameworks);netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Windows.Core\Windows.Core.csproj" />

--- a/src/NCrypt/NCryptExtensions.cs
+++ b/src/NCrypt/NCryptExtensions.cs
@@ -42,7 +42,7 @@ namespace PInvoke
         {
             int dwLanguageId = 0;
 
-#if DESKTOP
+#if NETFRAMEWORK || NETSTANDARD2_0_ORLATER
             dwLanguageId = CultureInfo.CurrentCulture.LCID;
 #endif
 

--- a/src/NCrypt/SecurityStatusException.cs
+++ b/src/NCrypt/SecurityStatusException.cs
@@ -9,7 +9,7 @@ namespace PInvoke
     /// <summary>
     /// An exception that describes a failure with a <see cref="SECURITY_STATUS"/> code.
     /// </summary>
-#if DESKTOP
+#if Serialization
     [Serializable]
 #endif
     public class SecurityStatusException : Exception
@@ -45,7 +45,7 @@ namespace PInvoke
             this.NativeErrorCode = status;
         }
 
-#if DESKTOP
+#if Serialization
         /// <summary>
         /// Initializes a new instance of the <see cref="SecurityStatusException"/> class
         /// for deserialization.

--- a/src/User32/User32+MENUITEMINFO.cs
+++ b/src/User32/User32+MENUITEMINFO.cs
@@ -14,7 +14,7 @@ namespace PInvoke
         /// <summary>
         /// Contains information about a menu item.
         /// </summary>
-#if NETSTANDARD1_1 || PROFILE92 || PROFILE111
+#if NETPORTABLE
         [StructLayout(LayoutKind.Sequential)]
 #else
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]

--- a/src/User32/User32+MONITORINFOEX.cs
+++ b/src/User32/User32+MONITORINFOEX.cs
@@ -17,7 +17,7 @@ namespace PInvoke
         /// MONITORINFOEX structure is a superset of the MONITORINFO structure. The MONITORINFOEX
         /// structure adds a string member to contain a name for the display monitor.
         /// </summary>
-#if NETSTANDARD1_1 || PROFILE92 || PROFILE111
+#if NETPORTABLE
         [StructLayout(LayoutKind.Sequential)]
 #else
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]

--- a/src/Windows.Core/SafeHandleZeroOrMinusOneIsInvalid.cs
+++ b/src/Windows.Core/SafeHandleZeroOrMinusOneIsInvalid.cs
@@ -1,7 +1,16 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NETSTANDARD1_1 || PROFILE92 || PROFILE111
+#if NETFRAMEWORK || NETSTANDARD2_0_ORLATER
+
+// We must type forward so that folks who compiled against our netstandard1.x library
+// can still run when linking against a more recent library at runtime.
+using System.Runtime.CompilerServices;
+using Microsoft.Win32.SafeHandles;
+
+[assembly: TypeForwardedTo(typeof(SafeHandleZeroOrMinusOneIsInvalid))]
+
+#else
 
 namespace Microsoft.Win32.SafeHandles
 {
@@ -18,14 +27,4 @@ namespace Microsoft.Win32.SafeHandles
         public override bool IsInvalid => this.handle == IntPtr.Zero || this.handle == new IntPtr(-1);
     }
 }
-
-#else
-
-// We must type forward so that folks who compiled against our net20 library
-// can still run when linking against a net40 library at runtime.
-using System.Runtime.CompilerServices;
-using Microsoft.Win32.SafeHandles;
-
-[assembly: TypeForwardedTo(typeof(SafeHandleZeroOrMinusOneIsInvalid))]
-
 #endif

--- a/src/Windows.Core/Windows.Core.csproj
+++ b/src/Windows.Core/Windows.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>$(PortableOnlyFrameworks);net20;net35</TargetFrameworks>
+    <TargetFrameworks>$(PortableOnlyFrameworks);net20;net35;netstandard2.0</TargetFrameworks>
     <Summary>P/Invoke types for common Windows APIs.</Summary>
     <Description>P/Invoke types for common Windows APIs.</Description>
   </PropertyGroup>


### PR DESCRIPTION
We only add them where necessary (which turns out to be only a few projects). .NET Standard 1.3, 1.6, and 2.0 are each interesting for specific projects. Rather than add all these to all projects (which would significantly increase build times and package sizes), I only add them to the projects that would actually significantly change.

Also update how we define C# preprocessor symbols for more resiliency against additions of target frameworks in the future.