### PR TITLE
kernel32!VerifyVersionInfo and ntdll!RtlVerifyVersionInfo

### DIFF
--- a/src/Kernel32/Kernel32+OSVERSIONINFOEX.cs
+++ b/src/Kernel32/Kernel32+OSVERSIONINFOEX.cs
@@ -14,7 +14,7 @@ namespace PInvoke
         /// The RTL_OSVERSIONINFOEXW structure contains operating system version information.
         /// </summary>
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-        public partial struct OSVERSIONINFOEX
+        public unsafe partial struct OSVERSIONINFOEX
         {
             /// <summary>
             /// The size, in bytes, of an RTL_OSVERSIONINFOEXW structure.
@@ -48,8 +48,7 @@ namespace PInvoke
             /// indicates the latest service pack installed on the system. If no service pack is installed, RtlGetVersion might not
             /// initialize this string. Initialize szCSDVersion to zero (empty string) before the call to RtlGetVersion.
             /// </summary>
-            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
-            public string szCSDVersion;
+            public fixed char szCSDVersion[128];
 
             /// <summary>
             /// The major version number of the latest service pack installed on the system. For example, for Service Pack 3,
@@ -78,6 +77,20 @@ namespace PInvoke
             /// Reserved for future use.
             /// </summary>
             public byte wReserved;
+
+            /// <summary>
+            /// Helper method to create <see cref="OSVERSIONINFOEX"/> with
+            /// the right pre-initialization for <see cref="dwOSVersionInfoSize"/>
+            /// </summary>
+            /// <returns>A newly initialzed instance of <see cref="OSVERSIONINFOEX"/></returns>
+            public static OSVERSIONINFOEX Create() => new OSVERSIONINFOEX
+            {
+#if NETSTANDARD1_3_ORLATER
+                dwOSVersionInfoSize = Marshal.SizeOf<OSVERSIONINFOEX>()
+#else
+                dwOSVersionInfoSize = Marshal.SizeOf(typeof(OSVERSIONINFOEX))
+#endif
+            };
         }
     }
 }

--- a/src/Kernel32/Kernel32+OSVERSIONINFOEX.cs
+++ b/src/Kernel32/Kernel32+OSVERSIONINFOEX.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace PInvoke
+{
+    using System.Runtime.InteropServices;
+
+    /// <summary>
+    /// Contains the <see cref="OSVERSIONINFOEX"/> nested type.
+    /// </summary>
+    public static partial class Kernel32
+    {
+        /// <summary>
+        /// The RTL_OSVERSIONINFOEXW structure contains operating system version information.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public partial struct OSVERSIONINFOEX
+        {
+            /// <summary>
+            /// The size, in bytes, of an RTL_OSVERSIONINFOEXW structure.
+            /// This member must be set before the structure is used with RtlGetVersion.
+            /// </summary>
+            public int dwOSVersionInfoSize;
+
+            /// <summary>
+            /// The major version number of the operating system. For example, for Windows 2000, the major version number is five.
+            /// </summary>
+            public int dwMajorVersion;
+
+            /// <summary>
+            /// The minor version number of the operating system. For example, for Windows 2000, the minor version number is zero
+            /// </summary>
+            public int dwMinorVersion;
+
+            /// <summary>
+            /// The build number of the operating system.
+            /// </summary>
+            public int dwBuildNumber;
+
+            /// <summary>
+            /// The operating system platform. For Win32 on NT-based operating systems, RtlGetVersion returns the value
+            /// VER_PLATFORM_WIN32_NT.
+            /// </summary>
+            public int dwPlatformId;
+
+            /// <summary>
+            /// The service-pack version string. This member contains a null-terminated string, such as "Service Pack 3", which
+            /// indicates the latest service pack installed on the system. If no service pack is installed, RtlGetVersion might not
+            /// initialize this string. Initialize szCSDVersion to zero (empty string) before the call to RtlGetVersion.
+            /// </summary>
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+            public string szCSDVersion;
+
+            /// <summary>
+            /// The major version number of the latest service pack installed on the system. For example, for Service Pack 3,
+            /// the major version number is three. If no service pack has been installed, the value is zero.
+            /// </summary>
+            public short wServicePackMajor;
+
+            /// <summary>
+            /// The minor version number of the latest service pack installed on the system. For example, for Service Pack 3,
+            /// the minor version number is zero.
+            /// </summary>
+            public short wServicePackMinor;
+
+            /// <summary>
+            /// The product suites available on the system. This member is set to zero or to the bitwise OR of one or more of
+            /// the <see cref="PRODUCT_SUITE"/> values.
+            /// </summary>
+            public PRODUCT_SUITE wSuiteMask;
+
+            /// <summary>
+            /// The product type. This member contains additional information about the system.
+            /// </summary>
+            public OS_TYPE wProductType;
+
+            /// <summary>
+            /// Reserved for future use.
+            /// </summary>
+            public byte wReserved;
+        }
+    }
+}

--- a/src/Kernel32/Kernel32+OS_TYPE.cs
+++ b/src/Kernel32/Kernel32+OS_TYPE.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace PInvoke
+{
+    /// <summary>
+    /// Contains the <see cref="OS_TYPE"/> nested type.
+    /// </summary>
+    public static partial class Kernel32
+    {
+        /// <summary>
+        /// The product type enumeration
+        /// </summary>
+        public enum OS_TYPE : byte
+        {
+            VER_NT_WORKSTATION = 0x00000001,
+            VER_NT_DOMAIN_CONTROLLER = 0x00000002,
+            VER_NT_SERVER = 0x00000003
+        }
+    }
+}

--- a/src/Kernel32/Kernel32+PRODUCT_SUITE.cs
+++ b/src/Kernel32/Kernel32+PRODUCT_SUITE.cs
@@ -61,11 +61,11 @@ namespace PInvoke
             /// Microsoft Small Business Server was once installed on the system, but may have been upgraded to another version of Windows.
             /// </summary>
             /// <remarks>
-            ///  You should not rely solely on the VER_SUITE_SMALLBUSINESS flag to determine whether Small Business Server is currently installed.
-            ///  Both this flag and the VER_SUITE_SMALLBUSINESS_RESTRICTED flag are set when this product suite is installed. If you upgrade this
-            ///  installation to Windows Server, Standard Edition, the VER_SUITE_SMALLBUSINESS_RESTRICTED flag is cleared, but the
-            ///  VER_SUITE_SMALLBUSINESS flag remains set, which, in this case, indicates that Small Business Server was previously installed on
-            ///  this system. If this installation is further upgraded to Windows Server, Enterprise Edition, the VER_SUITE_SMALLBUSINESS flag
+            ///  You should not rely solely on the <see cref="VER_SUITE_SMALLBUSINESS"/> flag to determine whether Small Business Server is currently installed.
+            ///  Both this flag and the <see cref="VER_SUITE_SMALLBUSINESS_RESTRICTED"/> flag are set when this product suite is installed. If you upgrade this
+            ///  installation to Windows Server, Standard Edition, the <see cref="VER_SUITE_SMALLBUSINESS_RESTRICTED"/> flag is cleared, but the
+            ///  <see cref="VER_SUITE_SMALLBUSINESS"/> flag remains set, which, in this case, indicates that Small Business Server was previously installed on
+            ///  this system. If this installation is further upgraded to Windows Server, Enterprise Edition, the <see cref="VER_SUITE_SMALLBUSINESS"/> flag
             ///  remains set.
             /// </remarks>
             VER_SUITE_SMALLBUSINESS = 0x00000001,
@@ -82,7 +82,7 @@ namespace PInvoke
             VER_SUITE_STORAGE_SERVER = 0x00002000,
 
             /// <summary>
-            /// Terminal Services is installed. This value is always set. If VER_SUITE_TERMINAL is set but VER_SUITE_SINGLEUSERTS is not set,
+            /// Terminal Services is installed. This value is always set. If <see cref="VER_SUITE_TERMINAL"/> is set but <see cref="VER_SUITE_SINGLEUSERTS"/> is not set,
             /// the operating system is running in application server mode.
             /// </summary>
             VER_SUITE_TERMINAL = 0x00000010,

--- a/src/Kernel32/Kernel32+PRODUCT_SUITE.cs
+++ b/src/Kernel32/Kernel32+PRODUCT_SUITE.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace PInvoke
+{
+    using System;
+
+    /// <summary>
+    /// Contains the <see cref="PRODUCT_SUITE"/> nested type
+    /// </summary>
+    public static partial class Kernel32
+    {
+        /// <summary>
+        /// The product suites available on the system.
+        /// </summary>
+        [Flags]
+        public enum PRODUCT_SUITE : short
+        {
+            /// <summary>
+            /// Microsoft BackOffice components are installed.
+            /// </summary>
+            VER_SUITE_BACKOFFICE = 0x00000004,
+
+            /// <summary>
+            /// Windows Server 2003, Web Edition is installed.
+            /// </summary>
+            VER_SUITE_BLADE = 0x00000400,
+
+            /// <summary>
+            /// Windows Server 2003, Compute Cluster Edition is installed.
+            /// </summary>
+            VER_SUITE_COMPUTE_SERVER = 0x00004000,
+
+            /// <summary>
+            /// Windows Server 2008 Datacenter, Windows Server 2003, Datacenter Edition, or Windows 2000 Datacenter Server is installed.
+            /// </summary>
+            VER_SUITE_DATACENTER = 0x00000080,
+
+            /// <summary>
+            /// Windows Server 2008 Enterprise, Windows Server 2003, Enterprise Edition, or Windows 2000 Advanced Server is installed.
+            /// </summary>
+            VER_SUITE_ENTERPRISE = 0x00000002,
+
+            /// <summary>
+            /// Windows XP Embedded is installed.
+            /// </summary>
+            VER_SUITE_EMBEDDEDNT = 0x00000040,
+
+            /// <summary>
+            /// Windows Vista Home Premium, Windows Vista Home Basic, or Windows XP Home Edition is installed.
+            /// </summary>
+            VER_SUITE_PERSONAL = 0x00000200,
+
+            /// <summary>
+            /// Remote Desktop is supported, but only one interactive session is supported.
+            /// This value is set unless the system is running in application server mode.
+            /// </summary>
+            VER_SUITE_SINGLEUSERTS = 0x00000100,
+
+            /// <summary>
+            /// Microsoft Small Business Server was once installed on the system, but may have been upgraded to another version of Windows.
+            /// </summary>
+            /// <remarks>
+            ///  You should not rely solely on the VER_SUITE_SMALLBUSINESS flag to determine whether Small Business Server is currently installed.
+            ///  Both this flag and the VER_SUITE_SMALLBUSINESS_RESTRICTED flag are set when this product suite is installed. If you upgrade this
+            ///  installation to Windows Server, Standard Edition, the VER_SUITE_SMALLBUSINESS_RESTRICTED flag is cleared, but the
+            ///  VER_SUITE_SMALLBUSINESS flag remains set, which, in this case, indicates that Small Business Server was previously installed on
+            ///  this system. If this installation is further upgraded to Windows Server, Enterprise Edition, the VER_SUITE_SMALLBUSINESS flag
+            ///  remains set.
+            /// </remarks>
+            VER_SUITE_SMALLBUSINESS = 0x00000001,
+
+            /// <summary>
+            /// Microsoft Small Business Server is installed with the restrictive client license in force.
+            /// For more information about this flag bit, see the remarks for <see cref="VER_SUITE_SMALLBUSINESS"/> flag.
+            /// </summary>
+            VER_SUITE_SMALLBUSINESS_RESTRICTED = 0x00000020,
+
+            /// <summary>
+            /// Windows Storage Server 2003 R2 or Windows Storage Server 2003 is installed.
+            /// </summary>
+            VER_SUITE_STORAGE_SERVER = 0x00002000,
+
+            /// <summary>
+            /// Terminal Services is installed. This value is always set. If VER_SUITE_TERMINAL is set but VER_SUITE_SINGLEUSERTS is not set,
+            /// the operating system is running in application server mode.
+            /// </summary>
+            VER_SUITE_TERMINAL = 0x00000010,
+
+            /// <summary>
+            /// Windows Home Server is installed.
+            /// </summary>
+            VER_SUITE_WH_SERVER = unchecked((short)0x00008000)
+        }
+    }
+}

--- a/src/Kernel32/Kernel32+VER_CONDITION.cs
+++ b/src/Kernel32/Kernel32+VER_CONDITION.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace PInvoke
+{
+    /// <summary>
+    /// Contains the nested type <see cref="VER_CONDITION"/>
+    /// </summary>
+    public static partial class Kernel32
+    {
+        /// <summary>
+        /// The operator to be used for the comparison. The VerifyVersionInfo function uses this operator to compare a specified
+        /// attribute value to the corresponding value for the currently running system.
+        /// </summary>
+        /// <remarks>
+        /// For all values of dwTypeBitMask other than VER_SUITENAME, this parameter can be one of the following values:
+        ///     - <see cref="VER_EQUAL"/>
+        ///     - <see cref="VER_GREATER"/>
+        ///     - <see cref="VER_GREATER_EQUAL"/>
+        ///     - <see cref="VER_LESS"/>
+        ///     - <see cref="VER_LESS_EQUAL"/>
+        /// If dwTypeBitMask is VER_SUITENAME, this parameter can be one of the following values:
+        ///     - <see cref="VER_AND"/>
+        ///     - <see cref="VER_OR"/>
+        /// </remarks>
+        public enum VER_CONDITION : byte
+        {
+            /// <summary>
+            /// The current value must be equal to the specified value.
+            /// </summary>
+            VER_EQUAL = 1,
+
+            /// <summary>
+            /// The current value must be greater than the specified value.
+            /// </summary>
+            VER_GREATER = 2,
+
+            /// <summary>
+            /// The current value must be greater than or equal to the specified value.
+            /// </summary>
+            VER_GREATER_EQUAL = 3,
+
+            /// <summary>
+            /// The current value must be less than the specified value.
+            /// </summary>
+            VER_LESS = 4,
+
+            /// <summary>
+            /// The current value must be less than or equal to the specified value.
+            /// </summary>
+            VER_LESS_EQUAL = 5,
+
+            /// <summary>
+            /// All product suites specified in the wSuiteMask member must be present in the current system.
+            /// </summary>
+            VER_AND = 6,
+
+            /// <summary>
+            /// At least one of the specified product suites must be present in the current system.
+            /// </summary>
+            VER_OR = 7
+        }
+    }
+}

--- a/src/Kernel32/Kernel32+VER_CONDITION.cs
+++ b/src/Kernel32/Kernel32+VER_CONDITION.cs
@@ -9,7 +9,7 @@ namespace PInvoke
     public static partial class Kernel32
     {
         /// <summary>
-        /// The operator to be used for the comparison. The VerifyVersionInfo function uses this operator to compare a specified
+        /// The operator to be used for the comparison. The <see cref="VerifyVersionInfo(OSVERSIONINFOEX*, VER_MASK, long)"/> function uses this operator to compare a specified
         /// attribute value to the corresponding value for the currently running system.
         /// </summary>
         /// <remarks>

--- a/src/Kernel32/Kernel32+VER_MASK.cs
+++ b/src/Kernel32/Kernel32+VER_MASK.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace PInvoke
+{
+    using System;
+
+    /// <summary>
+    /// Contains the <see cref="VER_MASK"/> nested type.
+    /// </summary>
+    public static partial class Kernel32
+    {
+        /// <summary>
+        /// A mask that indicates the member of the <see cref="OSVERSIONINFOEX"/> structure whose comparison operator is being set.
+        /// This value corresponds to one of the bits specified in the dwTypeMask parameter for the VerifyVersionInfo function.
+        /// </summary>
+        [Flags]
+        public enum VER_MASK : int
+        {
+            /// <summary>
+            /// dwBuildNumber
+            /// </summary>
+            VER_BUILDNUMBER = 0x0000004,
+
+            /// <summary>
+            /// dwBuildNumber
+            /// </summary>
+            VER_MAJORVERSION = 0x0000002,
+
+            /// <summary>
+            /// dwMinorVersion
+            /// </summary>
+            VER_MINORVERSION = 0x0000001,
+
+            /// <summary>
+            /// dwPlatformId
+            /// </summary>
+            VER_PLATFORMID = 0x0000008,
+
+            /// <summary>
+            /// wProductType
+            /// </summary>
+            VER_PRODUCT_TYPE = 0x0000080,
+
+            /// <summary>
+            /// wServicePackMajor
+            /// </summary>
+            VER_SERVICEPACKMAJOR = 0x0000020,
+
+            /// <summary>
+            /// wServicePackMinor
+            /// </summary>
+            VER_SERVICEPACKMINOR = 0x0000010,
+
+            /// <summary>
+            /// wSuiteMask
+            /// </summary>
+            VER_SUITENAME = 0x0000040
+        }
+    }
+}

--- a/src/Kernel32/Kernel32+VER_MASK.cs
+++ b/src/Kernel32/Kernel32+VER_MASK.cs
@@ -12,7 +12,7 @@ namespace PInvoke
     {
         /// <summary>
         /// A mask that indicates the member of the <see cref="OSVERSIONINFOEX"/> structure whose comparison operator is being set.
-        /// This value corresponds to one of the bits specified in the dwTypeMask parameter for the VerifyVersionInfo function.
+        /// This value corresponds to one of the bits specified in the dwTypeMask parameter for the <see cref="VerifyVersionInfo(OSVERSIONINFOEX*, VER_MASK, long)"/> function.
         /// </summary>
         [Flags]
         public enum VER_MASK : int

--- a/src/Kernel32/Kernel32.cs
+++ b/src/Kernel32/Kernel32.cs
@@ -544,15 +544,15 @@ namespace PInvoke
 
         /// <summary>
         /// Sets the bits of a 64-bit value to indicate the comparison operator to use for a specified operating system version
-        /// attribute. This function is used to build the dwlConditionMask parameter of the VerifyVersionInfo function.
+        /// attribute. This function is used to build the dwlConditionMask parameter of the <see cref="VerifyVersionInfo(OSVERSIONINFOEX*, VER_MASK, long)"/> function.
         /// </summary>
-        /// <param name="ConditionMask">A value to be passed as the dwlConditionMask parameter of the VerifyVersionInfo function.
+        /// <param name="ConditionMask">A value to be passed as the dwlConditionMask parameter of the <see cref="VerifyVersionInfo(OSVERSIONINFOEX*, VER_MASK, long)"/> function.
         /// The function stores the comparison information in the bits of this variable. Before the first call to <see cref="VerSetConditionMask(long, VER_MASK, VER_CONDITION)"/>,
         /// initialize this variable to zero. For subsequent calls, pass in the variable used in the previous call.</param>
         /// <param name="TypeMask">A mask that indicates the member of the <see cref="OSVERSIONINFOEX"/> structure whose comparison operator
         /// is being set. This value corresponds to one of the bits specified in the dwTypeMask parameter for the
-        /// VerifyVersionInfo function</param>
-        /// <param name="Condition">The operator to be used for the comparison. The VerifyVersionInfo function uses this
+        /// <see cref="VerifyVersionInfo(OSVERSIONINFOEX*, VER_MASK, long)"/> function</param>
+        /// <param name="Condition">The operator to be used for the comparison. The <see cref="VerifyVersionInfo(OSVERSIONINFOEX*, VER_MASK, long)"/> function uses this
         /// operator to compare a specified attribute value to the corresponding value for the currently running system.</param>
         /// <returns>The function returns the condition mask value.</returns>
         [DllImport(api_ms_win_core_sysinfo_l1_2_0)]
@@ -585,13 +585,13 @@ namespace PInvoke
         /// </returns>
         /// <remarks>
         /// <para>
-        /// The VerifyVersionInfo function retrieves version information about the currently running operating system and compares it to the valid
+        /// The <see cref="VerifyVersionInfo(OSVERSIONINFOEX*, VER_MASK, long)"/> function retrieves version information about the currently running operating system and compares it to the valid
         /// members of the <paramref name="lpVersionInformation"/> structure. This enables you to easily determine the presence of a required set of
-        /// operating system version conditions. It is preferable to use <see cref="VerifyVersionInfo(ref OSVERSIONINFOEX, VER_MASK, long)"/> rather than
+        /// operating system version conditions. It is preferable to use <see cref="VerifyVersionInfo(OSVERSIONINFOEX*, VER_MASK, long)"/> rather than
         /// calling the GetVersionEx function to perform your own comparisons.
         /// </para>
         /// <para>
-        /// Typically, <see cref="VerifyVersionInfo(ref OSVERSIONINFOEX, VER_MASK, long)"/> returns a nonzero value only if all specified tests succeed.
+        /// Typically, <see cref="VerifyVersionInfo(OSVERSIONINFOEX*, VER_MASK, long)"/> returns a nonzero value only if all specified tests succeed.
         /// However, major, minor, and service pack versions are tested in a hierarchical manner because the operating system version is a combination of
         /// these values. If a condition exists for the major version, it supersedes the conditions specified for minor version and service pack version.
         /// (You cannot test for major version greater than 5 and minor version less than or equal to 1. If you specify such a test, the function will
@@ -607,9 +607,9 @@ namespace PInvoke
         /// the specified version, so the testing stops.)
         /// </para>
         /// <para>
-        /// To verify a range of system versions, you must call <see cref="VerifyVersionInfo(ref OSVERSIONINFOEX, VER_MASK, long)"/> twice.For example, to verify
-        /// that the system version is greater than 5.0 but less than or equal to 5.1, first call <see cref="VerifyVersionInfo(ref OSVERSIONINFOEX, VER_MASK, long)"/> to
-        /// test that the major version is 5 and the minor version is greater than 0, then call <see cref="VerifyVersionInfo(ref OSVERSIONINFOEX, VER_MASK, long)"/>
+        /// To verify a range of system versions, you must call <see cref="VerifyVersionInfo(OSVERSIONINFOEX*, VER_MASK, long)"/> twice.For example, to verify
+        /// that the system version is greater than 5.0 but less than or equal to 5.1, first call <see cref="VerifyVersionInfo(OSVERSIONINFOEX*, VER_MASK, long)"/> to
+        /// test that the major version is 5 and the minor version is greater than 0, then call <see cref="VerifyVersionInfo(OSVERSIONINFOEX*, VER_MASK, long)"/>
         /// again to test that the major version is 5 and the minor version is less than or equal to 1.
         /// </para>
         /// <para>
@@ -622,21 +622,24 @@ namespace PInvoke
         /// </para>
         /// <para>
         /// Windows 10:
-        ///     <see cref="VerifyVersionInfo(ref OSVERSIONINFOEX, VER_MASK, long)"/> returns false when called by applications that do not have a
+        ///     <see cref="VerifyVersionInfo(OSVERSIONINFOEX*, VER_MASK, long)"/> returns false when called by applications that do not have a
         ///     compatibility manifest for Windows 8.1 or Windows 10 if the <paramref name="lpVersionInformation"/> parameter is set so that it specifies
         ///     Windows 8.1 or Windows 10, even when the current operating system version is Windows 8.1 or Windows 10. Specifically,
-        ///     <see cref="VerifyVersionInfo(ref OSVERSIONINFOEX, VER_MASK, long)"/> has the following behavior:
+        ///     <see cref="VerifyVersionInfo(OSVERSIONINFOEX*, VER_MASK, long)"/> has the following behavior:
         ///
-        ///     If the application has no manifest, <see cref="VerifyVersionInfo(ref OSVERSIONINFOEX, VER_MASK, long)"/> behaves as
+        ///     If the application has no manifest, <see cref="VerifyVersionInfo(OSVERSIONINFOEX*, VER_MASK, long)"/> behaves as
         ///         if the operation system version is Windows 8 (6.2).
-        ///     If the application has a manifest that contains the GUID that corresponds to Windows 8.1, <see cref="VerifyVersionInfo(ref OSVERSIONINFOEX, VER_MASK, long)"/>
+        ///     If the application has a manifest that contains the GUID that corresponds to Windows 8.1, <see cref="VerifyVersionInfo(OSVERSIONINFOEX*, VER_MASK, long)"/>
         ///         behaves as if the operation system version is Windows 8.1 (6.3).
-        ///     If the application has a manifest that contains the GUID that corresponds to Windows 10, <see cref="VerifyVersionInfo(ref OSVERSIONINFOEX, VER_MASK, long)"/>
+        ///     If the application has a manifest that contains the GUID that corresponds to Windows 10, <see cref="VerifyVersionInfo(OSVERSIONINFOEX*, VER_MASK, long)"/>
         ///         behaves as if the operation system version is Windows 10 (10.0).
         /// </para>
         /// </remarks>
         [DllImport(nameof(Kernel32))]
-        public static extern NTSTATUS VerifyVersionInfo(ref OSVERSIONINFOEX lpVersionInformation, VER_MASK dwTypeMask, long dwlConditionMask);
+        public static unsafe extern NTSTATUS VerifyVersionInfo(
+            [Friendly(FriendlyFlags.Bidirectional)] OSVERSIONINFOEX* lpVersionInformation,
+            VER_MASK dwTypeMask,
+            long dwlConditionMask);
 
         /// <summary>
         ///     Closes a file search handle opened by the FindFirstFile, FindFirstFileEx, FindFirstFileNameW,

--- a/src/Kernel32/Kernel32.cs
+++ b/src/Kernel32/Kernel32.cs
@@ -543,6 +543,102 @@ namespace PInvoke
         public static extern void SetLastError(uint dwErrCode);
 
         /// <summary>
+        /// Sets the bits of a 64-bit value to indicate the comparison operator to use for a specified operating system version
+        /// attribute. This function is used to build the dwlConditionMask parameter of the VerifyVersionInfo function.
+        /// </summary>
+        /// <param name="ConditionMask">A value to be passed as the dwlConditionMask parameter of the VerifyVersionInfo function.
+        /// The function stores the comparison information in the bits of this variable. Before the first call to <see cref="VerSetConditionMask(long, VER_MASK, VER_CONDITION)"/>,
+        /// initialize this variable to zero. For subsequent calls, pass in the variable used in the previous call.</param>
+        /// <param name="TypeMask">A mask that indicates the member of the <see cref="OSVERSIONINFOEX"/> structure whose comparison operator
+        /// is being set. This value corresponds to one of the bits specified in the dwTypeMask parameter for the
+        /// VerifyVersionInfo function</param>
+        /// <param name="Condition">The operator to be used for the comparison. The VerifyVersionInfo function uses this
+        /// operator to compare a specified attribute value to the corresponding value for the currently running system.</param>
+        /// <returns>The function returns the condition mask value.</returns>
+        [DllImport(api_ms_win_core_sysinfo_l1_2_0)]
+        public static extern long VerSetConditionMask(long ConditionMask, VER_MASK TypeMask, VER_CONDITION Condition);
+
+        /// <summary>
+        /// Compares a set of operating system version requirements to the corresponding values for the currently
+        /// running version of the system.This function is subject to manifest-based behavior.
+        /// </summary>
+        /// <param name="lpVersionInformation">
+        /// A pointer to an OSVERSIONINFOEX structure containing the operating system version requirements to compare. The <paramref name="dwTypeMask"/>
+        /// parameter indicates the members of this structure that contain information to compare.You must set the
+        /// <see cref="OSVERSIONINFOEX.dwOSVersionInfoSize"/> member of this structure to <code>Marshal.SizeOf(typeof(OSVERSIONINFOEX))</code>. You must
+        /// also specify valid data for the members indicated by <paramref name="dwTypeMask"/>. The function ignores structure members for which the
+        /// corresponding <paramref name="dwTypeMask"/> bit is not set
+        /// </param>
+        /// <param name="dwTypeMask">A mask that indicates the members of the <see cref="OSVERSIONINFOEX"/> structure to be tested.</param>
+        /// <param name="dwlConditionMask">The type of comparison to be used for each <paramref name="lpVersionInformation"/> member being compared. To build this value,
+        /// call the <see cref="VerSetConditionMask(long, VER_MASK, VER_CONDITION)"/> function once for each <see cref="OSVERSIONINFOEX"/> member being compared.</param>
+        /// <returns>
+        /// <para>
+        /// If the currently running operating system satisfies the specified requirements, the return value is a nonzero value.
+        /// </para>
+        /// <para>
+        /// If the current system does not satisfy the requirements, the return value is zero and <see cref="GetLastError"/> returns <see cref="Win32ErrorCode.ERROR_OLD_WIN_VERSION"/>.
+        /// </para>
+        /// <para>
+        /// If the function fails, the return value is zero and <see cref="GetLastError"/> returns an error code other than <see cref="Win32ErrorCode.ERROR_OLD_WIN_VERSION"/>.
+        /// </para>
+        /// </returns>
+        /// <remarks>
+        /// <para>
+        /// The VerifyVersionInfo function retrieves version information about the currently running operating system and compares it to the valid
+        /// members of the <paramref name="lpVersionInformation"/> structure. This enables you to easily determine the presence of a required set of
+        /// operating system version conditions. It is preferable to use <see cref="VerifyVersionInfo(ref OSVERSIONINFOEX, VER_MASK, long)"/> rather than
+        /// calling the GetVersionEx function to perform your own comparisons.
+        /// </para>
+        /// <para>
+        /// Typically, <see cref="VerifyVersionInfo(ref OSVERSIONINFOEX, VER_MASK, long)"/> returns a nonzero value only if all specified tests succeed.
+        /// However, major, minor, and service pack versions are tested in a hierarchical manner because the operating system version is a combination of
+        /// these values. If a condition exists for the major version, it supersedes the conditions specified for minor version and service pack version.
+        /// (You cannot test for major version greater than 5 and minor version less than or equal to 1. If you specify such a test, the function will
+        /// change the request to test for a minor version greater than 1 because it is performing a greater than operation on the major version.)
+        /// </para>
+        /// <para>
+        /// The function tests these values in this order: major version, minor version, and service pack version.The function continues testing values while
+        /// they are equal, and stops when one of the values does not meet the specified condition.For example, if you test for a system greater than or
+        /// equal to version 5.1 service pack 1, the test succeeds if the current version is 6.0. (The major version is greater than the specified version,
+        /// so the testing stops.) In the same way, if you test for a system greater than or equal to version 5.1 service pack 1, the test succeeds if the
+        /// current version is 5.2. (The minor version is greater than the specified versions, so the testing stops.) However, if you test for a system greater
+        /// than or equal to version 5.1 service pack 1, the test fails if the current version is 5.0 service pack 2. (The minor version is not greater than
+        /// the specified version, so the testing stops.)
+        /// </para>
+        /// <para>
+        /// To verify a range of system versions, you must call <see cref="VerifyVersionInfo(ref OSVERSIONINFOEX, VER_MASK, long)"/> twice.For example, to verify
+        /// that the system version is greater than 5.0 but less than or equal to 5.1, first call <see cref="VerifyVersionInfo(ref OSVERSIONINFOEX, VER_MASK, long)"/> to
+        /// test that the major version is 5 and the minor version is greater than 0, then call <see cref="VerifyVersionInfo(ref OSVERSIONINFOEX, VER_MASK, long)"/>
+        /// again to test that the major version is 5 and the minor version is less than or equal to 1.
+        /// </para>
+        /// <para>
+        /// Identifying the current operating system is usually not the best way to determine whether a particular operating system feature is present.
+        /// This is because the operating system may have had new features added in a redistributable DLL. Rather than using GetVersionEx to determine the operating
+        /// system platform or version number, test for the presence of the feature itself.
+        /// </para>
+        /// <para>
+        /// To verify whether the current operating system is either the Media Center or Tablet PC version of Windows, call GetSystemMetrics.
+        /// </para>
+        /// <para>
+        /// Windows 10:
+        ///     <see cref="VerifyVersionInfo(ref OSVERSIONINFOEX, VER_MASK, long)"/> returns false when called by applications that do not have a
+        ///     compatibility manifest for Windows 8.1 or Windows 10 if the <paramref name="lpVersionInformation"/> parameter is set so that it specifies
+        ///     Windows 8.1 or Windows 10, even when the current operating system version is Windows 8.1 or Windows 10. Specifically,
+        ///     <see cref="VerifyVersionInfo(ref OSVERSIONINFOEX, VER_MASK, long)"/> has the following behavior:
+        ///
+        ///     If the application has no manifest, <see cref="VerifyVersionInfo(ref OSVERSIONINFOEX, VER_MASK, long)"/> behaves as
+        ///         if the operation system version is Windows 8 (6.2).
+        ///     If the application has a manifest that contains the GUID that corresponds to Windows 8.1, <see cref="VerifyVersionInfo(ref OSVERSIONINFOEX, VER_MASK, long)"/>
+        ///         behaves as if the operation system version is Windows 8.1 (6.3).
+        ///     If the application has a manifest that contains the GUID that corresponds to Windows 10, <see cref="VerifyVersionInfo(ref OSVERSIONINFOEX, VER_MASK, long)"/>
+        ///         behaves as if the operation system version is Windows 10 (10.0).
+        /// </para>
+        /// </remarks>
+        [DllImport(nameof(Kernel32))]
+        public static extern NTSTATUS VerifyVersionInfo(ref OSVERSIONINFOEX lpVersionInformation, VER_MASK dwTypeMask, long dwlConditionMask);
+
+        /// <summary>
         ///     Closes a file search handle opened by the FindFirstFile, FindFirstFileEx, FindFirstFileNameW,
         ///     FindFirstFileNameTransactedW, FindFirstFileTransacted, FindFirstStreamTransactedW, or FindFirstStreamW functions.
         /// </summary>

--- a/src/Kernel32/PublicAPI.Unshipped.txt
+++ b/src/Kernel32/PublicAPI.Unshipped.txt
@@ -35,12 +35,13 @@ PInvoke.Kernel32.PRODUCT_SUITE.VER_SUITE_TERMINAL = 16 -> PInvoke.Kernel32.PRODU
 PInvoke.Kernel32.PRODUCT_SUITE.VER_SUITE_WH_SERVER = -32768 -> PInvoke.Kernel32.PRODUCT_SUITE
 PInvoke.Kernel32.OSVERSIONINFOEX
 PInvoke.Kernel32.OSVERSIONINFOEX.OSVERSIONINFOEX() -> void
+static PInvoke.Kernel32.OSVERSIONINFOEX.Create() -> PInvoke.Kernel32.OSVERSIONINFOEX
 PInvoke.Kernel32.OSVERSIONINFOEX.dwOSVersionInfoSize -> int
 PInvoke.Kernel32.OSVERSIONINFOEX.dwMajorVersion -> int
 PInvoke.Kernel32.OSVERSIONINFOEX.dwMinorVersion -> int
 PInvoke.Kernel32.OSVERSIONINFOEX.dwBuildNumber -> int
 PInvoke.Kernel32.OSVERSIONINFOEX.dwPlatformId -> int
-PInvoke.Kernel32.OSVERSIONINFOEX.szCSDVersion -> string
+PInvoke.Kernel32.OSVERSIONINFOEX.szCSDVersion -> char*
 PInvoke.Kernel32.OSVERSIONINFOEX.wServicePackMajor -> short
 PInvoke.Kernel32.OSVERSIONINFOEX.wServicePackMinor -> short
 PInvoke.Kernel32.OSVERSIONINFOEX.wSuiteMask -> PInvoke.Kernel32.PRODUCT_SUITE
@@ -67,4 +68,8 @@ static extern PInvoke.Kernel32.GetStartupInfo(PInvoke.Kernel32.STARTUPINFO* lpSt
 static extern PInvoke.Kernel32.SetLastError(uint dwErrCode) -> void
 static extern PInvoke.Kernel32.GetProcessTimes(PInvoke.Kernel32.SafeObjectHandle handle, out PInvoke.Kernel32.FILETIME creation, out PInvoke.Kernel32.FILETIME exit, out PInvoke.Kernel32.FILETIME kernel, out PInvoke.Kernel32.FILETIME user) -> bool
 static extern PInvoke.Kernel32.VerSetConditionMask(long ConditionMask, PInvoke.Kernel32.VER_MASK TypeMask, PInvoke.Kernel32.VER_CONDITION Condition) -> long
-static extern PInvoke.Kernel32.VerifyVersionInfo(ref PInvoke.Kernel32.OSVERSIONINFOEX lpVersionInformation, PInvoke.Kernel32.VER_MASK dwTypeMask, long dwlConditionMask) -> PInvoke.NTSTATUS
+static extern PInvoke.Kernel32.VerifyVersionInfo(PInvoke.Kernel32.OSVERSIONINFOEX* lpVersionInformation, PInvoke.Kernel32.VER_MASK dwTypeMask, long dwlConditionMask) -> PInvoke.NTSTATUS
+static PInvoke.Kernel32.VerifyVersionInfo(ref PInvoke.Kernel32.OSVERSIONINFOEX lpVersionInformation, PInvoke.Kernel32.VER_MASK dwTypeMask, long dwlConditionMask) -> PInvoke.NTSTATUS
+static PInvoke.Kernel32.VerifyVersionInfo(System.IntPtr lpVersionInformation, PInvoke.Kernel32.VER_MASK dwTypeMask, long dwlConditionMask) -> PInvoke.NTSTATUS
+
+

--- a/src/Kernel32/PublicAPI.Unshipped.txt
+++ b/src/Kernel32/PublicAPI.Unshipped.txt
@@ -1,3 +1,51 @@
+PInvoke.Kernel32.VER_CONDITION
+PInvoke.Kernel32.VER_CONDITION.VER_EQUAL = 1 -> PInvoke.Kernel32.VER_CONDITION
+PInvoke.Kernel32.VER_CONDITION.VER_GREATER = 2 -> PInvoke.Kernel32.VER_CONDITION
+PInvoke.Kernel32.VER_CONDITION.VER_GREATER_EQUAL = 3 -> PInvoke.Kernel32.VER_CONDITION
+PInvoke.Kernel32.VER_CONDITION.VER_LESS = 4 -> PInvoke.Kernel32.VER_CONDITION
+PInvoke.Kernel32.VER_CONDITION.VER_LESS_EQUAL = 5 -> PInvoke.Kernel32.VER_CONDITION
+PInvoke.Kernel32.VER_CONDITION.VER_AND = 6 -> PInvoke.Kernel32.VER_CONDITION
+PInvoke.Kernel32.VER_CONDITION.VER_OR = 7 -> PInvoke.Kernel32.VER_CONDITION
+PInvoke.Kernel32.VER_MASK
+PInvoke.Kernel32.VER_MASK.VER_BUILDNUMBER = 4 -> PInvoke.Kernel32.VER_MASK
+PInvoke.Kernel32.VER_MASK.VER_MAJORVERSION = 2 -> PInvoke.Kernel32.VER_MASK
+PInvoke.Kernel32.VER_MASK.VER_MINORVERSION = 1 -> PInvoke.Kernel32.VER_MASK
+PInvoke.Kernel32.VER_MASK.VER_PLATFORMID = 8 -> PInvoke.Kernel32.VER_MASK
+PInvoke.Kernel32.VER_MASK.VER_PRODUCT_TYPE = 128 -> PInvoke.Kernel32.VER_MASK
+PInvoke.Kernel32.VER_MASK.VER_SERVICEPACKMAJOR = 32 -> PInvoke.Kernel32.VER_MASK
+PInvoke.Kernel32.VER_MASK.VER_SERVICEPACKMINOR = 16 -> PInvoke.Kernel32.VER_MASK
+PInvoke.Kernel32.VER_MASK.VER_SUITENAME = 64 -> PInvoke.Kernel32.VER_MASK
+PInvoke.Kernel32.OS_TYPE
+PInvoke.Kernel32.OS_TYPE.VER_NT_WORKSTATION = 1 -> PInvoke.Kernel32.OS_TYPE
+PInvoke.Kernel32.OS_TYPE.VER_NT_DOMAIN_CONTROLLER = 2 -> PInvoke.Kernel32.OS_TYPE
+PInvoke.Kernel32.OS_TYPE.VER_NT_SERVER = 3 -> PInvoke.Kernel32.OS_TYPE
+PInvoke.Kernel32.PRODUCT_SUITE
+PInvoke.Kernel32.PRODUCT_SUITE.VER_SUITE_BACKOFFICE = 4 -> PInvoke.Kernel32.PRODUCT_SUITE
+PInvoke.Kernel32.PRODUCT_SUITE.VER_SUITE_BLADE = 1024 -> PInvoke.Kernel32.PRODUCT_SUITE
+PInvoke.Kernel32.PRODUCT_SUITE.VER_SUITE_COMPUTE_SERVER = 16384 -> PInvoke.Kernel32.PRODUCT_SUITE
+PInvoke.Kernel32.PRODUCT_SUITE.VER_SUITE_DATACENTER = 128 -> PInvoke.Kernel32.PRODUCT_SUITE
+PInvoke.Kernel32.PRODUCT_SUITE.VER_SUITE_ENTERPRISE = 2 -> PInvoke.Kernel32.PRODUCT_SUITE
+PInvoke.Kernel32.PRODUCT_SUITE.VER_SUITE_EMBEDDEDNT = 64 -> PInvoke.Kernel32.PRODUCT_SUITE
+PInvoke.Kernel32.PRODUCT_SUITE.VER_SUITE_PERSONAL = 512 -> PInvoke.Kernel32.PRODUCT_SUITE
+PInvoke.Kernel32.PRODUCT_SUITE.VER_SUITE_SINGLEUSERTS = 256 -> PInvoke.Kernel32.PRODUCT_SUITE
+PInvoke.Kernel32.PRODUCT_SUITE.VER_SUITE_SMALLBUSINESS = 1 -> PInvoke.Kernel32.PRODUCT_SUITE
+PInvoke.Kernel32.PRODUCT_SUITE.VER_SUITE_SMALLBUSINESS_RESTRICTED = 32 -> PInvoke.Kernel32.PRODUCT_SUITE
+PInvoke.Kernel32.PRODUCT_SUITE.VER_SUITE_STORAGE_SERVER = 8192 -> PInvoke.Kernel32.PRODUCT_SUITE
+PInvoke.Kernel32.PRODUCT_SUITE.VER_SUITE_TERMINAL = 16 -> PInvoke.Kernel32.PRODUCT_SUITE
+PInvoke.Kernel32.PRODUCT_SUITE.VER_SUITE_WH_SERVER = -32768 -> PInvoke.Kernel32.PRODUCT_SUITE
+PInvoke.Kernel32.OSVERSIONINFOEX
+PInvoke.Kernel32.OSVERSIONINFOEX.OSVERSIONINFOEX() -> void
+PInvoke.Kernel32.OSVERSIONINFOEX.dwOSVersionInfoSize -> int
+PInvoke.Kernel32.OSVERSIONINFOEX.dwMajorVersion -> int
+PInvoke.Kernel32.OSVERSIONINFOEX.dwMinorVersion -> int
+PInvoke.Kernel32.OSVERSIONINFOEX.dwBuildNumber -> int
+PInvoke.Kernel32.OSVERSIONINFOEX.dwPlatformId -> int
+PInvoke.Kernel32.OSVERSIONINFOEX.szCSDVersion -> string
+PInvoke.Kernel32.OSVERSIONINFOEX.wServicePackMajor -> short
+PInvoke.Kernel32.OSVERSIONINFOEX.wServicePackMinor -> short
+PInvoke.Kernel32.OSVERSIONINFOEX.wSuiteMask -> PInvoke.Kernel32.PRODUCT_SUITE
+PInvoke.Kernel32.OSVERSIONINFOEX.wProductType -> PInvoke.Kernel32.OS_TYPE
+PInvoke.Kernel32.OSVERSIONINFOEX.wReserved -> byte
 PInvoke.Kernel32.STARTUPINFO.Desktop.get -> string
 PInvoke.Kernel32.STARTUPINFO.Title.get -> string
 PInvoke.Kernel32.STARTUPINFO.hStdError -> System.IntPtr
@@ -18,3 +66,5 @@ static extern PInvoke.Kernel32.GetProcessId(System.IntPtr Process) -> int
 static extern PInvoke.Kernel32.GetStartupInfo(PInvoke.Kernel32.STARTUPINFO* lpStartupInfo) -> void
 static extern PInvoke.Kernel32.SetLastError(uint dwErrCode) -> void
 static extern PInvoke.Kernel32.GetProcessTimes(PInvoke.Kernel32.SafeObjectHandle handle, out PInvoke.Kernel32.FILETIME creation, out PInvoke.Kernel32.FILETIME exit, out PInvoke.Kernel32.FILETIME kernel, out PInvoke.Kernel32.FILETIME user) -> bool
+static extern PInvoke.Kernel32.VerSetConditionMask(long ConditionMask, PInvoke.Kernel32.VER_MASK TypeMask, PInvoke.Kernel32.VER_CONDITION Condition) -> long
+static extern PInvoke.Kernel32.VerifyVersionInfo(ref PInvoke.Kernel32.OSVERSIONINFOEX lpVersionInformation, PInvoke.Kernel32.VER_MASK dwTypeMask, long dwlConditionMask) -> PInvoke.NTSTATUS

--- a/src/NTDll/NTDll.cs
+++ b/src/NTDll/NTDll.cs
@@ -43,7 +43,7 @@ namespace PInvoke
             [Friendly(FriendlyFlags.In)] OBJECT_ATTRIBUTES* objectAttributes);
 
         /// <summary>
-        /// The RtlVerifyVersionInfo routine compares a specified set of operating system version requirements to the
+        /// The <see cref="RtlVerifyVersionInfo(Kernel32.OSVERSIONINFOEX*, Kernel32.VER_MASK, long)"/> routine compares a specified set of operating system version requirements to the
         /// corresponding attributes of the currently running version of the operating system.
         /// </summary>
         /// <param name="VersionInfo">Pointer to an <see cref="Kernel32.OSVERSIONINFOEX"/> structure that specifies the
@@ -59,13 +59,16 @@ namespace PInvoke
         ///     <see cref="NTSTATUS.Code.STATUS_REVISION_MISMATCH"/> when the specified version does not match the currently running version of the operating system.
         /// </returns>
         /// <remarks>
-        ///     See remarks in <see cref="Kernel32.VerifyVersionInfo(ref Kernel32.OSVERSIONINFOEX, Kernel32.VER_MASK, long)"/>.
+        ///     See remarks in <see cref="Kernel32.VerifyVersionInfo(Kernel32.OSVERSIONINFOEX*, Kernel32.VER_MASK, long)"/>.
         ///
-        ///     Unmanifested applications that call <see cref="RtlVerifyVersionInfo(ref Kernel32.OSVERSIONINFOEX, Kernel32.VER_MASK, long)"/> are not
+        ///     Unmanifested applications that call <see cref="RtlVerifyVersionInfo(Kernel32.OSVERSIONINFOEX*, Kernel32.VER_MASK, long)"/> are not
         ///     suspectible to version-lies by the OS.
         /// </remarks>
         [DllImport(nameof(NTDll))]
-        public static extern NTSTATUS RtlVerifyVersionInfo(ref Kernel32.OSVERSIONINFOEX VersionInfo, Kernel32.VER_MASK TypeMask, long ConditionMask);
+        public static unsafe extern NTSTATUS RtlVerifyVersionInfo(
+            [Friendly(FriendlyFlags.Bidirectional)]Kernel32.OSVERSIONINFOEX* VersionInfo,
+            Kernel32.VER_MASK TypeMask,
+            long ConditionMask);
 
         /// <summary>
         /// The NtClose routine closes an object handle.

--- a/src/NTDll/NTDll.cs
+++ b/src/NTDll/NTDll.cs
@@ -43,6 +43,31 @@ namespace PInvoke
             [Friendly(FriendlyFlags.In)] OBJECT_ATTRIBUTES* objectAttributes);
 
         /// <summary>
+        /// The RtlVerifyVersionInfo routine compares a specified set of operating system version requirements to the
+        /// corresponding attributes of the currently running version of the operating system.
+        /// </summary>
+        /// <param name="VersionInfo">Pointer to an <see cref="Kernel32.OSVERSIONINFOEX"/> structure that specifies the
+        /// operating system version requirements to compare to the corresponding attributes of the currently running
+        /// version of the operating system.</param>
+        /// <param name="TypeMask">Specifies which members of VersionInfo to compare with the corresponding attributes of
+        /// the currently running version of the operating system. </param>
+        /// <param name="ConditionMask">Specifies how to compare each VersionInfo member. To set the value of ConditionMask,
+        /// a caller should use the <see cref="Kernel32.VerSetConditionMask(long, Kernel32.VER_MASK, Kernel32.VER_CONDITION)"/> function.</param>
+        /// <returns>
+        ///     <see cref="NTSTATUS.Code.STATUS_SUCCESS"/> when the specified version matches the currently running version of the operating system.
+        ///     <see cref="NTSTATUS.Code.STATUS_INVALID_PARAMETER"/> when the input parameters are not valid.
+        ///     <see cref="NTSTATUS.Code.STATUS_REVISION_MISMATCH"/> when the specified version does not match the currently running version of the operating system.
+        /// </returns>
+        /// <remarks>
+        ///     See remarks in <see cref="Kernel32.VerifyVersionInfo(ref Kernel32.OSVERSIONINFOEX, Kernel32.VER_MASK, long)"/>.
+        ///
+        ///     Unmanifested applications that call <see cref="RtlVerifyVersionInfo(ref Kernel32.OSVERSIONINFOEX, Kernel32.VER_MASK, long)"/> are not
+        ///     suspectible to version-lies by the OS.
+        /// </remarks>
+        [DllImport(nameof(NTDll))]
+        public static extern NTSTATUS RtlVerifyVersionInfo(ref Kernel32.OSVERSIONINFOEX VersionInfo, Kernel32.VER_MASK TypeMask, long ConditionMask);
+
+        /// <summary>
         /// The NtClose routine closes an object handle.
         /// </summary>
         /// <param name="handle">Handle to an object of any type.</param>

--- a/src/NTDll/PublicAPI.Unshipped.txt
+++ b/src/NTDll/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
-static extern PInvoke.NTDll.RtlVerifyVersionInfo(ref PInvoke.Kernel32.OSVERSIONINFOEX VersionInfo, PInvoke.Kernel32.VER_MASK TypeMask, long ConditionMask) -> PInvoke.NTSTATUS
+static extern PInvoke.NTDll.RtlVerifyVersionInfo(PInvoke.Kernel32.OSVERSIONINFOEX* VersionInfo, PInvoke.Kernel32.VER_MASK TypeMask, long ConditionMask) -> PInvoke.NTSTATUS
+static PInvoke.NTDll.RtlVerifyVersionInfo(ref PInvoke.Kernel32.OSVERSIONINFOEX VersionInfo, PInvoke.Kernel32.VER_MASK TypeMask, long ConditionMask) -> PInvoke.NTSTATUS
+static PInvoke.NTDll.RtlVerifyVersionInfo(System.IntPtr VersionInfo, PInvoke.Kernel32.VER_MASK TypeMask, long ConditionMask) -> PInvoke.NTSTATUS

--- a/src/NTDll/PublicAPI.Unshipped.txt
+++ b/src/NTDll/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+static extern PInvoke.NTDll.RtlVerifyVersionInfo(ref PInvoke.Kernel32.OSVERSIONINFOEX VersionInfo, PInvoke.Kernel32.VER_MASK TypeMask, long ConditionMask) -> PInvoke.NTSTATUS


### PR DESCRIPTION
- P/Invokes for `kernel32!VerifyVersionInfo` & `ntdll!RtlVerifyVersionInfo`
  - Could not identify a suitable API Set DLL for `kernel32!VerifyVersionInfo`, so using `kernel32` directly in `DllImport`
- Support methods
  - `kernel32!VerSetConditionMask`
- Support types
  - `OSVERSIONINFOEX`, `OS_TYPE`, `PRODUCT_SUITE`, `VER_MASK`, `VER_CONDITION`
