### PR TITLE
Fix Kernel32.GetStartupInfo and STARTUPINFO struct

### DIFF
--- a/src/Kernel32.Tests/Kernel32Facts.cs
+++ b/src/Kernel32.Tests/Kernel32Facts.cs
@@ -30,4 +30,13 @@ public partial class Kernel32Facts
         SetLastError(2);
         Assert.Equal(2, Marshal.GetLastWin32Error());
     }
+
+    [Fact]
+    public unsafe void GetStartupInfo_Title()
+    {
+        var startupInfo = STARTUPINFO.Create();
+        GetStartupInfo(ref startupInfo);
+        Assert.NotNull(startupInfo.Title);
+        Assert.NotEqual(0, startupInfo.Title.Length);
+    }
 }

--- a/src/Kernel32/PublicAPI.Shipped.txt
+++ b/src/Kernel32/PublicAPI.Shipped.txt
@@ -985,13 +985,7 @@ PInvoke.Kernel32.STARTUPINFO.dwXSize -> int
 PInvoke.Kernel32.STARTUPINFO.dwY -> int
 PInvoke.Kernel32.STARTUPINFO.dwYCountChars -> int
 PInvoke.Kernel32.STARTUPINFO.dwYSize -> int
-PInvoke.Kernel32.STARTUPINFO.hStdError -> PInvoke.Kernel32.SafeObjectHandle
-PInvoke.Kernel32.STARTUPINFO.hStdInput -> PInvoke.Kernel32.SafeObjectHandle
-PInvoke.Kernel32.STARTUPINFO.hStdOutput -> PInvoke.Kernel32.SafeObjectHandle
-PInvoke.Kernel32.STARTUPINFO.lpDesktop -> string
-PInvoke.Kernel32.STARTUPINFO.lpReserved -> string
 PInvoke.Kernel32.STARTUPINFO.lpReserved2 -> System.IntPtr
-PInvoke.Kernel32.STARTUPINFO.lpTitle -> string
 PInvoke.Kernel32.STARTUPINFO.wShowWindow -> ushort
 PInvoke.Kernel32.STARTUPINFOEX
 PInvoke.Kernel32.STARTUPINFOEX.STARTUPINFOEX() -> void
@@ -1347,7 +1341,6 @@ static extern PInvoke.Kernel32.GetNamedPipeServerSessionId(PInvoke.Kernel32.Safe
 static extern PInvoke.Kernel32.GetNumberOfConsoleInputEvents(System.IntPtr hConsoleInput, out int lpNumberOfEvents) -> bool
 static extern PInvoke.Kernel32.GetOverlappedResult(PInvoke.Kernel32.SafeObjectHandle hFile, PInvoke.Kernel32.OVERLAPPED* lpOverlapped, out int lpNumberOfBytesTransferred, bool bWait) -> bool
 static extern PInvoke.Kernel32.GetProcAddress(PInvoke.Kernel32.SafeLibraryHandle hModule, string procName) -> System.IntPtr
-static extern PInvoke.Kernel32.GetStartupInfo(out PInvoke.Kernel32.STARTUPINFO lpStartupInfo) -> void
 static extern PInvoke.Kernel32.GetStdHandle(PInvoke.Kernel32.StdHandle nStdHandle) -> System.IntPtr
 static extern PInvoke.Kernel32.GetSystemTime(PInvoke.Kernel32.SYSTEMTIME* lpSystemTime) -> void
 static extern PInvoke.Kernel32.GetTickCount() -> uint

--- a/src/Kernel32/PublicAPI.Unshipped.txt
+++ b/src/Kernel32/PublicAPI.Unshipped.txt
@@ -1,2 +1,19 @@
+PInvoke.Kernel32.STARTUPINFO.Desktop.get -> string
+PInvoke.Kernel32.STARTUPINFO.Title.get -> string
+PInvoke.Kernel32.STARTUPINFO.hStdError -> System.IntPtr
+PInvoke.Kernel32.STARTUPINFO.hStdInput -> System.IntPtr
+PInvoke.Kernel32.STARTUPINFO.hStdOutput -> System.IntPtr
+PInvoke.Kernel32.STARTUPINFO.lpDesktop -> char*
+PInvoke.Kernel32.STARTUPINFO.lpDesktop_IntPtr.get -> System.IntPtr
+PInvoke.Kernel32.STARTUPINFO.lpDesktop_IntPtr.set -> void
+PInvoke.Kernel32.STARTUPINFO.lpReserved -> char*
+PInvoke.Kernel32.STARTUPINFO.lpReserved_IntPtr.get -> System.IntPtr
+PInvoke.Kernel32.STARTUPINFO.lpReserved_IntPtr.set -> void
+PInvoke.Kernel32.STARTUPINFO.lpTitle -> char*
+PInvoke.Kernel32.STARTUPINFO.lpTitle_IntPtr.get -> System.IntPtr
+PInvoke.Kernel32.STARTUPINFO.lpTitle_IntPtr.set -> void
+static PInvoke.Kernel32.GetStartupInfo(System.IntPtr lpStartupInfo) -> void
+static PInvoke.Kernel32.GetStartupInfo(ref PInvoke.Kernel32.STARTUPINFO lpStartupInfo) -> void
 static extern PInvoke.Kernel32.GetProcessId(System.IntPtr Process) -> int
+static extern PInvoke.Kernel32.GetStartupInfo(PInvoke.Kernel32.STARTUPINFO* lpStartupInfo) -> void
 static extern PInvoke.Kernel32.SetLastError(uint dwErrCode) -> void

--- a/src/Kernel32/storebanned/Kernel32+StartupInfo.cs
+++ b/src/Kernel32/storebanned/Kernel32+StartupInfo.cs
@@ -17,7 +17,8 @@ namespace PInvoke
         /// Specifies the window station, desktop, standard handles, and appearance of the main window for a process at creation time.
         /// </summary>
         [StructLayout(LayoutKind.Sequential)]
-        public struct STARTUPINFO
+        [OfferIntPtrPropertyAccessors]
+        public unsafe partial struct STARTUPINFO
         {
             /// <summary>
             /// The size of this data structure.
@@ -27,17 +28,17 @@ namespace PInvoke
             /// <summary>
             /// Reserved; must be NULL.
             /// </summary>
-            public string lpReserved;
+            public char* lpReserved;
 
             /// <summary>
             /// The name of the desktop, or the name of both the desktop and window station for this process. A backslash in the string indicates that the string includes both the desktop and window station names. For more information, see Thread Connection to a Desktop.
             /// </summary>
-            public string lpDesktop;
+            public char* lpDesktop;
 
             /// <summary>
             /// For console processes, this is the title displayed in the title bar if a new console window is created. If NULL, the name of the executable file is used as the window title instead. This parameter must be NULL for GUI or console processes that do not create a new console window.
             /// </summary>
-            public string lpTitle;
+            public char* lpTitle;
 
             /// <summary>
             /// If <see cref="dwFlags"/> specifies STARTF_USEPOSITION, this member is the x offset of the upper left corner of a window if a new window is created, in pixels. Otherwise, this member is ignored.
@@ -106,19 +107,29 @@ namespace PInvoke
             /// If <see cref="dwFlags"/> specifies <see cref="StartupInfoFlags.STARTF_USEHOTKEY"/>, this member specifies a hotkey value that is sent as the wParam parameter of a WM_SETHOTKEY message to the first eligible top-level window created by the application that owns the process. If the window is created with the WS_POPUP window style, it is not eligible unless the WS_EX_APPWINDOW extended window style is also set. For more information, see CreateWindowEx.
             /// Otherwise, this member is ignored.
             /// </summary>
-            public SafeObjectHandle hStdInput;
+            public IntPtr hStdInput;
 
             /// <summary>
             /// If <see cref="dwFlags"/> specifies <see cref="StartupInfoFlags.STARTF_USESTDHANDLES"/>, this member is the standard output handle for the process. Otherwise, this member is ignored and the default for standard output is the console window's buffer.
             /// If a process is launched from the taskbar or jump list, the system sets <see cref="hStdOutput"/> to a handle to the monitor that contains the taskbar or jump list used to launch the process. For more information, see Remarks.
             /// Windows 7, Windows Server 2008 R2, Windows Vista, Windows Server 2008, Windows XP, and Windows Server 2003:  This behavior was introduced in Windows 8 and Windows Server 2012.
             /// </summary>
-            public SafeObjectHandle hStdOutput;
+            public IntPtr hStdOutput;
 
             /// <summary>
             /// If <see cref="dwFlags"/> specifies <see cref="StartupInfoFlags.STARTF_USESTDHANDLES"/>, this member is the standard error handle for the process. Otherwise, this member is ignored and the default for standard error is the console window's buffer.
             /// </summary>
-            public SafeObjectHandle hStdError;
+            public IntPtr hStdError;
+
+            /// <summary>
+            /// Gets the value of <see cref="lpDesktop" /> as a string.
+            /// </summary>
+            public string Desktop => this.lpDesktop != null ? new string(this.lpDesktop) : null;
+
+            /// <summary>
+            /// Gets the value of <see cref="lpDesktop" /> as a string.
+            /// </summary>
+            public string Title => this.lpTitle != null ? new string(this.lpTitle) : null;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="STARTUPINFO"/> struct.
@@ -133,9 +144,6 @@ namespace PInvoke
 #else
                     cb = Marshal.SizeOf(typeof(STARTUPINFO)),
 #endif
-                    hStdInput = SafeObjectHandle.Null,
-                    hStdOutput = SafeObjectHandle.Null,
-                    hStdError = SafeObjectHandle.Null,
                 };
             }
         }

--- a/src/Kernel32/storebanned/Kernel32+StartupInfoFlags.cs
+++ b/src/Kernel32/storebanned/Kernel32+StartupInfoFlags.cs
@@ -97,7 +97,7 @@ namespace PInvoke
             /// <summary>
             /// The <see cref="STARTUPINFO.hStdInput"/>, <see cref="STARTUPINFO.hStdOutput"/>, and <see cref="STARTUPINFO.hStdError"/> members contain additional information.
             /// If this flag is specified when calling one of the process creation functions, the handles must be inheritable and the function's bInheritHandles parameter must be set to TRUE. For more information, see Handle Inheritance.
-            /// If this flag is specified when calling the <see cref="GetStartupInfo"/> function, these members are either the handle value specified during process creation or <see cref="INVALID_HANDLE_VALUE"/>.
+            /// If this flag is specified when calling the <see cref="GetStartupInfo(STARTUPINFO*)"/> function, these members are either the handle value specified during process creation or <see cref="INVALID_HANDLE_VALUE"/>.
             /// Handles must be closed with <see cref="CloseHandle"/> when they are no longer needed.
             /// This flag cannot be used with <see cref="STARTF_USEHOTKEY"/>.
             /// </summary>

--- a/src/Kernel32/storebanned/Kernel32.cs
+++ b/src/Kernel32/storebanned/Kernel32.cs
@@ -550,8 +550,8 @@ namespace PInvoke
         /// This function does not return a value, and does not fail.
         /// </remarks>
         [DllImport(api_ms_win_core_processthreads_l1_1_1, CharSet = CharSet.Unicode)]
-        public static extern void GetStartupInfo(
-            out STARTUPINFO lpStartupInfo);
+        public static extern unsafe void GetStartupInfo(
+            [Friendly(FriendlyFlags.Bidirectional)] STARTUPINFO* lpStartupInfo);
 
         /// <summary>
         /// Initializes the specified list of attributes for process and thread creation.


### PR DESCRIPTION
There were several problems here:

* We were using `SafeObjectHandle` instead of `IntPtr` when these are handles we don't own and the user will never destroy. I filed #410 because I'm not even sure what we were doing here was safe. I've avoided it by changing it to `IntPtr`.
* The signature of the method was using `out` when it has to use `ref` so that the value of `cb` can be passed in.
* The `LPWSTR` fields were typed as `string`, but evidently Windows is setting these fields to pointers that must live as long as the process since no memory management is documented.

Fixes #408