### PR TITLE
Add RtlGetVersion(OSVERSIONINFOEX) overload

### DIFF
--- a/src/CodeGeneration/OfferFriendlyOverloadsGenerator.cs
+++ b/src/CodeGeneration/OfferFriendlyOverloadsGenerator.cs
@@ -71,6 +71,7 @@ namespace PInvoke
                 .WithMembers(SyntaxFactory.List<MemberDeclarationSyntax>());
             var methodsWithNativePointers =
                 from method in type.Members.OfType<MethodDeclarationSyntax>()
+                where !method.AttributeLists.SelectMany(al => al.Attributes).Any(att => att.Name is SimpleNameSyntax sn && sn.Identifier.ValueText == "NoFriendlyOverloads")
                 where WhereIsPointerParameter(method.ParameterList.Parameters).Any() || method.ReturnType is PointerTypeSyntax
                 select method;
 

--- a/src/CodeGenerationAttributes/NoFriendlyOverloadsAttribute.cs
+++ b/src/CodeGenerationAttributes/NoFriendlyOverloadsAttribute.cs
@@ -1,0 +1,17 @@
+﻿// Copyright © .NET Foundation and Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace PInvoke
+{
+    using System;
+    using System.Diagnostics;
+
+    /// <summary>
+    /// Decorated on a method to suppress automatic generation of friendly overloads.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
+    [Conditional("CodeGeneration")]
+    public sealed class NoFriendlyOverloadsAttribute : Attribute
+    {
+    }
+}

--- a/src/NTDll/NTDll.Helpers.cs
+++ b/src/NTDll/NTDll.Helpers.cs
@@ -9,9 +9,17 @@ namespace PInvoke
     /// </content>
     public static partial class NTDll
     {
-        // This is where you define methods that assist in calling P/Invoke methods.
-        // For example, if a P/Invoke method requires allocating unmanaged memory
-        // and freeing it up after the call, a helper method in this file would
-        // make "P/Invoking" for most callers much easier and is a welcome addition.
+        /// <inheritdoc cref="RtlGetVersion(Kernel32.OSVERSIONINFO*)"/>
+        [NoFriendlyOverloads]
+        public static unsafe NTSTATUS RtlGetVersion(Kernel32.OSVERSIONINFOEX* versionInformation) => RtlGetVersion((Kernel32.OSVERSIONINFO*)versionInformation);
+
+        /// <inheritdoc cref="RtlGetVersion(ref Kernel32.OSVERSIONINFO)"/>
+        public static unsafe NTSTATUS RtlGetVersion(ref Kernel32.OSVERSIONINFOEX versionInformation)
+        {
+            fixed (Kernel32.OSVERSIONINFOEX* versionInformationLocal = &versionInformation)
+            {
+                return RtlGetVersion(versionInformationLocal);
+            }
+        }
     }
 }

--- a/src/NTDll/NTDll.cs
+++ b/src/NTDll/NTDll.cs
@@ -107,7 +107,7 @@ namespace PInvoke
         /// The <see cref="RtlGetVersion(Kernel32.OSVERSIONINFO*)"/> routine returns version information about the currently running operating system.
         /// </summary>
         /// <param name="versionInformation">
-        /// A <see cref="Kernel32.OSVERSIONINFO"/> structure that contains the version information about the currently running operating system.
+        /// A pointer to an <see cref="Kernel32.OSVERSIONINFO"/> or <see cref="Kernel32.OSVERSIONINFOEX"/> structure that contains the version information about the currently running operating system.
         /// </param>
         /// <returns>
         /// <see cref="RtlGetVersion(Kernel32.OSVERSIONINFO*)"/> returns <see cref="NTSTATUS.Code.STATUS_SUCCESS"/>.

--- a/src/NTDll/PublicAPI.Unshipped.txt
+++ b/src/NTDll/PublicAPI.Unshipped.txt
@@ -13,8 +13,10 @@ PInvoke.NTDll.PROCESS_BASIC_INFORMATION.Reserved2a -> void*
 PInvoke.NTDll.PROCESS_BASIC_INFORMATION.Reserved2b -> void*
 PInvoke.NTDll.PROCESS_BASIC_INFORMATION.Reserved3 -> void*
 PInvoke.NTDll.PROCESS_BASIC_INFORMATION.UniqueProcessId -> void*
+static PInvoke.NTDll.NtQueryInformationProcess(PInvoke.Kernel32.SafeObjectHandle ProcessHandle, PInvoke.NTDll.PROCESSINFOCLASS ProcessInformationClass, System.IntPtr ProcessInformation, int ProcessInformationLength, out int ReturnLength) -> PInvoke.NTSTATUS
+static PInvoke.NTDll.RtlGetVersion(PInvoke.Kernel32.OSVERSIONINFOEX* versionInformation) -> PInvoke.NTSTATUS
+static PInvoke.NTDll.RtlGetVersion(System.IntPtr versionInformation) -> PInvoke.NTSTATUS
+static PInvoke.NTDll.RtlGetVersion(ref PInvoke.Kernel32.OSVERSIONINFO versionInformation) -> PInvoke.NTSTATUS
+static PInvoke.NTDll.RtlGetVersion(ref PInvoke.Kernel32.OSVERSIONINFOEX versionInformation) -> PInvoke.NTSTATUS
 static extern PInvoke.NTDll.NtQueryInformationProcess(PInvoke.Kernel32.SafeObjectHandle ProcessHandle, PInvoke.NTDll.PROCESSINFOCLASS ProcessInformationClass, void* ProcessInformation, int ProcessInformationLength, out int ReturnLength) -> PInvoke.NTSTATUS
 static extern PInvoke.NTDll.RtlGetVersion(PInvoke.Kernel32.OSVERSIONINFO* versionInformation) -> PInvoke.NTSTATUS
-static PInvoke.NTDll.NtQueryInformationProcess(PInvoke.Kernel32.SafeObjectHandle ProcessHandle, PInvoke.NTDll.PROCESSINFOCLASS ProcessInformationClass, System.IntPtr ProcessInformation, int ProcessInformationLength, out int ReturnLength) -> PInvoke.NTSTATUS
-static PInvoke.NTDll.RtlGetVersion(ref PInvoke.Kernel32.OSVERSIONINFO versionInformation) -> PInvoke.NTSTATUS
-static PInvoke.NTDll.RtlGetVersion(System.IntPtr versionInformation) -> PInvoke.NTSTATUS


### PR DESCRIPTION
This required a way to suppress friendly overload generation on a per-method basis.