### PR TITLE
Use C# sizeof wherever possible

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -7,6 +7,8 @@
     Restore NuGet packages.
 .Parameter Build
     Build the entire project. Requires that -Restore is or has been executed.
+.Parameter Rebuild
+    Build the entire project with the Rebuild target. This may be slower than -Build but ensures you'll see any build warnings from prior builds. Requires that -Restore is or has been executed.
 .Parameter Test
     Run all built tests.
 .Parameter Configuration
@@ -22,6 +24,7 @@
 Param(
     [switch]$Restore,
     [switch]$Build,
+    [switch]$Rebuild,
     [switch]$Test,
     [Parameter()][ValidateSet('debug', 'release')]
     [string]$Configuration = $env:BUILDCONFIGURATION,
@@ -57,7 +60,7 @@ $PackageRestoreRoot = if ($env:NUGET_PACKAGES) { $env:NUGET_PACKAGES } else { Jo
 $MSBuildCommand = Get-Command MSBuild.exe -ErrorAction SilentlyContinue
 
 Function Get-ExternalTools {
-    if ($Build -and !$MSBuildCommand) {
+    if (($Build -or $Rebuild) -and !$MSBuildCommand) {
         Write-Error "Unable to find MSBuild.exe. Make sure you're running in a VS Developer Prompt."
         exit 1;
     }
@@ -70,9 +73,11 @@ if ($Restore -and $PSCmdlet.ShouldProcess($SolutionFile, "Restore packages")) {
     & "$PSScriptRoot\init.ps1"
 }
 
-if ($Build -and $PSCmdlet.ShouldProcess($SolutionFile, "Build")) {
+if (($Build -or $Rebuild) -and $PSCmdlet.ShouldProcess($SolutionFile, "Build")) {
+    $msbuildTarget = "build"
+    if ($Rebuild) { $msbuildTarget = "rebuild" }
     $buildArgs = @()
-    $buildArgs += $SolutionFile,'/nologo','/nr:false','/m','/v:minimal','/t:build,pack'
+    $buildArgs += $SolutionFile,'/nologo','/nr:false','/m','/v:minimal',"/t:$msbuildTarget,pack"
     $buildArgs += "/p:Configuration=$Configuration"
     $buildArgs += "/clp:ForceNoAlign;Summary"
     $buildArgs += '/fl','/flp:verbosity=normal;logfile=msbuild.log','/flp1:warningsonly;logfile=msbuild.wrn;NoSummary;verbosity=minimal','/flp2:errorsonly;logfile=msbuild.err;NoSummary;verbosity=minimal'

--- a/src/BCrypt.Tests/BCryptFacts.cs
+++ b/src/BCrypt.Tests/BCryptFacts.cs
@@ -397,7 +397,7 @@ public class BCryptFacts
             using (hash)
             {
                 var ops = new BCRYPT_MULTI_HASH_OPERATION[parallelism];
-                int opsSize = parallelism * Marshal.SizeOf<BCRYPT_MULTI_HASH_OPERATION>();
+                int opsSize = parallelism * sizeof(BCRYPT_MULTI_HASH_OPERATION);
                 fixed (byte* dataPtr = data)
                 {
                     for (int i = 0; i < ops.Length; i++)

--- a/src/BCrypt/BCrypt+BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO.cs
+++ b/src/BCrypt/BCrypt+BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO.cs
@@ -129,11 +129,7 @@ namespace PInvoke
             {
                 return new BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO
                 {
-#if NETSTANDARD2_0_ORLATER || NETFX_CORE
-                    cbSize = Marshal.SizeOf<BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO>(),
-#else
-                    cbSize = Marshal.SizeOf(typeof(BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO)),
-#endif
+                    cbSize = sizeof(BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO),
                     dwInfoVersion = BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO_VERSION,
                 };
             }

--- a/src/BCrypt/BCrypt+BCRYPT_KEY_DATA_BLOB_HEADER.cs
+++ b/src/BCrypt/BCrypt+BCRYPT_KEY_DATA_BLOB_HEADER.cs
@@ -76,13 +76,9 @@ namespace PInvoke
                 return header.AddHeaderToKey(keyMaterial);
             }
 
-            private byte[] AddHeaderToKey(byte[] keyMaterial)
+            private unsafe byte[] AddHeaderToKey(byte[] keyMaterial)
             {
-#if NETSTANDARD2_0_ORLATER || NETFX_CORE
-                int headerLength = Marshal.SizeOf<BCRYPT_KEY_DATA_BLOB_HEADER>();
-#else
-                int headerLength = Marshal.SizeOf(typeof(BCRYPT_KEY_DATA_BLOB_HEADER));
-#endif
+                int headerLength = sizeof(BCRYPT_KEY_DATA_BLOB_HEADER);
                 byte[] keyWithHeader = new byte[headerLength + keyMaterial.Length];
                 Array.Copy(BitConverter.GetBytes((uint)this.dwMagic), keyWithHeader, sizeof(uint));
                 Array.Copy(BitConverter.GetBytes(this.dwVersion), 0, keyWithHeader, sizeof(uint), sizeof(uint));

--- a/src/CfgMgr32.Tests/CfgMgr32Facts.cs
+++ b/src/CfgMgr32.Tests/CfgMgr32Facts.cs
@@ -17,7 +17,7 @@ public class CfgMgr32Facts
     [Fact]
     public void CM_NOTIFY_FILTER_Test()
     {
-        Assert.Equal(0x1a0, Marshal.SizeOf<CM_NOTIFY_FILTER>());
+        Assert.Equal(0x1a0, CM_NOTIFY_FILTER.Create().cbSize);
     }
 
     [Fact]

--- a/src/Fusion/MSCorEE+ASSEMBLY_INFO.cs
+++ b/src/Fusion/MSCorEE+ASSEMBLY_INFO.cs
@@ -46,13 +46,7 @@ namespace PInvoke
             /// with the <see cref="cbAssemblyInfo"/> field initialized.
             /// </summary>
             /// <returns>The newly initialized struct.</returns>
-            public static ASSEMBLY_INFO Create()
-            {
-                return new ASSEMBLY_INFO
-                {
-                    cbAssemblyInfo = (uint)Marshal.SizeOf(typeof(ASSEMBLY_INFO)),
-                };
-            }
+            public static ASSEMBLY_INFO Create() => new ASSEMBLY_INFO { cbAssemblyInfo = (uint)sizeof(ASSEMBLY_INFO) };
         }
     }
 }

--- a/src/Hid/Hid+HiddAttributes.cs
+++ b/src/Hid/Hid+HiddAttributes.cs
@@ -35,12 +35,7 @@ namespace PInvoke
             /// </summary>
             public ushort VersionNumber;
 
-            public static HiddAttributes Create()
-            {
-                var result = default(HiddAttributes);
-                result.Size = Marshal.SizeOf(result);
-                return result;
-            }
+            public static unsafe HiddAttributes Create() => new HiddAttributes { Size = sizeof(HiddAttributes) };
         }
     }
 }

--- a/src/IPHlpApi.Tests/IPHlpApiFacts.cs
+++ b/src/IPHlpApi.Tests/IPHlpApiFacts.cs
@@ -11,10 +11,10 @@ using Xunit;
 public class IPHlpApiFacts
 {
     [Fact]
-    public void StructSizeTest()
+    public unsafe void StructSizeTest()
     {
-        Assert.Equal(0x04, Marshal.SizeOf<IPHlpApi.MIB_TCPTABLE_OWNER_PID>());
-        Assert.Equal(0x18, Marshal.SizeOf<IPHlpApi.MIB_TCPROW_OWNER_PID>());
+        Assert.Equal(0x04, sizeof(IPHlpApi.MIB_TCPTABLE_OWNER_PID));
+        Assert.Equal(0x18, sizeof(IPHlpApi.MIB_TCPROW_OWNER_PID));
     }
 
     [Fact]
@@ -32,7 +32,7 @@ public class IPHlpApiFacts
                 if (IPHlpApi.GetExtendedTcpTable(tcpTablePtr, ref tcpTableLength, bOrder: true, AddressFamily.InterNetwork, IPHlpApi.TCP_TABLE_CLASS.TCP_TABLE_OWNER_PID_ALL, 0) == Win32ErrorCode.ERROR_SUCCESS)
                 {
                     IPHlpApi.MIB_TCPTABLE_OWNER_PID* tcpTable = (IPHlpApi.MIB_TCPTABLE_OWNER_PID*)tcpTablePtr;
-                    var tableSize = Marshal.SizeOf<IPHlpApi.MIB_TCPTABLE_OWNER_PID>();
+                    var tableSize = sizeof(IPHlpApi.MIB_TCPTABLE_OWNER_PID);
 
                     IPHlpApi.MIB_TCPROW_OWNER_PID* tcpRow = (IPHlpApi.MIB_TCPROW_OWNER_PID*)(tcpTablePtr + tableSize);
 

--- a/src/Kernel32/Kernel32+OSVERSIONINFOEX.cs
+++ b/src/Kernel32/Kernel32+OSVERSIONINFOEX.cs
@@ -82,14 +82,7 @@ namespace PInvoke
             /// the right pre-initialization for <see cref="dwOSVersionInfoSize"/>
             /// </summary>
             /// <returns>A newly initialzed instance of <see cref="OSVERSIONINFOEX"/></returns>
-            public static OSVERSIONINFOEX Create() => new OSVERSIONINFOEX
-            {
-#if NETSTANDARD2_0_ORLATER || NETFX_CORE
-                dwOSVersionInfoSize = Marshal.SizeOf<OSVERSIONINFOEX>()
-#else
-                dwOSVersionInfoSize = Marshal.SizeOf(typeof(OSVERSIONINFOEX))
-#endif
-            };
+            public static OSVERSIONINFOEX Create() => new OSVERSIONINFOEX { dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX) };
         }
     }
 }

--- a/src/Kernel32/Kernel32+SECURITY_ATTRIBUTES.cs
+++ b/src/Kernel32/Kernel32+SECURITY_ATTRIBUTES.cs
@@ -44,17 +44,7 @@ namespace PInvoke
             /// Initializes a new instance of the <see cref="SECURITY_ATTRIBUTES"/> struct.
             /// </summary>
             /// <returns>A new instance of <see cref="SECURITY_ATTRIBUTES"/>.</returns>
-            public static SECURITY_ATTRIBUTES Create()
-            {
-                return new SECURITY_ATTRIBUTES
-                {
-#if NETSTANDARD2_0_ORLATER || NETFX_CORE
-                    nLength = Marshal.SizeOf<SECURITY_ATTRIBUTES>(),
-#else
-                    nLength = Marshal.SizeOf(typeof(SECURITY_ATTRIBUTES)),
-#endif
-                };
-            }
+            public static unsafe SECURITY_ATTRIBUTES Create() => new SECURITY_ATTRIBUTES { nLength = sizeof(SECURITY_ATTRIBUTES) };
         }
     }
 }

--- a/src/Kernel32/Kernel32.cs
+++ b/src/Kernel32/Kernel32.cs
@@ -639,8 +639,9 @@ namespace PInvoke
         /// </summary>
         /// <param name="lpVersionInformation">
         /// A pointer to an OSVERSIONINFOEX structure containing the operating system version requirements to compare. The <paramref name="dwTypeMask"/>
-        /// parameter indicates the members of this structure that contain information to compare.You must set the
-        /// <see cref="OSVERSIONINFOEX.dwOSVersionInfoSize"/> member of this structure to <code>Marshal.SizeOf(typeof(OSVERSIONINFOEX))</code>. You must
+        /// parameter indicates the members of this structure that contain information to compare. You must set the
+        /// <see cref="OSVERSIONINFOEX.dwOSVersionInfoSize"/> member of this structure to <code>Marshal.SizeOf(typeof(OSVERSIONINFOEX))</code>
+        /// or create it with <see cref="OSVERSIONINFOEX.Create"/>. You must
         /// also specify valid data for the members indicated by <paramref name="dwTypeMask"/>. The function ignores structure members for which the
         /// corresponding <paramref name="dwTypeMask"/> bit is not set
         /// </param>

--- a/src/Kernel32/storebanned/Kernel32+MODULEENTRY32.cs
+++ b/src/Kernel32/storebanned/Kernel32+MODULEENTRY32.cs
@@ -111,11 +111,7 @@ namespace PInvoke
             {
                 return new MODULEENTRY32
                 {
-#if NETSTANDARD2_0_ORLATER
-                    dwSize = Marshal.SizeOf<MODULEENTRY32>(),
-#else
-                    dwSize = Marshal.SizeOf(typeof(MODULEENTRY32)),
-#endif
+                    dwSize = sizeof(MODULEENTRY32),
                     th32ModuleID = 1,
                 };
             }

--- a/src/Kernel32/storebanned/Kernel32+PROCESSENTRY32.cs
+++ b/src/Kernel32/storebanned/Kernel32+PROCESSENTRY32.cs
@@ -104,17 +104,7 @@ namespace PInvoke
             /// with <see cref="dwSize" /> set to the correct value.
             /// </summary>
             /// <returns>An instance of <see cref="PROCESSENTRY32"/>.</returns>
-            public static PROCESSENTRY32 Create()
-            {
-                return new PROCESSENTRY32
-                {
-#if NETSTANDARD2_0_ORLATER
-                    dwSize = Marshal.SizeOf<PROCESSENTRY32>(),
-#else
-                    dwSize = Marshal.SizeOf(typeof(PROCESSENTRY32)),
-#endif
-                };
-            }
+            public static PROCESSENTRY32 Create() => new PROCESSENTRY32 { dwSize = sizeof(PROCESSENTRY32) };
         }
     }
 }

--- a/src/Kernel32/storebanned/Kernel32+StartupInfo.cs
+++ b/src/Kernel32/storebanned/Kernel32+StartupInfo.cs
@@ -134,17 +134,7 @@ namespace PInvoke
             /// Initializes a new instance of the <see cref="STARTUPINFO"/> struct.
             /// </summary>
             /// <returns>An initialized instance of the struct.</returns>
-            public static STARTUPINFO Create()
-            {
-                return new STARTUPINFO
-                {
-#if NETSTANDARD2_0_ORLATER
-                    cb = Marshal.SizeOf<STARTUPINFO>(),
-#else
-                    cb = Marshal.SizeOf(typeof(STARTUPINFO)),
-#endif
-                };
-            }
+            public static STARTUPINFO Create() => new STARTUPINFO { cb = sizeof(STARTUPINFO) };
         }
     }
 }

--- a/src/Magnification.Tests/MagnificationFacts.cs
+++ b/src/Magnification.Tests/MagnificationFacts.cs
@@ -17,9 +17,12 @@ public class MagnificationFacts
     }
 
     [Fact]
-    public void MAGCOLOREFFECT_IsRightSize()
+    public unsafe void MAGCOLOREFFECT_IsRightSize()
     {
         Assert.Equal(sizeof(float) * 5 * 5, Marshal.SizeOf<MAGCOLOREFFECT>());
+#pragma warning disable xUnit2000 // Constants and literals should be the expected argument
+        Assert.Equal(sizeof(float) * 5 * 5, sizeof(MAGCOLOREFFECT));
+#pragma warning restore xUnit2000 // Constants and literals should be the expected argument
     }
 
     [Fact]
@@ -43,9 +46,12 @@ public class MagnificationFacts
     }
 
     [Fact]
-    public void MAGTRANSFORM_IsRightSize()
+    public unsafe void MAGTRANSFORM_IsRightSize()
     {
         Assert.Equal(sizeof(float) * 3 * 3, Marshal.SizeOf<MAGTRANSFORM>());
+#pragma warning disable xUnit2000 // Constants and literals should be the expected argument
+        Assert.Equal(sizeof(float) * 3 * 3, sizeof(MAGTRANSFORM));
+#pragma warning restore xUnit2000 // Constants and literals should be the expected argument
     }
 
     [Fact]

--- a/src/NCrypt/NCrypt+NCRYPT_KEY_BLOB_HEADER.cs
+++ b/src/NCrypt/NCrypt+NCRYPT_KEY_BLOB_HEADER.cs
@@ -52,17 +52,7 @@ namespace PInvoke
             /// with the <see cref="cbSize"/> field set appropriately.
             /// </summary>
             /// <returns>An initialized instance of the struct.</returns>
-            public static NCRYPT_KEY_BLOB_HEADER Create()
-            {
-                return new NCRYPT_KEY_BLOB_HEADER
-                {
-#if NETSTANDARD2_0_ORLATER || NETFX_CORE
-                    cbSize = Marshal.SizeOf<NCRYPT_KEY_BLOB_HEADER>(),
-#else
-                    cbSize = Marshal.SizeOf(typeof(NCRYPT_KEY_BLOB_HEADER)),
-#endif
-                };
-            }
+            public static unsafe NCRYPT_KEY_BLOB_HEADER Create() => new NCRYPT_KEY_BLOB_HEADER { cbSize = sizeof(NCRYPT_KEY_BLOB_HEADER) };
         }
     }
 }

--- a/src/NTDll/NTDll+OBJECT_ATTRIBUTES.cs
+++ b/src/NTDll/NTDll+OBJECT_ATTRIBUTES.cs
@@ -108,13 +108,7 @@ namespace PInvoke
             /// Initializes a new instance of the <see cref="OBJECT_ATTRIBUTES"/> structure.
             /// </summary>
             /// <returns>An <see cref="OBJECT_ATTRIBUTES"/> instance with <see cref="Length"/> initialized.</returns>
-            public static OBJECT_ATTRIBUTES Create()
-            {
-                return new OBJECT_ATTRIBUTES
-                {
-                    Length = Marshal.SizeOf(typeof(OBJECT_ATTRIBUTES)),
-                };
-            }
+            public static OBJECT_ATTRIBUTES Create() => new OBJECT_ATTRIBUTES { Length = sizeof(OBJECT_ATTRIBUTES) };
         }
     }
 }

--- a/src/SetupApi/SetupApi+SP_DEVICE_INTERFACE_DATA.cs
+++ b/src/SetupApi/SetupApi+SP_DEVICE_INTERFACE_DATA.cs
@@ -4,6 +4,7 @@
 namespace PInvoke
 {
     using System;
+    using System.Runtime.CompilerServices;
     using System.Runtime.InteropServices;
 
     /// <content>
@@ -43,12 +44,7 @@ namespace PInvoke
             /// Create an instance with <see cref="Size" /> set to the correct value.
             /// </summary>
             /// <returns>An instance of <see cref="SP_DEVICE_INTERFACE_DATA" /> with it's <see cref="Size" /> member set.</returns>
-            public static SP_DEVICE_INTERFACE_DATA Create()
-            {
-                var result = default(SP_DEVICE_INTERFACE_DATA);
-                result.Size = Marshal.SizeOf(result);
-                return result;
-            }
+            public static unsafe SP_DEVICE_INTERFACE_DATA Create() => new SP_DEVICE_INTERFACE_DATA { Size = sizeof(SP_DEVICE_INTERFACE_DATA) };
         }
     }
 }

--- a/src/SetupApi/SetupApi+SP_DEVINFO_DATA.cs
+++ b/src/SetupApi/SetupApi+SP_DEVINFO_DATA.cs
@@ -53,13 +53,7 @@ namespace PInvoke
             /// with <see cref="cbSize" /> set to the correct value.
             /// </summary>
             /// <returns>An instance of <see cref="SP_DEVINFO_DATA"/>.</returns>
-            public static SP_DEVINFO_DATA Create()
-            {
-                return new SP_DEVINFO_DATA
-                {
-                    cbSize = Marshal.SizeOf(typeof(SP_DEVINFO_DATA)),
-                };
-            }
+            public static unsafe SP_DEVINFO_DATA Create() => new SP_DEVINFO_DATA { cbSize = sizeof(SP_DEVINFO_DATA) };
         }
     }
 }

--- a/src/SetupApi/SetupApi+SP_DEVINSTALL_PARAMS.cs
+++ b/src/SetupApi/SetupApi+SP_DEVINSTALL_PARAMS.cs
@@ -101,13 +101,7 @@ namespace PInvoke
             /// with <see cref="cbSize" /> set to the correct value.
             /// </summary>
             /// <returns>An instance of <see cref="SP_DEVINSTALL_PARAMS"/>.</returns>
-            public static SP_DEVINSTALL_PARAMS Create()
-            {
-                return new SP_DEVINSTALL_PARAMS
-                {
-                    cbSize = Marshal.SizeOf(typeof(SP_DEVINSTALL_PARAMS)),
-                };
-            }
+            public static SP_DEVINSTALL_PARAMS Create() => new SP_DEVINSTALL_PARAMS { cbSize = sizeof(SP_DEVINSTALL_PARAMS) };
         }
     }
 }

--- a/src/SetupApi/SetupApi+SP_DRVINFO_DATA.cs
+++ b/src/SetupApi/SetupApi+SP_DRVINFO_DATA.cs
@@ -69,7 +69,7 @@ namespace PInvoke
             /// with <see cref="cbSize" /> set to the correct value.
             /// </summary>
             /// <returns>An instance of <see cref="SP_DRVINFO_DATA"/>.</returns>
-            public static SP_DRVINFO_DATA Create() => new SP_DRVINFO_DATA { cbSize = Marshal.SizeOf(typeof(SP_DRVINFO_DATA)) };
+            public static SP_DRVINFO_DATA Create() => new SP_DRVINFO_DATA { cbSize = sizeof(SP_DRVINFO_DATA) };
         }
     }
 }

--- a/src/User32.Tests/User32Facts.cs
+++ b/src/User32.Tests/User32Facts.cs
@@ -150,7 +150,7 @@ public partial class User32Facts
     }
 
     [Fact]
-    public void MENUBARINFO_MarshalSizeAsExpected()
+    public unsafe void MENUBARINFO_MarshalSizeAsExpected()
     {
         MENUBARINFO info = default;
         int expectedSize = IntPtr.Size == 4 ? 0x20 : 0x30;

--- a/src/User32/PublicAPI.Unshipped.txt
+++ b/src/User32/PublicAPI.Unshipped.txt
@@ -102,7 +102,6 @@ PInvoke.User32.MENUBARINFO.hMenu -> System.IntPtr
 PInvoke.User32.MENUBARINFO.hwndMenu -> System.IntPtr
 PInvoke.User32.MENUBARINFO.rcBar -> PInvoke.RECT
 PInvoke.User32.MENUINFO
-PInvoke.User32.MENUINFO.Create() -> PInvoke.User32.MENUINFO
 PInvoke.User32.MENUINFO.MENUINFO() -> void
 PInvoke.User32.MENUINFO.cbSize -> int
 PInvoke.User32.MENUINFO.cyMax -> uint
@@ -215,6 +214,7 @@ static PInvoke.User32.LoadCursor(System.IntPtr hInstance, char[] lpCursorName) -
 static PInvoke.User32.LoadImage(System.IntPtr hInst, System.IntPtr name, PInvoke.User32.ImageType type, int cx, int cy, PInvoke.User32.LoadImageFlags fuLoad) -> System.IntPtr
 static PInvoke.User32.LoadImage(System.IntPtr hInst, char[] name, PInvoke.User32.ImageType type, int cx, int cy, PInvoke.User32.LoadImageFlags fuLoad) -> System.IntPtr
 static PInvoke.User32.MENUBARINFO.Create() -> PInvoke.User32.MENUBARINFO
+static PInvoke.User32.MENUINFO.Create() -> PInvoke.User32.MENUINFO
 static PInvoke.User32.MsgWaitForMultipleObjectsEx(uint nCount, System.IntPtr pHandles, uint dwMilliseconds, PInvoke.User32.WakeMask dwWakeMask, PInvoke.User32.MsgWaitForMultipleObjectsExFlags dwFlags) -> uint
 static PInvoke.User32.MsgWaitForMultipleObjectsEx(uint nCount, System.IntPtr[] pHandles, uint dwMilliseconds, PInvoke.User32.WakeMask dwWakeMask, PInvoke.User32.MsgWaitForMultipleObjectsExFlags dwFlags) -> uint
 static PInvoke.User32.SetMenuItemInfo(System.IntPtr hMenu, uint uItem, bool fByPosition, PInvoke.User32.MENUITEMINFO lpmii) -> bool

--- a/src/User32/USer32+HELPINFO.cs
+++ b/src/User32/USer32+HELPINFO.cs
@@ -20,7 +20,7 @@ namespace PInvoke
             public uint dwContextId;
             public POINT MousePos;
 
-            public static HELPINFO Create() => new HELPINFO { cbSize = Marshal.SizeOf(typeof(HELPINFO)) };
+            public static unsafe HELPINFO Create() => new HELPINFO { cbSize = sizeof(HELPINFO) };
         }
     }
 }

--- a/src/User32/User32+CURSORINFO.cs
+++ b/src/User32/User32+CURSORINFO.cs
@@ -43,7 +43,7 @@ namespace PInvoke
             /// <returns>
             /// An instance of the structure.
             /// </returns>
-            public static CURSORINFO Create() => new CURSORINFO { cbSize = Marshal.SizeOf(typeof(CURSORINFO)) };
+            public static unsafe CURSORINFO Create() => new CURSORINFO { cbSize = sizeof(CURSORINFO) };
         }
     }
 }

--- a/src/User32/User32+DISPLAY_DEVICE.cs
+++ b/src/User32/User32+DISPLAY_DEVICE.cs
@@ -52,7 +52,7 @@ namespace PInvoke
             /// <returns>
             /// An instance of the structure.
             /// </returns>
-            public static DISPLAY_DEVICE Create() => new DISPLAY_DEVICE { cb = (uint)Marshal.SizeOf(typeof(DISPLAY_DEVICE)) };
+            public static DISPLAY_DEVICE Create() => new DISPLAY_DEVICE { cb = (uint)sizeof(DISPLAY_DEVICE) };
         }
     }
 }

--- a/src/User32/User32+FLASHWINFO.cs
+++ b/src/User32/User32+FLASHWINFO.cs
@@ -37,13 +37,7 @@ namespace PInvoke
             /// Create a new instance of <see cref="FLASHWINFO"/> with <see cref="cbSize"/> set to the correct value.
             /// </summary>
             /// <returns>A new instance of <see cref="FLASHWINFO"/> with <see cref="cbSize"/> set to the correct value.</returns>
-            public static FLASHWINFO Create()
-            {
-                return new FLASHWINFO
-                {
-                    cbSize = Marshal.SizeOf(typeof(FLASHWINFO))
-                };
-            }
+            public static unsafe FLASHWINFO Create() => new FLASHWINFO { cbSize = sizeof(FLASHWINFO) };
         }
     }
 }

--- a/src/User32/User32+MENUBARINFO.cs
+++ b/src/User32/User32+MENUBARINFO.cs
@@ -92,12 +92,7 @@ namespace PInvoke
             /// with the <see cref="cbSize"/> preset as required.
             /// </summary>
             /// <returns>The newly initialized instance.</returns>
-            public static MENUBARINFO Create()
-            {
-                var result = default(MENUBARINFO);
-                result.cbSize = Marshal.SizeOf(result);
-                return result;
-            }
+            public static unsafe MENUBARINFO Create() => new MENUBARINFO { cbSize = sizeof(MENUBARINFO) };
         }
     }
 }

--- a/src/User32/User32+MENUINFO.cs
+++ b/src/User32/User32+MENUINFO.cs
@@ -49,7 +49,7 @@ namespace PInvoke
             /// Create a new instance of <see cref="MENUINFO"/> with <see cref="cbSize"/> set to the correct value.
             /// </summary>
             /// <returns>A new instance of <see cref="MENUINFO"/> with <see cref="cbSize"/> set to the correct value.</returns>
-            public MENUINFO Create() => new MENUINFO { cbSize = Marshal.SizeOf(typeof(MENUINFO)) };
+            public static unsafe MENUINFO Create() => new MENUINFO { cbSize = sizeof(MENUINFO) };
         }
     }
 }

--- a/src/User32/User32+MENUITEMINFO.cs
+++ b/src/User32/User32+MENUITEMINFO.cs
@@ -150,13 +150,7 @@ namespace PInvoke
             /// Create a new instance of <see cref="MENUITEMINFO"/> with <see cref="cbSize"/> set to the correct value.
             /// </summary>
             /// <returns>A new instance of <see cref="MENUITEMINFO"/> with <see cref="cbSize"/> set to the correct value.</returns>
-            public static MENUITEMINFO Create()
-            {
-                return new MENUITEMINFO
-                {
-                    cbSize = Marshal.SizeOf(typeof(MENUITEMINFO))
-                };
-            }
+            public static MENUITEMINFO Create() => new MENUITEMINFO { cbSize = sizeof(MENUITEMINFO) };
         }
     }
 }

--- a/src/User32/User32+MONITORINFOEX.cs
+++ b/src/User32/User32+MONITORINFOEX.cs
@@ -54,13 +54,7 @@ namespace PInvoke
             /// </summary>
             public fixed char DeviceName[CCHDEVICENAME];
 
-            public static MONITORINFOEX Create()
-            {
-                var monitorIfo = default(MONITORINFOEX);
-                monitorIfo.cbSize = Marshal.SizeOf(typeof(MONITORINFOEX));
-
-                return monitorIfo;
-            }
+            public static MONITORINFOEX Create() => new MONITORINFOEX { cbSize = sizeof(MONITORINFOEX) };
         }
     }
 }

--- a/src/User32/User32+MSGBOXPARAMS.cs
+++ b/src/User32/User32+MSGBOXPARAMS.cs
@@ -27,12 +27,7 @@ namespace PInvoke
 
             public uint dwLanguageId;
 
-            public static MSGBOXPARAMS Create()
-            {
-                var nw = default(MSGBOXPARAMS);
-                nw.cbSize = Marshal.SizeOf(typeof(MSGBOXPARAMS));
-                return nw;
-            }
+            public static MSGBOXPARAMS Create() => new MSGBOXPARAMS { cbSize = Marshal.SizeOf(typeof(MSGBOXPARAMS)) };
         }
     }
 }

--- a/src/User32/User32+WINDOWINFO.cs
+++ b/src/User32/User32+WINDOWINFO.cs
@@ -23,12 +23,7 @@ namespace PInvoke
             public ushort atomWindowType;
             public ushort wCreatorVersion;
 
-            public static WINDOWINFO Create()
-            {
-                var nw = default(WINDOWINFO);
-                nw.cbSize = (uint)Marshal.SizeOf(typeof(WINDOWINFO));
-                return nw;
-            }
+            public static unsafe WINDOWINFO Create() => new WINDOWINFO { cbSize = (uint)sizeof(WINDOWINFO) };
         }
     }
 }

--- a/src/User32/User32+WINDOWPLACEMENT.cs
+++ b/src/User32/User32+WINDOWPLACEMENT.cs
@@ -41,13 +41,7 @@ namespace PInvoke
             /// Create a new instance of <see cref="WINDOWPLACEMENT"/> with <see cref="length"/> set to the correct value.
             /// </summary>
             /// <returns>A new instance of <see cref="WINDOWPLACEMENT"/> with <see cref="length"/> set to the correct value.</returns>
-            public static WINDOWPLACEMENT Create()
-            {
-                return new WINDOWPLACEMENT
-                {
-                    length = Marshal.SizeOf(typeof(WINDOWPLACEMENT))
-                };
-            }
+            public static unsafe WINDOWPLACEMENT Create() => new WINDOWPLACEMENT { length = sizeof(WINDOWPLACEMENT) };
         }
     }
 }

--- a/src/Windows.Core.Tests/HResultFacts.cs
+++ b/src/Windows.Core.Tests/HResultFacts.cs
@@ -9,11 +9,12 @@ using Xunit;
 public class HResultFacts
 {
     [Fact]
-    public void MarshaledSize()
+    public unsafe void MarshaledSize()
     {
         // It's imperative that the struct be exactly the size of an Int32
         // since we use it in interop.
         Assert.Equal(sizeof(int), Marshal.SizeOf(typeof(HResult)));
+        Assert.Equal(sizeof(int), sizeof(HResult));
     }
 
     [Fact]

--- a/src/Windows.Core.Tests/NTStatusFacts.cs
+++ b/src/Windows.Core.Tests/NTStatusFacts.cs
@@ -9,11 +9,12 @@ using Xunit;
 public class NTStatusFacts
 {
     [Fact]
-    public void MarshaledSize()
+    public unsafe void MarshaledSize()
     {
         // It's imperative that the struct be exactly the size of an Int32
         // since we use it in interop.
         Assert.Equal(sizeof(int), Marshal.SizeOf(typeof(NTSTATUS)));
+        Assert.Equal(sizeof(int), sizeof(NTSTATUS));
     }
 
     [Fact]


### PR DESCRIPTION
`sizeof(T)` is much faster than `Marshal.SizeOf<T>`, but it can only be safely used when `T` is a blittable type. This means all members are value types and have no `MarshalAs` attribute on them. This rule is recursive for all members.

Closes #475