### PR TITLE
Fixes order of high and low fields in FILETIME

### DIFF
--- a/src/Kernel32/Kernel32+FILETIME.cs
+++ b/src/Kernel32/Kernel32+FILETIME.cs
@@ -23,14 +23,14 @@ namespace PInvoke
         public struct FILETIME
         {
             /// <summary>
-            /// Specifies the high 32 bits of the FILETIME.
-            /// </summary>
-            public int dwHighDateTime;
-
-            /// <summary>
             /// Specifies the low 32 bits of the FILETIME.
             /// </summary>
             public int dwLowDateTime;
+
+            /// <summary>
+            /// Specifies the high 32 bits of the FILETIME.
+            /// </summary>
+            public int dwHighDateTime;
         }
     }
 }


### PR DESCRIPTION
As @adrianrus brought up in https://github.com/AArnott/pinvoke/pull/415#discussion_r241040057, our `FILETIME` struct had the fields backwards. This PR fixes it.