### PR TITLE
Add EnumDisplaySettings

### DIFF
--- a/src/User32.Tests/User32Facts+EnumDisplaySettingsFacts.cs
+++ b/src/User32.Tests/User32Facts+EnumDisplaySettingsFacts.cs
@@ -21,4 +21,19 @@ public partial class User32Facts
         Assert.True(mode.dmPelsWidth > 0);
         Assert.True(mode.dmPelsHeight > 0);
     }
+
+    [Fact]
+    public void EnumDisplaySettingsEx_Test()
+    {
+        // Arrange
+        var mode = DEVMODE.Create();
+
+        // Act
+        var result = EnumDisplaySettingsEx(null, ENUM_CURRENT_SETTINGS, ref mode, EnumDisplaySettingsExFlags.EDS_RAWMODE);
+
+        // Assert
+        Assert.True(result);
+        Assert.True(mode.dmPelsWidth > 0);
+        Assert.True(mode.dmPelsHeight > 0);
+    }
 }

--- a/src/User32.Tests/User32Facts+EnumDisplaySettingsFacts.cs
+++ b/src/User32.Tests/User32Facts+EnumDisplaySettingsFacts.cs
@@ -1,0 +1,24 @@
+﻿// Copyright © .NET Foundation and Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using PInvoke;
+using Xunit;
+using static PInvoke.User32;
+
+public partial class User32Facts
+{
+    [Fact]
+    public void EnumDisplaySettings_Test()
+    {
+        // Arrange
+        var mode = DEVMODE.Create();
+
+        // Act
+        var result = EnumDisplaySettings(null, ENUM_CURRENT_SETTINGS, ref mode);
+
+        // Assert
+        Assert.True(result);
+        Assert.True(mode.dmPelsWidth > 0);
+        Assert.True(mode.dmPelsHeight > 0);
+    }
+}

--- a/src/User32/PublicAPI.Unshipped.txt
+++ b/src/User32/PublicAPI.Unshipped.txt
@@ -1,7 +1,18 @@
 PInvoke.User32.EnumDisplayDevicesFlags
 PInvoke.User32.EnumDisplayDevicesFlags.EDD_GET_DEVICE_INTERFACE_NAME = 1 -> PInvoke.User32.EnumDisplayDevicesFlags
+PInvoke.User32.EnumDisplaySettingsExFlags
+PInvoke.User32.EnumDisplaySettingsExFlags.EDS_RAWMODE = 2 -> PInvoke.User32.EnumDisplaySettingsExFlags
+PInvoke.User32.EnumDisplaySettingsExFlags.EDS_ROTATEDMODE = 4 -> PInvoke.User32.EnumDisplaySettingsExFlags
+const PInvoke.User32.ENUM_CURRENT_SETTINGS = 4294967295 -> uint
+const PInvoke.User32.ENUM_REGISTRY_SETTINGS = 4294967294 -> uint
 static PInvoke.User32.EnumDisplayDevices(string lpDevice, uint iDevNum, System.IntPtr lpDisplayDevice, PInvoke.User32.EnumDisplayDevicesFlags dwFlags) -> bool
 static PInvoke.User32.EnumDisplayDevices(string lpDevice, uint iDevNum, ref PInvoke.DISPLAY_DEVICE lpDisplayDevice, PInvoke.User32.EnumDisplayDevicesFlags dwFlags) -> bool
+static PInvoke.User32.EnumDisplaySettings(string lpszDeviceName, uint iModeNum, System.IntPtr lpDevMode) -> bool
+static PInvoke.User32.EnumDisplaySettings(string lpszDeviceName, uint iModeNum, ref PInvoke.DEVMODE lpDevMode) -> bool
+static PInvoke.User32.EnumDisplaySettingsEx(string lpszDeviceName, uint iModeNum, System.IntPtr lpDevMode, PInvoke.User32.EnumDisplaySettingsExFlags dwFlags) -> bool
+static PInvoke.User32.EnumDisplaySettingsEx(string lpszDeviceName, uint iModeNum, ref PInvoke.DEVMODE lpDevMode, PInvoke.User32.EnumDisplaySettingsExFlags dwFlags) -> bool
 static extern PInvoke.User32.EnumDisplayDevices(string lpDevice, uint iDevNum, PInvoke.DISPLAY_DEVICE* lpDisplayDevice, PInvoke.User32.EnumDisplayDevicesFlags dwFlags) -> bool
+static extern PInvoke.User32.EnumDisplaySettings(string lpszDeviceName, uint iModeNum, PInvoke.DEVMODE* lpDevMode) -> bool
+static extern PInvoke.User32.EnumDisplaySettingsEx(string lpszDeviceName, uint iModeNum, PInvoke.DEVMODE* lpDevMode, PInvoke.User32.EnumDisplaySettingsExFlags dwFlags) -> bool
 static extern PInvoke.User32.UnregisterClass(string lpClassName, System.IntPtr hInstance) -> bool
 static readonly PInvoke.User32.DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED -> System.IntPtr

--- a/src/User32/PublicAPI.Unshipped.txt
+++ b/src/User32/PublicAPI.Unshipped.txt
@@ -5,14 +5,14 @@ PInvoke.User32.EnumDisplaySettingsExFlags.EDS_RAWMODE = 2 -> PInvoke.User32.Enum
 PInvoke.User32.EnumDisplaySettingsExFlags.EDS_ROTATEDMODE = 4 -> PInvoke.User32.EnumDisplaySettingsExFlags
 const PInvoke.User32.ENUM_CURRENT_SETTINGS = 4294967295 -> uint
 const PInvoke.User32.ENUM_REGISTRY_SETTINGS = 4294967294 -> uint
-static PInvoke.User32.EnumDisplayDevices(string lpDevice, uint iDevNum, System.IntPtr lpDisplayDevice, PInvoke.User32.EnumDisplayDevicesFlags dwFlags) -> bool
-static PInvoke.User32.EnumDisplayDevices(string lpDevice, uint iDevNum, ref PInvoke.DISPLAY_DEVICE lpDisplayDevice, PInvoke.User32.EnumDisplayDevicesFlags dwFlags) -> bool
-static PInvoke.User32.EnumDisplaySettings(string lpszDeviceName, uint iModeNum, System.IntPtr lpDevMode) -> bool
-static PInvoke.User32.EnumDisplaySettings(string lpszDeviceName, uint iModeNum, ref PInvoke.DEVMODE lpDevMode) -> bool
-static PInvoke.User32.EnumDisplaySettingsEx(string lpszDeviceName, uint iModeNum, System.IntPtr lpDevMode, PInvoke.User32.EnumDisplaySettingsExFlags dwFlags) -> bool
-static PInvoke.User32.EnumDisplaySettingsEx(string lpszDeviceName, uint iModeNum, ref PInvoke.DEVMODE lpDevMode, PInvoke.User32.EnumDisplaySettingsExFlags dwFlags) -> bool
-static extern PInvoke.User32.EnumDisplayDevices(string lpDevice, uint iDevNum, PInvoke.DISPLAY_DEVICE* lpDisplayDevice, PInvoke.User32.EnumDisplayDevicesFlags dwFlags) -> bool
-static extern PInvoke.User32.EnumDisplaySettings(string lpszDeviceName, uint iModeNum, PInvoke.DEVMODE* lpDevMode) -> bool
-static extern PInvoke.User32.EnumDisplaySettingsEx(string lpszDeviceName, uint iModeNum, PInvoke.DEVMODE* lpDevMode, PInvoke.User32.EnumDisplaySettingsExFlags dwFlags) -> bool
+static PInvoke.User32.EnumDisplayDevices(System.IntPtr lpDevice, uint iDevNum, System.IntPtr lpDisplayDevice, PInvoke.User32.EnumDisplayDevicesFlags dwFlags) -> bool
+static PInvoke.User32.EnumDisplayDevices(char[] lpDevice, uint iDevNum, ref PInvoke.DISPLAY_DEVICE lpDisplayDevice, PInvoke.User32.EnumDisplayDevicesFlags dwFlags) -> bool
+static PInvoke.User32.EnumDisplaySettings(System.IntPtr lpszDeviceName, uint iModeNum, System.IntPtr lpDevMode) -> bool
+static PInvoke.User32.EnumDisplaySettings(char[] lpszDeviceName, uint iModeNum, ref PInvoke.DEVMODE lpDevMode) -> bool
+static PInvoke.User32.EnumDisplaySettingsEx(System.IntPtr lpszDeviceName, uint iModeNum, System.IntPtr lpDevMode, PInvoke.User32.EnumDisplaySettingsExFlags dwFlags) -> bool
+static PInvoke.User32.EnumDisplaySettingsEx(char[] lpszDeviceName, uint iModeNum, ref PInvoke.DEVMODE lpDevMode, PInvoke.User32.EnumDisplaySettingsExFlags dwFlags) -> bool
+static extern PInvoke.User32.EnumDisplayDevices(char* lpDevice, uint iDevNum, PInvoke.DISPLAY_DEVICE* lpDisplayDevice, PInvoke.User32.EnumDisplayDevicesFlags dwFlags) -> bool
+static extern PInvoke.User32.EnumDisplaySettings(char* lpszDeviceName, uint iModeNum, PInvoke.DEVMODE* lpDevMode) -> bool
+static extern PInvoke.User32.EnumDisplaySettingsEx(char* lpszDeviceName, uint iModeNum, PInvoke.DEVMODE* lpDevMode, PInvoke.User32.EnumDisplaySettingsExFlags dwFlags) -> bool
 static extern PInvoke.User32.UnregisterClass(string lpClassName, System.IntPtr hInstance) -> bool
 static readonly PInvoke.User32.DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED -> System.IntPtr

--- a/src/User32/User32+EnumDisplaySettingsExFlags.cs
+++ b/src/User32/User32+EnumDisplaySettingsExFlags.cs
@@ -1,0 +1,32 @@
+﻿// Copyright © .NET Foundation and Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace PInvoke
+{
+    using System;
+
+    /// <content>
+    /// Contains the <see cref="EnumDisplaySettingsExFlags"/> nested type.
+    /// </content>
+    public partial class User32
+    {
+        /// <summary>
+        /// Flags for <see cref="EnumDisplaySettingsEx(string, uint, ref DEVMODE, EnumDisplaySettingsExFlags)"/>.
+        /// </summary>
+        [Flags]
+        public enum EnumDisplaySettingsExFlags : uint
+        {
+            /// <summary>
+            /// If set, the function will return all graphics modes reported by the adapter driver, regardless of monitor capabilities.
+            /// Otherwise, it will only return modes that are compatible with current monitors.
+            /// </summary>
+            EDS_RAWMODE = 0x00000002,
+
+            /// <summary>
+            /// If set, the function will return graphics modes in all orientations.
+            /// Otherwise, it will only return modes that have the same orientation as the one currently set for the requested display.
+            /// </summary>
+            EDS_ROTATEDMODE = 0x00000004,
+        }
+    }
+}

--- a/src/User32/User32+EnumDisplaySettingsExFlags.cs
+++ b/src/User32/User32+EnumDisplaySettingsExFlags.cs
@@ -11,7 +11,7 @@ namespace PInvoke
     public partial class User32
     {
         /// <summary>
-        /// Flags for <see cref="EnumDisplaySettingsEx(string, uint, ref DEVMODE, EnumDisplaySettingsExFlags)"/>.
+        /// Flags for <see cref="EnumDisplaySettingsEx(char*, uint, DEVMODE*, EnumDisplaySettingsExFlags)"/>.
         /// </summary>
         [Flags]
         public enum EnumDisplaySettingsExFlags : uint

--- a/src/User32/User32.cs
+++ b/src/User32/User32.cs
@@ -1677,7 +1677,7 @@ namespace PInvoke
         /// </param>
         /// <param name="lpDisplayDevice">
         /// A pointer to a <see cref="DISPLAY_DEVICE"/> structure that receives information about the display device specified by <paramref name="iDevNum"/>.
-        /// Before calling <see cref="EnumDisplayDevices(string, uint, DISPLAY_DEVICE*, EnumDisplayDevicesFlags)"/>, you must initialize the member <see cref="DISPLAY_DEVICE.cb"/> to the size, in bytes, of <see cref="DISPLAY_DEVICE"/>.
+        /// Before calling <see cref="EnumDisplayDevices(char*, uint, DISPLAY_DEVICE*, EnumDisplayDevicesFlags)"/>, you must initialize the member <see cref="DISPLAY_DEVICE.cb"/> to the size, in bytes, of <see cref="DISPLAY_DEVICE"/>.
         /// </param>
         /// <param name="dwFlags">
         /// Set this flag to <see cref="EnumDisplayDevicesFlags.EDD_GET_DEVICE_INTERFACE_NAME"/> to retrieve the device interface name for <c>GUID_DEVINTERFACE_MONITOR</c>, which is registered by the operating system on a per monitor basis.
@@ -1695,7 +1695,7 @@ namespace PInvoke
         [DllImport(nameof(User32), SetLastError = true, CharSet = CharSet.Unicode)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern unsafe bool EnumDisplayDevices(
-            [MarshalAs(UnmanagedType.LPWStr)] string lpDevice,
+            [Friendly(FriendlyFlags.Array | FriendlyFlags.In)] char* lpDevice,
             uint iDevNum,
             [Friendly(FriendlyFlags.Bidirectional)] DISPLAY_DEVICE* lpDisplayDevice,
             EnumDisplayDevicesFlags dwFlags);
@@ -1705,7 +1705,7 @@ namespace PInvoke
         /// </summary>
         /// <param name="lpszDeviceName">
         /// A pointer to a null-terminated string that specifies the display device about whose graphics mode the function will obtain information.
-        /// This parameter is either <c>NULL</c> or a <see cref="DISPLAY_DEVICE.DeviceName"/> returned from <see cref="EnumDisplayDevices(string, uint, DISPLAY_DEVICE*, EnumDisplayDevicesFlags)"/>.
+        /// This parameter is either <c>NULL</c> or a <see cref="DISPLAY_DEVICE.DeviceName"/> returned from <see cref="EnumDisplayDevices(char*, uint, DISPLAY_DEVICE*, EnumDisplayDevicesFlags)"/>.
         /// A <c>NULL</c> value specifies the current display device on the computer on which the calling thread is running.
         /// </param>
         /// <param name="iModeNum">
@@ -1713,13 +1713,13 @@ namespace PInvoke
         /// <para><see cref="ENUM_CURRENT_SETTINGS"/>: Retrieve the current settings for the display device.</para>
         /// <para><see cref="ENUM_REGISTRY_SETTINGS"/>: Retrieve the settings for the display device that are currently stored in the registry.</para>
         /// <para>
-        /// Graphics mode indexes start at zero. To obtain information for all of a display device's graphics modes, make a series of calls to <see cref="EnumDisplaySettings(string, uint, DEVMODE*)"/>, as follows: Set <paramref name="iModeNum"/> to zero for the first call,
+        /// Graphics mode indexes start at zero. To obtain information for all of a display device's graphics modes, make a series of calls to <see cref="EnumDisplaySettings(char*, uint, DEVMODE*)"/>, as follows: Set <paramref name="iModeNum"/> to zero for the first call,
         /// and increment <paramref name="iModeNum"/> by one for each subsequent call.
         /// </para>
         /// <para>
         /// Continue calling the function until the return value is zero.<br/>
-        /// When you call <see cref="EnumDisplaySettings(string, uint, DEVMODE*)"/> with <paramref name="iModeNum"/> set to zero, the operating system initializes and caches information about the display device.<br/>
-        /// When you call <see cref="EnumDisplaySettings(string, uint, DEVMODE*)"/> with <paramref name="iModeNum"/> set to a nonzero value,
+        /// When you call <see cref="EnumDisplaySettings(char*, uint, DEVMODE*)"/> with <paramref name="iModeNum"/> set to zero, the operating system initializes and caches information about the display device.<br/>
+        /// When you call <see cref="EnumDisplaySettings(char*, uint, DEVMODE*)"/> with <paramref name="iModeNum"/> set to a nonzero value,
         /// the function returns the information that was cached the last time the function was called with iModeNum set to zero.
         /// </para>
         /// </param>
@@ -1734,7 +1734,7 @@ namespace PInvoke
         [DllImport(nameof(User32))]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern unsafe bool EnumDisplaySettings(
-            [MarshalAs(UnmanagedType.LPWStr)] string lpszDeviceName,
+            [Friendly(FriendlyFlags.Array | FriendlyFlags.In)] char* lpszDeviceName,
             uint iModeNum,
             [Friendly(FriendlyFlags.Bidirectional)]DEVMODE* lpDevMode);
 
@@ -1743,7 +1743,7 @@ namespace PInvoke
         /// </summary>
         /// <param name="lpszDeviceName">
         /// A pointer to a null-terminated string that specifies the display device about whose graphics mode the function will obtain information.
-        /// This parameter is either <c>NULL</c> or a <see cref="DISPLAY_DEVICE.DeviceName"/> returned from <see cref="EnumDisplayDevices(string, uint, DISPLAY_DEVICE*, EnumDisplayDevicesFlags)"/>.
+        /// This parameter is either <c>NULL</c> or a <see cref="DISPLAY_DEVICE.DeviceName"/> returned from <see cref="EnumDisplayDevices(char*, uint, DISPLAY_DEVICE*, EnumDisplayDevicesFlags)"/>.
         /// A <c>NULL</c> value specifies the current display device on the computer on which the calling thread is running.
         /// </param>
         /// <param name="iModeNum">
@@ -1751,13 +1751,13 @@ namespace PInvoke
         /// <para><see cref="ENUM_CURRENT_SETTINGS"/>: Retrieve the current settings for the display device.</para>
         /// <para><see cref="ENUM_REGISTRY_SETTINGS"/>: Retrieve the settings for the display device that are currently stored in the registry.</para>
         /// <para>
-        /// Graphics mode indexes start at zero. To obtain information for all of a display device's graphics modes, make a series of calls to <see cref="EnumDisplaySettingsEx(string, uint, DEVMODE*, EnumDisplaySettingsExFlags)"/>, as follows: Set <paramref name="iModeNum"/> to zero for the first call,
+        /// Graphics mode indexes start at zero. To obtain information for all of a display device's graphics modes, make a series of calls to <see cref="EnumDisplaySettingsEx(char*, uint, DEVMODE*, EnumDisplaySettingsExFlags)"/>, as follows: Set <paramref name="iModeNum"/> to zero for the first call,
         /// and increment <paramref name="iModeNum"/> by one for each subsequent call.
         /// </para>
         /// <para>
         /// Continue calling the function until the return value is zero.<br/>
-        /// When you call <see cref="EnumDisplaySettingsEx(string, uint, DEVMODE*, EnumDisplaySettingsExFlags)"/> with <paramref name="iModeNum"/> set to zero, the operating system initializes and caches information about the display device.<br/>
-        /// When you call <see cref="EnumDisplaySettingsEx(string, uint, DEVMODE*, EnumDisplaySettingsExFlags)"/> with <paramref name="iModeNum"/> set to a nonzero value,
+        /// When you call <see cref="EnumDisplaySettingsEx(char*, uint, DEVMODE*, EnumDisplaySettingsExFlags)"/> with <paramref name="iModeNum"/> set to zero, the operating system initializes and caches information about the display device.<br/>
+        /// When you call <see cref="EnumDisplaySettingsEx(char*, uint, DEVMODE*, EnumDisplaySettingsExFlags)"/> with <paramref name="iModeNum"/> set to a nonzero value,
         /// the function returns the information that was cached the last time the function was called with iModeNum set to zero.
         /// </para>
         /// </param>
@@ -1772,10 +1772,10 @@ namespace PInvoke
         /// As noted in the description of the <paramref name="iModeNum"/> parameter, you can use this behavior to enumerate all of a display device's graphics modes.
         /// </remarks>
         /// <returns>If the function succeeds, the return value is nonzero. If the function fails, the return value is zero.</returns>
-        [DllImport(nameof(User32), EntryPoint = "EnumDisplaySettingsExW")]
+        [DllImport(nameof(User32))]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern unsafe bool EnumDisplaySettingsEx(
-            [MarshalAs(UnmanagedType.LPWStr)] string lpszDeviceName,
+            [Friendly(FriendlyFlags.Array | FriendlyFlags.In)] char* lpszDeviceName,
             uint iModeNum,
             [Friendly(FriendlyFlags.Bidirectional)] DEVMODE* lpDevMode,
             EnumDisplaySettingsExFlags dwFlags);

--- a/src/User32/User32.cs
+++ b/src/User32/User32.cs
@@ -62,6 +62,10 @@ namespace PInvoke
 
         public const uint WAIT_FAILED = 0xFFFFFFFF;
 
+        public const uint ENUM_CURRENT_SETTINGS = unchecked((uint)-1);
+
+        public const uint ENUM_REGISTRY_SETTINGS = unchecked((uint)-2);
+
         /// <summary>
         ///     A bitmap that is drawn by the window that owns the menu. The application must process the WM_MEASUREITEM and
         ///     WM_DRAWITEM messages.
@@ -1688,13 +1692,93 @@ namespace PInvoke
         /// <remarks>
         /// See https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-enumdisplaydevicesa#remarks.
         /// </remarks>
-        [DllImport(nameof(User32), SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "EnumDisplayDevicesW")]
+        [DllImport(nameof(User32), SetLastError = true, CharSet = CharSet.Unicode)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern unsafe bool EnumDisplayDevices(
             [MarshalAs(UnmanagedType.LPWStr)] string lpDevice,
             uint iDevNum,
             [Friendly(FriendlyFlags.Bidirectional)] DISPLAY_DEVICE* lpDisplayDevice,
             EnumDisplayDevicesFlags dwFlags);
+
+        /// <summary>
+        /// Retrieves information about one of the graphics modes for a display device. To retrieve information for all the graphics modes of a display device, make a series of calls to this function.
+        /// </summary>
+        /// <param name="lpszDeviceName">
+        /// A pointer to a null-terminated string that specifies the display device about whose graphics mode the function will obtain information.
+        /// This parameter is either <c>NULL</c> or a <see cref="DISPLAY_DEVICE.DeviceName"/> returned from <see cref="EnumDisplayDevices(string, uint, DISPLAY_DEVICE*, EnumDisplayDevicesFlags)"/>.
+        /// A <c>NULL</c> value specifies the current display device on the computer on which the calling thread is running.
+        /// </param>
+        /// <param name="iModeNum">
+        /// <para>The type of information to be retrieved. This value can be a graphics mode index or one of the following values.</para>
+        /// <para><see cref="ENUM_CURRENT_SETTINGS"/>: Retrieve the current settings for the display device.</para>
+        /// <para><see cref="ENUM_REGISTRY_SETTINGS"/>: Retrieve the settings for the display device that are currently stored in the registry.</para>
+        /// <para>
+        /// Graphics mode indexes start at zero. To obtain information for all of a display device's graphics modes, make a series of calls to <see cref="EnumDisplaySettings(string, uint, DEVMODE*)"/>, as follows: Set <paramref name="iModeNum"/> to zero for the first call,
+        /// and increment <paramref name="iModeNum"/> by one for each subsequent call.
+        /// </para>
+        /// <para>
+        /// Continue calling the function until the return value is zero.<br/>
+        /// When you call <see cref="EnumDisplaySettings(string, uint, DEVMODE*)"/> with <paramref name="iModeNum"/> set to zero, the operating system initializes and caches information about the display device.<br/>
+        /// When you call <see cref="EnumDisplaySettings(string, uint, DEVMODE*)"/> with <paramref name="iModeNum"/> set to a nonzero value,
+        /// the function returns the information that was cached the last time the function was called with iModeNum set to zero.
+        /// </para>
+        /// </param>
+        /// <param name="lpDevMode">
+        /// A pointer to a <see cref="DEVMODE"/> structure into which the function stores information about the specified graphics mode.
+        /// </param>
+        /// <remarks>
+        /// The function fails if <paramref name="iModeNum"/> is greater than the index of the display device's last graphics mode.
+        /// As noted in the description of the <paramref name="iModeNum"/> parameter, you can use this behavior to enumerate all of a display device's graphics modes.
+        /// </remarks>
+        /// <returns>If the function succeeds, the return value is nonzero. If the function fails, the return value is zero.</returns>
+        [DllImport(nameof(User32))]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern unsafe bool EnumDisplaySettings(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpszDeviceName,
+            uint iModeNum,
+            [Friendly(FriendlyFlags.Bidirectional)]DEVMODE* lpDevMode);
+
+        /// <summary>
+        /// Retrieves information about one of the graphics modes for a display device. To retrieve information for all the graphics modes of a display device, make a series of calls to this function.
+        /// </summary>
+        /// <param name="lpszDeviceName">
+        /// A pointer to a null-terminated string that specifies the display device about whose graphics mode the function will obtain information.
+        /// This parameter is either <c>NULL</c> or a <see cref="DISPLAY_DEVICE.DeviceName"/> returned from <see cref="EnumDisplayDevices(string, uint, DISPLAY_DEVICE*, EnumDisplayDevicesFlags)"/>.
+        /// A <c>NULL</c> value specifies the current display device on the computer on which the calling thread is running.
+        /// </param>
+        /// <param name="iModeNum">
+        /// <para>The type of information to be retrieved. This value can be a graphics mode index or one of the following values.</para>
+        /// <para><see cref="ENUM_CURRENT_SETTINGS"/>: Retrieve the current settings for the display device.</para>
+        /// <para><see cref="ENUM_REGISTRY_SETTINGS"/>: Retrieve the settings for the display device that are currently stored in the registry.</para>
+        /// <para>
+        /// Graphics mode indexes start at zero. To obtain information for all of a display device's graphics modes, make a series of calls to <see cref="EnumDisplaySettingsEx(string, uint, DEVMODE*, EnumDisplaySettingsExFlags)"/>, as follows: Set <paramref name="iModeNum"/> to zero for the first call,
+        /// and increment <paramref name="iModeNum"/> by one for each subsequent call.
+        /// </para>
+        /// <para>
+        /// Continue calling the function until the return value is zero.<br/>
+        /// When you call <see cref="EnumDisplaySettingsEx(string, uint, DEVMODE*, EnumDisplaySettingsExFlags)"/> with <paramref name="iModeNum"/> set to zero, the operating system initializes and caches information about the display device.<br/>
+        /// When you call <see cref="EnumDisplaySettingsEx(string, uint, DEVMODE*, EnumDisplaySettingsExFlags)"/> with <paramref name="iModeNum"/> set to a nonzero value,
+        /// the function returns the information that was cached the last time the function was called with iModeNum set to zero.
+        /// </para>
+        /// </param>
+        /// <param name="lpDevMode">
+        /// A pointer to a <see cref="DEVMODE"/> structure into which the function stores information about the specified graphics mode.
+        /// </param>
+        /// <param name="dwFlags">
+        /// See documentation on the fields of <see cref="EnumDisplaySettingsExFlags"/>.
+        /// </param>
+        /// <remarks>
+        /// The function fails if <paramref name="iModeNum"/> is greater than the index of the display device's last graphics mode.
+        /// As noted in the description of the <paramref name="iModeNum"/> parameter, you can use this behavior to enumerate all of a display device's graphics modes.
+        /// </remarks>
+        /// <returns>If the function succeeds, the return value is nonzero. If the function fails, the return value is zero.</returns>
+        [DllImport(nameof(User32), EntryPoint = "EnumDisplaySettingsExW")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern unsafe bool EnumDisplaySettingsEx(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpszDeviceName,
+            uint iModeNum,
+            [Friendly(FriendlyFlags.Bidirectional)] DEVMODE* lpDevMode,
+            EnumDisplaySettingsExFlags dwFlags);
 
         [DllImport(nameof(User32), SetLastError = true, CharSet = CharSet.Unicode)]
         [return: MarshalAs(UnmanagedType.Bool)]

--- a/src/Windows.Core/DEVMODE.cs
+++ b/src/Windows.Core/DEVMODE.cs
@@ -1,0 +1,1356 @@
+﻿// Copyright © .NET Foundation and Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace PInvoke
+{
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Runtime.InteropServices;
+
+    /// <summary>
+    /// Contains information about the initialization and environment of a printer or a display device.
+    /// </summary>
+    [StructLayout(LayoutKind.Explicit)]
+    public unsafe struct DEVMODE
+    {
+        public const int CCHDEVICENAME = 32;
+        public const int CCHFORMNAME = 32;
+
+        /// <summary>
+        /// A zero-terminated character array that specifies the "friendly" name of the printer or display; for example, "PCL/HP LaserJet" in the case of PCL/HP LaserJet.
+        /// This string is unique among device drivers. Note that this name may be truncated to fit in the <see cref="dmDeviceName"/> array.
+        /// </summary>
+        [FieldOffset(0)]
+        public fixed char dmDeviceName[CCHDEVICENAME];
+
+        /// <summary>
+        /// The version number of the initialization data specification on which the structure is based.
+        /// To ensure the correct version is used for any operating system, use <c>DM_SPECVERSION</c>.
+        /// </summary>
+        [FieldOffset(64)]
+        public ushort dmSpecVersion;
+
+        /// <summary>
+        /// The driver version number assigned by the driver developer.
+        /// </summary>
+        [FieldOffset(66)]
+        public ushort dmDriverVersion;
+
+        /// <summary>
+        /// Specifies the size, in bytes, of the <see cref="DEVMODE"/> structure, not including any private driver-specific data that might follow the structure's public members
+        /// Set this member to size of <see cref="DEVMODE"/> to indicate the version of the <see cref="DEVMODE"/> structure being used.
+        /// </summary>
+        [FieldOffset(68)]
+        public ushort dmSize;
+
+        /// <summary>
+        /// Contains the number of bytes of private driver-data that follow this structure.
+        /// If a device driver does not use device-specific information, set this member to zero.
+        /// </summary>
+        [FieldOffset(70)]
+        public ushort dmDriverExtra;
+
+        /// <summary>
+        /// Specifies whether certain members of the <see cref="DEVMODE"/> structure have been initialized.
+        /// If a member is initialized, its corresponding bit is set, otherwise the bit is clear. A driver supports only those <see cref="DEVMODE"/> members that are appropriate for the printer or display technology.
+        /// </summary>
+        [FieldOffset(72)]
+        public DEVMODE_FieldUseFlags dmFields;
+
+        /// <summary>
+        /// For printers, specifies the paper orientation.
+        /// </summary>
+        /// <remarks>
+        /// This member is not used for displays.
+        /// </remarks>
+        [FieldOffset(76)]
+        public DEVMODE_PrinterOrientationOptions dmOrientation;
+
+        /// <summary>
+        /// For printers, specifies the size of the paper to be printed on.
+        /// This member must be zero if the length and width of the paper are specified by the <see cref="dmPaperLength"/> and <see cref="dmPaperWidth"/> members.
+        /// Otherwise, this member must be one of the <see cref="DEVMODE_PrintPaperOptions"/>.
+        /// </summary>
+        /// <remarks>
+        /// This member is not used for displays.
+        /// </remarks>
+        [FieldOffset(78)]
+        public DEVMODE_PrintPaperOptions dmPaperSize;
+
+        /// <summary>
+        /// For printers, specifies the length of the paper, in units of 1/10 of a millimeter.
+        /// This value overrides the length of the paper specified by the <see cref="dmPaperSize"/> member, and is used if the paper is of a custom size, or if the device is a dot matrix printer, which can print a page of arbitrary length.
+        /// </summary>
+        /// <remarks>
+        /// This member is not used for displays.
+        /// </remarks>
+        [FieldOffset(80)]
+        public short dmPaperLength;
+
+        /// <summary>
+        /// For printers, specifies the width of the paper, in units of 1/10 of a millimeter.
+        /// This value overrides the width of the paper specified by the <see cref="dmPaperSize"/> member.
+        /// This member must be used if <see cref="dmPaperLength"/> is used.
+        /// </summary>
+        /// <remarks>
+        /// This member is not used for displays.
+        /// </remarks>
+        [FieldOffset(82)]
+        public short dmPaperWidth;
+
+        /// <summary>
+        /// For printers, specifies the percentage by which the image is to be scaled for printing.
+        /// The image's page size is scaled to the physical page by a factor of <see cref="dmScale"/>/100.
+        /// For example, a 17-inch by 22-inch image with a scale value of 100 requires 17x22-inch paper, while the same image with a scale value of 50 should print as half-sized and fit on letter-sized paper.
+        /// </summary>
+        /// <remarks>
+        /// This member is not used for displays.
+        /// </remarks>
+        [FieldOffset(84)]
+        public short dmScale;
+
+        /// <summary>
+        /// For printers, specifies the number of copies to be printed, if the device supports multiple copies.
+        /// </summary>
+        /// <remarks>
+        /// This member is not used for displays.
+        /// </remarks>
+        [FieldOffset(86)]
+        public short dmCopies;
+
+        /// <summary>
+        /// For printers, specifies the printer's default input bin.
+        /// </summary>
+        /// <remarks>
+        /// This member is not used for displays.
+        /// </remarks>
+        [FieldOffset(88)]
+        public DEVMODE_PrintBinSelectionOptions dmDefaultSource;
+
+        /// <summary>
+        /// For printers, specifies the printer resolution.
+        /// If a positive value is specified, it represents the number of dots per inch (DPI) for the x resolution, and the y resolution is specified by <see cref="dmYResolution"/>.
+        /// </summary>
+        /// <remarks>
+        /// This member is not used for displays.
+        /// </remarks>
+        [FieldOffset(90)]
+        public DEVMODE_PrintQualityOptions dmPrintQuality;
+
+        /// <summary>
+        /// For displays, specifies a <see cref="POINT"/> structure containing the x- and y-coordinates of upper-left corner of the display, in desktop coordinates.
+        /// This member is used to determine the relative position of monitors in a multiple monitor environment.
+        /// </summary>
+        /// <remarks>
+        /// This member is not used for printers.
+        /// </remarks>
+        [FieldOffset(76)]
+        public POINT dmPosition;
+
+        /// <summary>
+        /// This member is defined only for Windows XP and later.
+        /// For displays, specifies the orientation at which images should be presented.
+        /// When the <see cref="DEVMODE_FieldUseFlags.DM_DISPLAYORIENTATION"/> bit is not set in the <see cref="dmFields"/> member, this member must be set to zero.
+        /// When the <see cref="DEVMODE_FieldUseFlags.DM_DISPLAYORIENTATION"/> bit is set in the <see cref="dmFields"/> member, this member must be set to one of the <see cref="DEVMODE_DisplayOrientationOptions"/> values.
+        /// </summary>
+        /// <remarks>
+        /// This member is not used for printers.
+        /// </remarks>
+        [FieldOffset(84)]
+        public DEVMODE_DisplayOrientationOptions dmDisplayOrientation;
+
+        /// <summary>
+        /// This member is defined only for Windows XP and later.
+        /// For fixed-resolution displays, specifies how the device can present a lower - resolution mode on a higher - resolution display.
+        /// For example, if a display device's resolution is fixed at 1024 X 768, and its mode is set to 640 x 480, the device can either display a 640 X 480 image within the 1024 X 768 screen space, or stretch the 640 X 480 image to fill the larger screen space.
+        /// When the <see cref="DEVMODE_FieldUseFlags.DM_DISPLAYFIXEDOUTPUT"/> bit is not set in the <see cref="dmFields"/> member, this member must be set to zero.
+        /// When the <see cref="DEVMODE_FieldUseFlags.DM_DISPLAYFIXEDOUTPUT"/> bit is set in the <see cref="dmFields"/> member, this member must be set to one of the <see cref="DEVMODE_DisplayFixedOutputOptions"/> values.
+        /// </summary>
+        /// <remarks>
+        /// This member is not used for printers.
+        /// </remarks>
+        [FieldOffset(88)]
+        public DEVMODE_DisplayFixedOutputOptions dmDisplayFixedOutput;
+
+        /// <summary>
+        /// For printers, specifies whether a color printer should print color or monochrome.
+        /// </summary>
+        /// <remarks>
+        /// This member is not used for displays.
+        /// </remarks>
+        [FieldOffset(92)]
+        public DEVMODE_PrintColorOptions dmColor;
+
+        /// <summary>
+        /// For printers, specifies duplex (double-sided) printing for duplex-capable printers.
+        /// </summary>
+        /// <remarks>
+        /// This member is not used for displays.
+        /// </remarks>
+        [FieldOffset(94)]
+        public DEVMODE_PrintDuplexOptions dmDuplex;
+
+        /// <summary>
+        /// Specifies the y-resolution, in dots per inch, of the printer. If the printer initializes this member, the <c>dmPrintQuality</c> member specifies the x-resolution, in dots per inch, of the printer.
+        /// </summary>
+        /// <remarks>
+        /// This member is not used for displays.
+        /// </remarks>
+        [FieldOffset(96)]
+        public short dmYResolution;
+
+        /// <summary>
+        /// For printers, specifies how TrueType fonts should be printed. This member must be one of the <see cref="DEVMODE_TrueTypeOptions"/> values.
+        /// </summary>
+        /// <remarks>
+        /// This member is not used for displays.
+        /// </remarks>
+        [FieldOffset(98)]
+        public DEVMODE_TrueTypeOptions dmTTOption;
+
+        /// <summary>
+        /// For printers, specifies whether multiple copies should be collated. This member can be one of <see cref="DEVMODE_CollationSelectionOptions"/> values.
+        /// </summary>
+        /// <remarks>
+        /// This member is not used for displays.
+        /// </remarks>
+        [FieldOffset(100)]
+        public DEVMODE_CollationSelectionOptions dmCollate;
+
+        /// <summary>
+        /// A zero-terminated character array that specifies the name of the form to use; for example, "Letter" or "Legal". A complete set of names can be retrieved by using the EnumForms function.
+        /// </summary>
+        /// <remarks>
+        /// This member is not used for displays.
+        /// </remarks>
+        [FieldOffset(102)]
+        public fixed char dmFormName[CCHFORMNAME];
+
+        /// <summary>
+        /// The number of pixels per logical inch. Printer drivers do not use this member.
+        /// </summary>
+        /// <remarks>
+        /// This member is not used for printers.
+        /// </remarks>
+        [FieldOffset(166)]
+        public ushort dmLogPixels;
+
+        /// <summary>
+        /// Specifies the color resolution, in bits per pixel, of the display device (for example: 4 bits for 16 colors, 8 bits for 256 colors, or 16 bits for 65,536 colors).
+        /// Display drivers use this member, for example, in the <c>User32.EnumDisplaySettings</c> function.
+        /// Printer drivers do not use this member.
+        /// </summary>
+        /// <remarks>
+        /// This member is not used for printers.
+        /// </remarks>
+        [FieldOffset(168)]
+        public uint dmBitsPerPel;
+
+        /// <summary>
+        /// Specifies the width, in pixels, of the visible device surface.
+        /// Display drivers use this member, for example, in the <c>User32.EnumDisplaySettings</c> function.
+        /// Printer drivers do not use this member.
+        /// </summary>
+        /// <remarks>
+        /// This member is not used for printers.
+        /// </remarks>
+        [FieldOffset(172)]
+        public uint dmPelsWidth;
+
+        /// <summary>
+        /// Specifies the height, in pixels, of the visible device surface.
+        /// Display drivers use this member, for example, in the <c>User32.EnumDisplaySettings</c> function.
+        /// Printer drivers do not use this member.
+        /// </summary>
+        /// <remarks>
+        /// This member is not used for printers.
+        /// </remarks>
+        [FieldOffset(176)]
+        public uint dmPelsHeight;
+
+        /// <summary>
+        /// For displays, specifies a display device's display mode. This member can be one of the <see cref="DEVMODE_DisplayOptions"/> flags.
+        /// </summary>
+        /// <remarks>
+        /// This member is not used for printers.
+        /// </remarks>
+        [FieldOffset(180)]
+        public DEVMODE_DisplayOptions dmDisplayFlags;
+
+        /// <summary>
+        /// For printers, specifies whether the print system handles "N-up" printing (playing multiple EMF logical pages onto a single physical page).
+        /// </summary>
+        /// <remarks>
+        /// This member is not used for displays.
+        /// </remarks>
+        [FieldOffset(180)]
+        public DEVMODE_PrinterOptions dmNup;
+
+        /// <summary>
+        /// Specifies the frequency, in hertz (cycles per second), of the display device in a particular mode.
+        /// This value is also known as the display device's vertical refresh rate. Display drivers use this member.
+        /// It is used, for example, in the ChangeDisplaySettings function. Printer drivers do not use this member.
+        /// </summary>
+        /// <remarks>
+        /// When you call the <c>User32.EnumDisplaySettings</c> function, the <see cref="dmDisplayFrequency"/> member may return with the value 0 or 1.
+        /// These values represent the display hardware's default refresh rate.
+        /// This default rate is typically set by switches on a display card or computer motherboard, or by a configuration program that does not use display functions such as <c>User32.EnumDisplaySettings</c>.
+        /// </remarks>
+        /// <remarks>
+        /// This member is not used for printers.
+        /// </remarks>
+        [FieldOffset(148)]
+        public uint dmDisplayFrequency;
+
+        /// <summary>
+        /// Specifies one of the <see cref="DEVMODE_DeviceIcmMethodOptions"/> constants.
+        /// </summary>
+        [FieldOffset(188)]
+        public DEVMODE_DeviceIcmMethodOptions dmICMMethod;
+
+        /// <summary>
+        /// Specifies one of the <see cref="DEVMODE_DeviceIcmIntentOptions"/> constants.
+        /// </summary>
+        [FieldOffset(192)]
+        public DEVMODE_DeviceIcmIntentOptions dmICMIntent;
+
+        /// <summary>
+        /// Specifies one of the <see cref="DEVMODE_DeviceMediaTypeOptions"/> constants.
+        /// </summary>
+        [FieldOffset(196)]
+        public DEVMODE_DeviceMediaTypeOptions dmMediaType;
+
+        /// <summary>
+        /// Specifies one of the <see cref="DEVMODE_DitherTypeOptions"/> constants.
+        /// </summary>
+        [FieldOffset(200)]
+        public DEVMODE_DitherTypeOptions dmDitherType;
+
+        /// <summary>
+        /// Not used; must be zero.
+        /// </summary>
+        [FieldOffset(204)]
+        public uint dmReserved1;
+
+        /// <summary>
+        /// Not used; must be zero.
+        /// </summary>
+        [FieldOffset(208)]
+        public uint dmReserved2;
+
+        /// <summary>
+        /// This member must be zero.
+        /// </summary>
+        [FieldOffset(212)]
+        public uint dmPanningWidth;
+
+        /// <summary>
+        /// This member must be zero.
+        /// </summary>
+        [FieldOffset(216)]
+        public uint dmPanningHeight;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DEVMODE"/> struct
+        /// with the <see cref="dmSize" /> field initialized.
+        /// </summary>
+        /// <returns>
+        /// An instance of the structure.
+        /// </returns>
+        public static DEVMODE Create() => new DEVMODE { dmSize = (ushort)sizeof(DEVMODE) };
+    }
+
+    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmFields" /> member.</summary>
+    [Flags]
+    [SuppressMessage("Compiler", "SA1201:Elements should appear in the correct order", Justification = "Special")]
+    public enum DEVMODE_FieldUseFlags : uint
+    {
+        /// <summary>
+        /// Not set.
+        /// </summary>
+        NONE = 0,
+        DM_ORIENTATION = 0x00000001,
+        DM_PAPERSIZE = 0x00000002,
+        DM_PAPERLENGTH = 0x00000004,
+        DM_PAPERWIDTH = 0x00000008,
+        DM_SCALE = 0x00000010,
+
+        // #if (WINVER >= 0x0500)
+        DM_POSITION = 0x00000020,
+        DM_NUP = 0x00000040,
+
+        // #endif /* WINVER >= 0x0500 */
+
+        // #if (WINVER >= 0x0501)
+        DM_DISPLAYORIENTATION = 0x00000080,
+
+        // #endif /* WINVER >= 0x0501 */
+        DM_COPIES = 0x00000100,
+        DM_DEFAULTSOURCE = 0x00000200,
+        DM_PRINTQUALITY = 0x00000400,
+        DM_COLOR = 0x00000800,
+        DM_DUPLEX = 0x00001000,
+        DM_YRESOLUTION = 0x00002000,
+        DM_TTOPTION = 0x00004000,
+        DM_COLLATE = 0x00008000,
+        DM_FORMNAME = 0x00010000,
+        DM_LOGPIXELS = 0x00020000,
+        DM_BITSPERPEL = 0x00040000,
+        DM_PELSWIDTH = 0x00080000,
+        DM_PELSHEIGHT = 0x00100000,
+        DM_DISPLAYFLAGS = 0x00200000,
+        DM_DISPLAYFREQUENCY = 0x00400000,
+
+        // #if (WINVER >= 0x0400)
+        DM_ICMMETHOD = 0x00800000,
+        DM_ICMINTENT = 0x01000000,
+        DM_MEDIATYPE = 0x02000000,
+        DM_DITHERTYPE = 0x04000000,
+        DM_PANNINGWIDTH = 0x08000000,
+        DM_PANNINGHEIGHT = 0x10000000,
+
+        // #endif /* WINVER >= 0x0400 */
+
+        // #if (WINVER >= 0x0501)
+        DM_DISPLAYFIXEDOUTPUT = 0x20000000,
+    }
+
+    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmOrientation" /> member.</summary>
+    public enum DEVMODE_PrinterOrientationOptions : short
+    {
+        DMORIENT_PORTRAIT = 1,
+        DMORIENT_LANDSCAPE = 2,
+    }
+
+    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmPaperSize" /> member.</summary>
+    public enum DEVMODE_PrintPaperOptions : short
+    {
+        /// <summary>
+        ///  If the length and width of the paper are both set by the <see cref="DEVMODE.dmPaperLength"/> and <see cref="DEVMODE.dmPaperWidth"/> members.
+        /// </summary>
+        NONE = 0,
+
+        /// <summary>
+        /// DMPAPER_FIRST.
+        /// </summary>
+        DMPAPER_FIRST = DMPAPER_LETTER,
+
+        /// <summary>
+        /// Letter 8 1/2 x 11 in.
+        /// </summary>
+        DMPAPER_LETTER = 1,
+
+        /// <summary>
+        /// Letter Small 8 1/2 x 11 in.
+        /// </summary>
+        DMPAPER_LETTERSMALL = 2,
+
+        /// <summary>
+        /// Tabloid 11 x 17 in.
+        /// </summary>
+        DMPAPER_TABLOID = 3,
+
+        /// <summary>
+        /// Ledger 17 x 11 in.
+        /// </summary>
+        DMPAPER_LEDGER = 4,
+
+        /// <summary>
+        /// Legal 8 1/2 x 14 in.
+        /// </summary>
+        DMPAPER_LEGAL = 5,
+
+        /// <summary>
+        /// Statement 5 1/2 x 8 1/2 in.
+        /// </summary>
+        DMPAPER_STATEMENT = 6,
+
+        /// <summary>
+        /// Executive 7 1/4 x 10 1/2 in.
+        /// </summary>
+        DMPAPER_EXECUTIVE = 7,
+
+        /// <summary>
+        /// A3 297 x 420 mm.
+        /// </summary>
+        DMPAPER_A3 = 8,
+
+        /// <summary>
+        /// A4 210 x 297 mm.
+        /// </summary>
+        DMPAPER_A4 = 9,
+
+        /// <summary>
+        /// A4 Small 210 x 297 mm.
+        /// </summary>
+        DMPAPER_A4SMALL = 10,
+
+        /// <summary>
+        /// A5 148 x 210 mm.
+        /// </summary>
+        DMPAPER_A5 = 11,
+
+        /// <summary>
+        /// B4 (JIS) 250 x 354.
+        /// </summary>
+        DMPAPER_B4 = 12,
+
+        /// <summary>
+        /// B5 (JIS) 182 x 257 mm.
+        /// </summary>
+        DMPAPER_B5 = 13,
+
+        /// <summary>
+        /// Folio 8 1/2 x 13 in.
+        /// </summary>
+        DMPAPER_FOLIO = 14,
+
+        /// <summary>
+        /// Quarto 215 x 275 mm.
+        /// </summary>
+        DMPAPER_QUARTO = 15,
+
+        /// <summary>
+        /// 10x14 in.
+        /// </summary>
+        DMPAPER_10X14 = 16,
+
+        /// <summary>
+        /// 11x17 in.
+        /// </summary>
+        DMPAPER_11X17 = 17,
+
+        /// <summary>
+        /// Note 8 1/2 x 11 in.
+        /// </summary>
+        DMPAPER_NOTE = 18,
+
+        /// <summary>
+        /// Envelope #9 3 7/8 x 8 7/8.
+        /// </summary>
+        DMPAPER_ENV_9 = 19,
+
+        /// <summary>
+        /// Envelope #10 4 1/8 x 9 1/2.
+        /// </summary>
+        DMPAPER_ENV_10 = 20,
+
+        /// <summary>
+        /// Envelope #11 4 1/2 x 10 3/8.
+        /// </summary>
+        DMPAPER_ENV_11 = 21,
+
+        /// <summary>
+        /// Envelope #12 4 \276 x 11.
+        /// </summary>
+        DMPAPER_ENV_12 = 22,
+
+        /// <summary>
+        /// Envelope #14 5 x 11 1/2.
+        /// </summary>
+        DMPAPER_ENV_14 = 23,
+
+        /// <summary>
+        /// C size sheet.
+        /// </summary>
+        DMPAPER_CSHEET = 24,
+
+        /// <summary>
+        /// D size sheet.
+        /// </summary>
+        DMPAPER_DSHEET = 25,
+
+        /// <summary>
+        /// E size sheet.
+        /// </summary>
+        DMPAPER_ESHEET = 26,
+
+        /// <summary>
+        /// Envelope DL 110 x 220mm.
+        /// </summary>
+        DMPAPER_ENV_DL = 27,
+
+        /// <summary>
+        /// Envelope C5 162 x 229 mm.
+        /// </summary>
+        DMPAPER_ENV_C5 = 28,
+
+        /// <summary>
+        /// Envelope C3  324 x 458 mm.
+        /// </summary>
+        DMPAPER_ENV_C3 = 29,
+
+        /// <summary>
+        /// Envelope C4  229 x 324 mm.
+        /// </summary>
+        DMPAPER_ENV_C4 = 30,
+
+        /// <summary>
+        /// Envelope C6  114 x 162 mm.
+        /// </summary>
+        DMPAPER_ENV_C6 = 31,
+
+        /// <summary>
+        /// Envelope C65 114 x 229 mm.
+        /// </summary>
+        DMPAPER_ENV_C65 = 32,
+
+        /// <summary>
+        /// Envelope B4  250 x 353 mm.
+        /// </summary>
+        DMPAPER_ENV_B4 = 33,
+
+        /// <summary>
+        /// Envelope B5  176 x 250 mm.
+        /// </summary>
+        DMPAPER_ENV_B5 = 34,
+
+        /// <summary>
+        /// Envelope B6  176 x 125 mm.
+        /// </summary>
+        DMPAPER_ENV_B6 = 35,
+
+        /// <summary>
+        /// Envelope 110 x 230 mm.
+        /// </summary>
+        DMPAPER_ENV_ITALY = 36,
+
+        /// <summary>
+        /// Envelope Monarch 3.875 x 7.5 in.
+        /// </summary>
+        DMPAPER_ENV_MONARCH = 37,
+
+        /// <summary>
+        /// 6 3/4 Envelope 3 5/8 x 6 1/2 in.
+        /// </summary>
+        DMPAPER_ENV_PERSONAL = 38,
+
+        /// <summary>
+        /// US Std Fanfold 14 7/8 x 11 in.
+        /// </summary>
+        DMPAPER_FANFOLD_US = 39,
+
+        /// <summary>
+        /// German Std Fanfold 8 1/2 x 12 in.
+        /// </summary>
+        DMPAPER_FANFOLD_STD_GERMAN = 40,
+
+        /// <summary>
+        /// German Legal Fanfold 8 1/2 x 13 in.
+        /// </summary>
+        DMPAPER_FANFOLD_LGL_GERMAN = 41,
+
+        /// <summary>
+        /// B4 (ISO) 250 x 353 mm.
+        /// </summary>
+        DMPAPER_ISO_B4 = 42,
+
+        /// <summary>
+        /// Japanese Postcard 100 x 148 mm.
+        /// </summary>
+        DMPAPER_JAPANESE_POSTCARD = 43,
+
+        /// <summary>
+        /// 9 x 11 in.
+        /// </summary>
+        DMPAPER_9X11 = 44,
+
+        /// <summary>
+        /// 10 x 11 in.
+        /// </summary>
+        DMPAPER_10X11 = 45,
+
+        /// <summary>
+        /// 15 x 11 in.
+        /// </summary>
+        DMPAPER_15X11 = 46,
+
+        /// <summary>
+        /// Envelope Invite 220 x 220 mm.
+        /// </summary>
+        DMPAPER_ENV_INVITE = 47,
+
+        /// <summary>
+        /// RESERVED--DO NOT USE.
+        /// </summary>
+        DMPAPER_RESERVED_48 = 48,
+
+        /// <summary>
+        /// RESERVED--DO NOT USE.
+        /// </summary>
+        DMPAPER_RESERVED_49 = 49,
+
+        /// <summary>
+        /// Letter Extra 9 \275 x 12 in.
+        /// </summary>
+        DMPAPER_LETTER_EXTRA = 50,
+
+        /// <summary>
+        /// Legal Extra 9 \275 x 15 in.
+        /// </summary>
+        DMPAPER_LEGAL_EXTRA = 51,
+
+        /// <summary>
+        /// Tabloid Extra 11.69 x 18 in.
+        /// </summary>
+        DMPAPER_TABLOID_EXTRA = 52,
+
+        /// <summary>
+        /// A4 Extra 9.27 x 12.69 in.
+        /// </summary>
+        DMPAPER_A4_EXTRA = 53,
+
+        /// <summary>
+        /// Letter Transverse 8 \275 x 11 in.
+        /// </summary>
+        DMPAPER_LETTER_TRANSVERSE = 54,
+
+        /// <summary>
+        /// A4 Transverse 210 x 297 mm.
+        /// </summary>
+        DMPAPER_A4_TRANSVERSE = 55,
+
+        /// <summary>
+        /// Letter Extra Transverse 9\275 x 12 in.
+        /// </summary>
+        DMPAPER_LETTER_EXTRA_TRANSVERSE = 56,
+
+        /// <summary>
+        /// SuperA/SuperA/A4 227 x 356 mm.
+        /// </summary>
+        DMPAPER_A_PLUS = 57,
+
+        /// <summary>
+        /// SuperB/SuperB/A3 305 x 487 mm.
+        /// </summary>
+        DMPAPER_B_PLUS = 58,
+
+        /// <summary>
+        /// Letter Plus 8.5 x 12.69 in.
+        /// </summary>
+        DMPAPER_LETTER_PLUS = 59,
+
+        /// <summary>
+        /// A4 Plus 210 x 330 mm.
+        /// </summary>
+        DMPAPER_A4_PLUS = 60,
+
+        /// <summary>
+        /// A5 Transverse 148 x 210 mm.
+        /// </summary>
+        DMPAPER_A5_TRANSVERSE = 61,
+
+        /// <summary>
+        /// B5 (JIS) Transverse 182 x 257 mm.
+        /// </summary>
+        DMPAPER_B5_TRANSVERSE = 62,
+
+        /// <summary>
+        /// A3 Extra 322 x 445 mm.
+        /// </summary>
+        DMPAPER_A3_EXTRA = 63,
+
+        /// <summary>
+        /// A5 Extra 174 x 235 mm.
+        /// </summary>
+        DMPAPER_A5_EXTRA = 64,
+
+        /// <summary>
+        /// B5 (ISO) Extra 201 x 276 mm.
+        /// </summary>
+        DMPAPER_B5_EXTRA = 65,
+
+        /// <summary>
+        /// A2 420 x 594 mm.
+        /// </summary>
+        DMPAPER_A2 = 66,
+
+        /// <summary>
+        /// A3 Transverse 297 x 420 mm.
+        /// </summary>
+        DMPAPER_A3_TRANSVERSE = 67,
+
+        /// <summary>
+        /// A3 Extra Transverse 322 x 445 mm.
+        /// </summary>
+        DMPAPER_A3_EXTRA_TRANSVERSE = 68,
+
+        /// <summary>
+        /// Japanese Double Postcard 200 x 148 mm.
+        /// </summary>
+        DMPAPER_DBL_JAPANESE_POSTCARD = 69,
+
+        /// <summary>
+        /// A6 105 x 148 mm.
+        /// </summary>
+        DMPAPER_A6 = 70,
+
+        /// <summary>
+        /// Japanese Envelope Kaku #2.
+        /// </summary>
+        DMPAPER_JENV_KAKU2 = 71,
+
+        /// <summary>
+        /// Japanese Envelope Kaku #3.
+        /// </summary>
+        DMPAPER_JENV_KAKU3 = 72,
+
+        /// <summary>
+        /// Japanese Envelope Chou #3.
+        /// </summary>
+        DMPAPER_JENV_CHOU3 = 73,
+
+        /// <summary>
+        /// Japanese Envelope Chou #4.
+        /// </summary>
+        DMPAPER_JENV_CHOU4 = 74,
+
+        /// <summary>
+        /// Letter Rotated 11 x 8 1/2 11 in.
+        /// </summary>
+        DMPAPER_LETTER_ROTATED = 75,
+
+        /// <summary>
+        /// A3 Rotated 420 x 297 mm.
+        /// </summary>
+        DMPAPER_A3_ROTATED = 76,
+
+        /// <summary>
+        /// A4 Rotated 297 x 210 mm.
+        /// </summary>
+        DMPAPER_A4_ROTATED = 77,
+
+        /// <summary>
+        /// A5 Rotated 210 x 148 mm.
+        /// </summary>
+        DMPAPER_A5_ROTATED = 78,
+
+        /// <summary>
+        /// B4 (JIS) Rotated 364 x 257 mm.
+        /// </summary>
+        DMPAPER_B4_JIS_ROTATED = 79,
+
+        /// <summary>
+        /// B5 (JIS) Rotated 257 x 182 mm.
+        /// </summary>
+        DMPAPER_B5_JIS_ROTATED = 80,
+
+        /// <summary>
+        /// Japanese Postcard Rotated 148 x 100 mm.
+        /// </summary>
+        DMPAPER_JAPANESE_POSTCARD_ROTATED = 81,
+
+        /// <summary>
+        /// Double Japanese Postcard Rotated 148 x 200 mm.
+        /// </summary>
+        DMPAPER_DBL_JAPANESE_POSTCARD_ROTATED = 82,
+
+        /// <summary>
+        /// A6 Rotated 148 x 105 mm.
+        /// </summary>
+        DMPAPER_A6_ROTATED = 83,
+
+        /// <summary>
+        /// Japanese Envelope Kaku #2 Rotated.
+        /// </summary>
+        DMPAPER_JENV_KAKU2_ROTATED = 84,
+
+        /// <summary>
+        /// Japanese Envelope Kaku #3 Rotated.
+        /// </summary>
+        DMPAPER_JENV_KAKU3_ROTATED = 85,
+
+        /// <summary>
+        /// Japanese Envelope Chou #3 Rotated.
+        /// </summary>
+        DMPAPER_JENV_CHOU3_ROTATED = 86,
+
+        /// <summary>
+        /// Japanese Envelope Chou #4 Rotated.
+        /// </summary>
+        DMPAPER_JENV_CHOU4_ROTATED = 87,
+
+        /// <summary>
+        /// B6 (JIS) 128 x 182 mm.
+        /// </summary>
+        DMPAPER_B6_JIS = 88,
+
+        /// <summary>
+        /// B6 (JIS) Rotated 182 x 128 mm.
+        /// </summary>
+        DMPAPER_B6_JIS_ROTATED = 89,
+
+        /// <summary>
+        /// 12 x 11 in.
+        /// </summary>
+        DMPAPER_12X11 = 90,
+
+        /// <summary>
+        /// Japanese Envelope You #4.
+        /// </summary>
+        DMPAPER_JENV_YOU4 = 91,
+
+        /// <summary>
+        /// Japanese Envelope You #4 Rotated.
+        /// </summary>
+        DMPAPER_JENV_YOU4_ROTATED = 92,
+
+        /// <summary>
+        /// PRC 16K 146 x 215 mm.
+        /// </summary>
+        DMPAPER_P16K = 93,
+
+        /// <summary>
+        /// PRC 32K 97 x 151 mm.
+        /// </summary>
+        DMPAPER_P32K = 94,
+
+        /// <summary>
+        /// PRC 32K(Big) 97 x 151 mm.
+        /// </summary>
+        DMPAPER_P32KBIG = 95,
+
+        /// <summary>
+        /// PRC Envelope #1 102 x 165 mm.
+        /// </summary>
+        DMPAPER_PENV_1 = 96,
+
+        /// <summary>
+        /// PRC Envelope #2 102 x 176 mm.
+        /// </summary>
+        DMPAPER_PENV_2 = 97,
+
+        /// <summary>
+        /// PRC Envelope #3 125 x 176 mm.
+        /// </summary>
+        DMPAPER_PENV_3 = 98,
+
+        /// <summary>
+        /// PRC Envelope #4 110 x 208 mm.
+        /// </summary>
+        DMPAPER_PENV_4 = 99,
+
+        /// <summary>
+        /// PRC Envelope #5 110 x 220 mm.
+        /// </summary>
+        DMPAPER_PENV_5 = 100,
+
+        /// <summary>
+        /// PRC Envelope #6 120 x 230 mm.
+        /// </summary>
+        DMPAPER_PENV_6 = 101,
+
+        /// <summary>
+        /// PRC Envelope #7 160 x 230 mm.
+        /// </summary>
+        DMPAPER_PENV_7 = 102,
+
+        /// <summary>
+        /// PRC Envelope #8 120 x 309 mm.
+        /// </summary>
+        DMPAPER_PENV_8 = 103,
+
+        /// <summary>
+        /// PRC Envelope #9 229 x 324 mm.
+        /// </summary>
+        DMPAPER_PENV_9 = 104,
+
+        /// <summary>
+        /// PRC Envelope #10 324 x 458 mm.
+        /// </summary>
+        DMPAPER_PENV_10 = 105,
+
+        /// <summary>
+        /// PRC 16K Rotated.
+        /// </summary>
+        DMPAPER_P16K_ROTATED = 106,
+
+        /// <summary>
+        /// PRC 32K Rotated.
+        /// </summary>
+        DMPAPER_P32K_ROTATED = 107,
+
+        /// <summary>
+        /// PRC 32K(Big) Rotated.
+        /// </summary>
+        DMPAPER_P32KBIG_ROTATED = 108,
+
+        /// <summary>
+        /// PRC Envelope #1 Rotated 165 x 102 mm.
+        /// </summary>
+        DMPAPER_PENV_1_ROTATED = 109,
+
+        /// <summary>
+        /// PRC Envelope #2 Rotated 176 x 102 mm.
+        /// </summary>
+        DMPAPER_PENV_2_ROTATED = 110,
+
+        /// <summary>
+        /// PRC Envelope #3 Rotated 176 x 125 mm.
+        /// </summary>
+        DMPAPER_PENV_3_ROTATED = 111,
+
+        /// <summary>
+        /// PRC Envelope #4 Rotated 208 x 110 mm.
+        /// </summary>
+        DMPAPER_PENV_4_ROTATED = 112,
+
+        /// <summary>
+        /// PRC Envelope #5 Rotated 220 x 110 mm.
+        /// </summary>
+        DMPAPER_PENV_5_ROTATED = 113,
+
+        /// <summary>
+        /// PRC Envelope #6 Rotated 230 x 120 mm.
+        /// </summary>
+        DMPAPER_PENV_6_ROTATED = 114,
+
+        /// <summary>
+        /// PRC Envelope #7 Rotated 230 x 160 mm.
+        /// </summary>
+        DMPAPER_PENV_7_ROTATED = 115,
+
+        /// <summary>
+        /// PRC Envelope #8 Rotated 309 x 120 mm.
+        /// </summary>
+        DMPAPER_PENV_8_ROTATED = 116,
+
+        /// <summary>
+        /// PRC Envelope #9 Rotated 324 x 229 mm.
+        /// </summary>
+        DMPAPER_PENV_9_ROTATED = 117,
+
+        /// <summary>
+        /// PRC Envelope #10 Rotated 458 x 324 mm.
+        /// </summary>
+        DMPAPER_PENV_10_ROTATED = 118,
+
+        /// <summary>
+        /// DMPAPER_LAST.
+        /// </summary>
+        DMPAPER_LAST = DMPAPER_PENV_10_ROTATED,
+
+        /// <summary>
+        /// DMPAPER_USER.
+        /// </summary>
+        DMPAPER_USER = 256,
+    }
+
+    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmDefaultSource" /> member.</summary>
+    public enum DEVMODE_PrintBinSelectionOptions : short
+    {
+        DMBIN_FIRST = DMBIN_UPPER,
+        DMBIN_UPPER = 1,
+        DMBIN_ONLYONE = 1,
+        DMBIN_LOWER = 2,
+        DMBIN_MIDDLE = 3,
+        DMBIN_MANUAL = 4,
+        DMBIN_ENVELOPE = 5,
+        DMBIN_ENVMANUAL = 6,
+        DMBIN_AUTO = 7,
+        DMBIN_TRACTOR = 8,
+        DMBIN_SMALLFMT = 9,
+        DMBIN_LARGEFMT = 10,
+        DMBIN_LARGECAPACITY = 11,
+        DMBIN_CASSETTE = 14,
+        DMBIN_FORMSOURCE = 15,
+        DMBIN_LAST = DMBIN_FORMSOURCE,
+
+        DMBIN_USER = 256,    /* device specific bins start here */
+    }
+
+    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmPrintQuality" /> member.</summary>
+    public enum DEVMODE_PrintQualityOptions : short
+    {
+        DMRES_HIGH = -4,
+        DMRES_MEDIUM = -3,
+        DMRES_LOW = -2,
+        DMRES_DRAFT = -1,
+    }
+
+    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmDisplayOrientation" /> member.</summary>
+    public enum DEVMODE_DisplayOrientationOptions : uint
+    {
+        /// <summary>
+        /// The current mode's display device orientation is the natural orientation of the device, and should be used as the default.
+        /// </summary>
+        DMDO_DEFAULT = 0,
+
+        /// <summary>
+        /// The display device orientation is 90 degrees (measured clockwise) from that of <see cref="DMDO_DEFAULT"/>.
+        /// </summary>
+        DMDO_90 = 1,
+
+        /// <summary>
+        /// The display device orientation is 180 degrees (measured clockwise) from that of <see cref="DMDO_DEFAULT"/>.
+        /// </summary>
+        DMDO_180 = 2,
+
+        /// <summary>
+        /// The display device orientation is 270 degrees (measured clockwise) from that of <see cref="DMDO_DEFAULT"/>.
+        /// </summary>
+        DMDO_270 = 3,
+    }
+
+    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmDisplayFixedOutput" /> member.</summary>
+    public enum DEVMODE_DisplayFixedOutputOptions : uint
+    {
+        /// <summary>
+        /// The display's default setting.
+        /// </summary>
+        DMDFO_DEFAULT = 0,
+
+        /// <summary>
+        /// The display device presents a lower-resolution mode image by stretching it to fill the larger screen space.
+        /// </summary>
+        DMDFO_STRETCH = 1,
+
+        /// <summary>
+        /// The display device presents a lower resolution mode image by centering it in the larger screen space.
+        /// </summary>
+        DMDFO_CENTER = 2,
+    }
+
+    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmColor" /> member.</summary>
+    public enum DEVMODE_PrintColorOptions : short
+    {
+        DMCOLOR_MONOCHROME = 1,
+        DMCOLOR_COLOR = 2,
+    }
+
+    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmDuplex" /> member.</summary>
+    public enum DEVMODE_PrintDuplexOptions : short
+    {
+        /// <summary>
+        /// Print single-sided.
+        /// </summary>
+        DMDUP_SIMPLEX = 1,
+
+        /// <summary>
+        /// Print double-sided, using long edge binding.
+        /// </summary>
+        DMDUP_VERTICAL = 2,
+
+        /// <summary>
+        /// Print double-sided, using short edge binding.
+        /// </summary>
+        DMDUP_HORIZONTAL = 3,
+    }
+
+    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmTTOption" /> member.</summary>
+    public enum DEVMODE_TrueTypeOptions : short
+    {
+        /// <summary>
+        /// Print TT fonts as graphics.
+        /// </summary>
+        DMTT_BITMAP = 1,
+
+        /// <summary>
+        /// Download TT fonts as soft fonts.
+        /// </summary>
+        DMTT_DOWNLOAD = 2,
+
+        /// <summary>
+        /// Substitute device fonts for TT fonts.
+        /// </summary>
+        DMTT_SUBDEV = 3,
+
+        // #if (WINVER >= 0x0400)
+
+        /// <summary>
+        /// Download TT fonts as outline soft fonts.
+        /// </summary>
+        DMTT_DOWNLOAD_OUTLINE = 4,
+    }
+
+    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmCollate" /> member.</summary>
+    public enum DEVMODE_CollationSelectionOptions : short
+    {
+        /// <summary>
+        /// Do not collate when printing multiple copies.
+        /// </summary>
+        DMCOLLATE_FALSE = 0,
+
+        /// <summary>
+        /// Collate when printing multiple copies.
+        /// </summary>
+        DMCOLLATE_TRUE = 1,
+    }
+
+    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmDisplayFlags" /> member.</summary>
+    [Flags]
+    public enum DEVMODE_DisplayOptions : uint
+    {
+        /// <summary>
+        /// Not set.
+        /// </summary>
+        NONE = 0x00000000,
+
+        /// <summary>
+        /// Specifies that the display is a noncolor device.
+        /// If this flag is not set, color is assumed.
+        /// </summary>
+        DM_INTERLACED = 0x00000002,
+
+        /// <summary>
+        /// Specifies that the display mode is interlaced.
+        /// If the flag is not set, noninterlaced is assumed.
+        /// </summary>
+        DMDISPLAYFLAGS_TEXTMODE = 0x00000004,
+    }
+
+    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmNup" /> member.</summary>
+    public enum DEVMODE_PrinterOptions : uint
+    {
+        /// <summary>
+        /// The print system handles "N-up" printing.
+        /// </summary>
+        DMNUP_SYSTEM = 1,
+
+        /// <summary>
+        /// The print system does not handle "N-up" printing. An application can set <see cref="DEVMODE.dmNup"/> to <see cref="DMNUP_ONEUP"/> if it intends to carry out "N-up" printing on its own.
+        /// </summary>
+        DMNUP_ONEUP = 2,
+    }
+
+    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmICMMethod" /> member.</summary>
+    public enum DEVMODE_DeviceIcmMethodOptions : uint
+    {
+        /// <summary>
+        /// ICM disabled.
+        /// </summary>
+        DMICMMETHOD_NONE = 1,
+
+        /// <summary>
+        /// ICM handled by system.
+        /// </summary>
+        DMICMMETHOD_SYSTEM = 2,
+
+        /// <summary>
+        /// ICM handled by driver.
+        /// </summary>
+        DMICMMETHOD_DRIVER = 3,
+
+        /// <summary>
+        /// ICM handled by device.
+        /// </summary>
+        DMICMMETHOD_DEVICE = 4,
+
+        /// <summary>
+        /// Device-specific methods start here.
+        /// </summary>
+        DMICMMETHOD_USER = 256,
+    }
+
+    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmICMIntent" /> member.</summary>
+    public enum DEVMODE_DeviceIcmIntentOptions : uint
+    {
+        /// <summary>
+        /// Maximize color saturation.
+        /// </summary>
+        DMICM_SATURATE = 1,
+
+        /// <summary>
+        /// Maximize color contrast.
+        /// </summary>
+        DMICM_CONTRAST = 2,
+
+        /// <summary>
+        /// Use specific color metric.
+        /// </summary>
+        DMICM_COLORIMETRIC = 3,
+
+        /// <summary>
+        /// Use specific color metric.
+        /// </summary>
+        DMICM_ABS_COLORIMETRIC = 4,
+
+        /// <summary>
+        /// Device-specific intents start here.
+        /// </summary>
+        DMICM_USER = 256,
+    }
+
+    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmMediaType" /> member.</summary>
+    public enum DEVMODE_DeviceMediaTypeOptions : uint
+    {
+        /// <summary>
+        /// Standard paper.
+        /// </summary>
+        DMMEDIA_STANDARD = 1,
+
+        /// <summary>
+        /// Transparency.
+        /// </summary>
+        DMMEDIA_TRANSPARENCY = 2,
+
+        /// <summary>
+        /// Glossy paper.
+        /// </summary>
+        DMMEDIA_GLOSSY = 3,
+
+        /// <summary>
+        /// Device-specific media start here.
+        /// </summary>
+        DMMEDIA_USER = 256,
+    }
+
+    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmDitherType" /> member.</summary>
+    public enum DEVMODE_DitherTypeOptions : uint
+    {
+        /// <summary>
+        /// No dithering.
+        /// </summary>
+        DMDITHER_NONE = 1,
+
+        /// <summary>
+        /// Dither with a coarse brush.
+        /// </summary>
+        DMDITHER_COARSE = 2,
+
+        /// <summary>
+        /// Dither with a fine brush.
+        /// </summary>
+        DMDITHER_FINE = 3,
+
+        /// <summary>
+        /// LineArt dithering.
+        /// </summary>
+        DMDITHER_LINEART = 4,
+
+        /// <summary>
+        /// LineArt dithering.
+        /// </summary>
+        DMDITHER_ERRORDIFFUSION = 5,
+
+        /// <summary>
+        /// LineArt dithering.
+        /// </summary>
+        DMDITHER_RESERVED6 = 6,
+
+        /// <summary>
+        /// LineArt dithering.
+        /// </summary>
+        DMDITHER_RESERVED7 = 7,
+
+        /// <summary>
+        /// LineArt dithering.
+        /// </summary>
+        DMDITHER_RESERVED8 = 8,
+
+        /// <summary>
+        /// LineArt dithering.
+        /// </summary>
+        DMDITHER_RESERVED9 = 9,
+
+        /// <summary>
+        /// Device does grayscaling.
+        /// </summary>
+        DMDITHER_GRAYSCALE = 10,
+
+        /// <summary>
+        /// Device-specific dithers start here.
+        /// </summary>
+        DMDITHER_USER = 256,
+    }
+}

--- a/src/Windows.Core/DEVMODE.cs
+++ b/src/Windows.Core/DEVMODE.cs
@@ -55,7 +55,7 @@ namespace PInvoke
         /// If a member is initialized, its corresponding bit is set, otherwise the bit is clear. A driver supports only those <see cref="DEVMODE"/> members that are appropriate for the printer or display technology.
         /// </summary>
         [FieldOffset(72)]
-        public DEVMODE_FieldUseFlags dmFields;
+        public FieldUseFlags dmFields;
 
         /// <summary>
         /// For printers, specifies the paper orientation.
@@ -64,18 +64,18 @@ namespace PInvoke
         /// This member is not used for displays.
         /// </remarks>
         [FieldOffset(76)]
-        public DEVMODE_PrinterOrientationOptions dmOrientation;
+        public PrinterOrientationOptions dmOrientation;
 
         /// <summary>
         /// For printers, specifies the size of the paper to be printed on.
         /// This member must be zero if the length and width of the paper are specified by the <see cref="dmPaperLength"/> and <see cref="dmPaperWidth"/> members.
-        /// Otherwise, this member must be one of the <see cref="DEVMODE_PrintPaperOptions"/>.
+        /// Otherwise, this member must be one of the <see cref="PrintPaperOptions"/>.
         /// </summary>
         /// <remarks>
         /// This member is not used for displays.
         /// </remarks>
         [FieldOffset(78)]
-        public DEVMODE_PrintPaperOptions dmPaperSize;
+        public PrintPaperOptions dmPaperSize;
 
         /// <summary>
         /// For printers, specifies the length of the paper, in units of 1/10 of a millimeter.
@@ -125,7 +125,7 @@ namespace PInvoke
         /// This member is not used for displays.
         /// </remarks>
         [FieldOffset(88)]
-        public DEVMODE_PrintBinSelectionOptions dmDefaultSource;
+        public PrintBinSelectionOptions dmDefaultSource;
 
         /// <summary>
         /// For printers, specifies the printer resolution.
@@ -135,7 +135,7 @@ namespace PInvoke
         /// This member is not used for displays.
         /// </remarks>
         [FieldOffset(90)]
-        public DEVMODE_PrintQualityOptions dmPrintQuality;
+        public PrintQualityOptions dmPrintQuality;
 
         /// <summary>
         /// For displays, specifies a <see cref="POINT"/> structure containing the x- and y-coordinates of upper-left corner of the display, in desktop coordinates.
@@ -150,27 +150,27 @@ namespace PInvoke
         /// <summary>
         /// This member is defined only for Windows XP and later.
         /// For displays, specifies the orientation at which images should be presented.
-        /// When the <see cref="DEVMODE_FieldUseFlags.DM_DISPLAYORIENTATION"/> bit is not set in the <see cref="dmFields"/> member, this member must be set to zero.
-        /// When the <see cref="DEVMODE_FieldUseFlags.DM_DISPLAYORIENTATION"/> bit is set in the <see cref="dmFields"/> member, this member must be set to one of the <see cref="DEVMODE_DisplayOrientationOptions"/> values.
+        /// When the <see cref="FieldUseFlags.DM_DISPLAYORIENTATION"/> bit is not set in the <see cref="dmFields"/> member, this member must be set to zero.
+        /// When the <see cref="FieldUseFlags.DM_DISPLAYORIENTATION"/> bit is set in the <see cref="dmFields"/> member, this member must be set to one of the <see cref="DisplayOrientationOptions"/> values.
         /// </summary>
         /// <remarks>
         /// This member is not used for printers.
         /// </remarks>
         [FieldOffset(84)]
-        public DEVMODE_DisplayOrientationOptions dmDisplayOrientation;
+        public DisplayOrientationOptions dmDisplayOrientation;
 
         /// <summary>
         /// This member is defined only for Windows XP and later.
         /// For fixed-resolution displays, specifies how the device can present a lower - resolution mode on a higher - resolution display.
         /// For example, if a display device's resolution is fixed at 1024 X 768, and its mode is set to 640 x 480, the device can either display a 640 X 480 image within the 1024 X 768 screen space, or stretch the 640 X 480 image to fill the larger screen space.
-        /// When the <see cref="DEVMODE_FieldUseFlags.DM_DISPLAYFIXEDOUTPUT"/> bit is not set in the <see cref="dmFields"/> member, this member must be set to zero.
-        /// When the <see cref="DEVMODE_FieldUseFlags.DM_DISPLAYFIXEDOUTPUT"/> bit is set in the <see cref="dmFields"/> member, this member must be set to one of the <see cref="DEVMODE_DisplayFixedOutputOptions"/> values.
+        /// When the <see cref="FieldUseFlags.DM_DISPLAYFIXEDOUTPUT"/> bit is not set in the <see cref="dmFields"/> member, this member must be set to zero.
+        /// When the <see cref="FieldUseFlags.DM_DISPLAYFIXEDOUTPUT"/> bit is set in the <see cref="dmFields"/> member, this member must be set to one of the <see cref="DisplayFixedOutputOptions"/> values.
         /// </summary>
         /// <remarks>
         /// This member is not used for printers.
         /// </remarks>
         [FieldOffset(88)]
-        public DEVMODE_DisplayFixedOutputOptions dmDisplayFixedOutput;
+        public DisplayFixedOutputOptions dmDisplayFixedOutput;
 
         /// <summary>
         /// For printers, specifies whether a color printer should print color or monochrome.
@@ -179,7 +179,7 @@ namespace PInvoke
         /// This member is not used for displays.
         /// </remarks>
         [FieldOffset(92)]
-        public DEVMODE_PrintColorOptions dmColor;
+        public PrintColorOptions dmColor;
 
         /// <summary>
         /// For printers, specifies duplex (double-sided) printing for duplex-capable printers.
@@ -188,7 +188,7 @@ namespace PInvoke
         /// This member is not used for displays.
         /// </remarks>
         [FieldOffset(94)]
-        public DEVMODE_PrintDuplexOptions dmDuplex;
+        public PrintDuplexOptions dmDuplex;
 
         /// <summary>
         /// Specifies the y-resolution, in dots per inch, of the printer. If the printer initializes this member, the <c>dmPrintQuality</c> member specifies the x-resolution, in dots per inch, of the printer.
@@ -200,22 +200,22 @@ namespace PInvoke
         public short dmYResolution;
 
         /// <summary>
-        /// For printers, specifies how TrueType fonts should be printed. This member must be one of the <see cref="DEVMODE_TrueTypeOptions"/> values.
+        /// For printers, specifies how TrueType fonts should be printed. This member must be one of the <see cref="TrueTypeOptions"/> values.
         /// </summary>
         /// <remarks>
         /// This member is not used for displays.
         /// </remarks>
         [FieldOffset(98)]
-        public DEVMODE_TrueTypeOptions dmTTOption;
+        public TrueTypeOptions dmTTOption;
 
         /// <summary>
-        /// For printers, specifies whether multiple copies should be collated. This member can be one of <see cref="DEVMODE_CollationSelectionOptions"/> values.
+        /// For printers, specifies whether multiple copies should be collated. This member can be one of <see cref="CollationSelectionOptions"/> values.
         /// </summary>
         /// <remarks>
         /// This member is not used for displays.
         /// </remarks>
         [FieldOffset(100)]
-        public DEVMODE_CollationSelectionOptions dmCollate;
+        public CollationSelectionOptions dmCollate;
 
         /// <summary>
         /// A zero-terminated character array that specifies the name of the form to use; for example, "Letter" or "Legal". A complete set of names can be retrieved by using the EnumForms function.
@@ -269,13 +269,13 @@ namespace PInvoke
         public uint dmPelsHeight;
 
         /// <summary>
-        /// For displays, specifies a display device's display mode. This member can be one of the <see cref="DEVMODE_DisplayOptions"/> flags.
+        /// For displays, specifies a display device's display mode. This member can be one of the <see cref="DisplayOptions"/> flags.
         /// </summary>
         /// <remarks>
         /// This member is not used for printers.
         /// </remarks>
         [FieldOffset(180)]
-        public DEVMODE_DisplayOptions dmDisplayFlags;
+        public DisplayOptions dmDisplayFlags;
 
         /// <summary>
         /// For printers, specifies whether the print system handles "N-up" printing (playing multiple EMF logical pages onto a single physical page).
@@ -284,7 +284,7 @@ namespace PInvoke
         /// This member is not used for displays.
         /// </remarks>
         [FieldOffset(180)]
-        public DEVMODE_PrinterOptions dmNup;
+        public PrinterOptions dmNup;
 
         /// <summary>
         /// Specifies the frequency, in hertz (cycles per second), of the display device in a particular mode.
@@ -303,28 +303,28 @@ namespace PInvoke
         public uint dmDisplayFrequency;
 
         /// <summary>
-        /// Specifies one of the <see cref="DEVMODE_DeviceIcmMethodOptions"/> constants.
+        /// Specifies one of the <see cref="DeviceIcmMethodOptions"/> constants.
         /// </summary>
         [FieldOffset(188)]
-        public DEVMODE_DeviceIcmMethodOptions dmICMMethod;
+        public DeviceIcmMethodOptions dmICMMethod;
 
         /// <summary>
-        /// Specifies one of the <see cref="DEVMODE_DeviceIcmIntentOptions"/> constants.
+        /// Specifies one of the <see cref="DeviceIcmIntentOptions"/> constants.
         /// </summary>
         [FieldOffset(192)]
-        public DEVMODE_DeviceIcmIntentOptions dmICMIntent;
+        public DeviceIcmIntentOptions dmICMIntent;
 
         /// <summary>
-        /// Specifies one of the <see cref="DEVMODE_DeviceMediaTypeOptions"/> constants.
+        /// Specifies one of the <see cref="DeviceMediaTypeOptions"/> constants.
         /// </summary>
         [FieldOffset(196)]
-        public DEVMODE_DeviceMediaTypeOptions dmMediaType;
+        public DeviceMediaTypeOptions dmMediaType;
 
         /// <summary>
-        /// Specifies one of the <see cref="DEVMODE_DitherTypeOptions"/> constants.
+        /// Specifies one of the <see cref="DitherTypeOptions"/> constants.
         /// </summary>
         [FieldOffset(200)]
-        public DEVMODE_DitherTypeOptions dmDitherType;
+        public DitherTypeOptions dmDitherType;
 
         /// <summary>
         /// Not used; must be zero.
@@ -358,999 +358,999 @@ namespace PInvoke
         /// An instance of the structure.
         /// </returns>
         public static DEVMODE Create() => new DEVMODE { dmSize = (ushort)sizeof(DEVMODE) };
-    }
-
-    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmFields" /> member.</summary>
-    [Flags]
-    [SuppressMessage("Compiler", "SA1201:Elements should appear in the correct order", Justification = "Special")]
-    public enum DEVMODE_FieldUseFlags : uint
-    {
-        /// <summary>
-        /// Not set.
-        /// </summary>
-        NONE = 0,
-        DM_ORIENTATION = 0x00000001,
-        DM_PAPERSIZE = 0x00000002,
-        DM_PAPERLENGTH = 0x00000004,
-        DM_PAPERWIDTH = 0x00000008,
-        DM_SCALE = 0x00000010,
-
-        // #if (WINVER >= 0x0500)
-        DM_POSITION = 0x00000020,
-        DM_NUP = 0x00000040,
-
-        // #endif /* WINVER >= 0x0500 */
-
-        // #if (WINVER >= 0x0501)
-        DM_DISPLAYORIENTATION = 0x00000080,
-
-        // #endif /* WINVER >= 0x0501 */
-        DM_COPIES = 0x00000100,
-        DM_DEFAULTSOURCE = 0x00000200,
-        DM_PRINTQUALITY = 0x00000400,
-        DM_COLOR = 0x00000800,
-        DM_DUPLEX = 0x00001000,
-        DM_YRESOLUTION = 0x00002000,
-        DM_TTOPTION = 0x00004000,
-        DM_COLLATE = 0x00008000,
-        DM_FORMNAME = 0x00010000,
-        DM_LOGPIXELS = 0x00020000,
-        DM_BITSPERPEL = 0x00040000,
-        DM_PELSWIDTH = 0x00080000,
-        DM_PELSHEIGHT = 0x00100000,
-        DM_DISPLAYFLAGS = 0x00200000,
-        DM_DISPLAYFREQUENCY = 0x00400000,
-
-        // #if (WINVER >= 0x0400)
-        DM_ICMMETHOD = 0x00800000,
-        DM_ICMINTENT = 0x01000000,
-        DM_MEDIATYPE = 0x02000000,
-        DM_DITHERTYPE = 0x04000000,
-        DM_PANNINGWIDTH = 0x08000000,
-        DM_PANNINGHEIGHT = 0x10000000,
-
-        // #endif /* WINVER >= 0x0400 */
-
-        // #if (WINVER >= 0x0501)
-        DM_DISPLAYFIXEDOUTPUT = 0x20000000,
-    }
-
-    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmOrientation" /> member.</summary>
-    public enum DEVMODE_PrinterOrientationOptions : short
-    {
-        DMORIENT_PORTRAIT = 1,
-        DMORIENT_LANDSCAPE = 2,
-    }
-
-    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmPaperSize" /> member.</summary>
-    public enum DEVMODE_PrintPaperOptions : short
-    {
-        /// <summary>
-        ///  If the length and width of the paper are both set by the <see cref="DEVMODE.dmPaperLength"/> and <see cref="DEVMODE.dmPaperWidth"/> members.
-        /// </summary>
-        NONE = 0,
-
-        /// <summary>
-        /// DMPAPER_FIRST.
-        /// </summary>
-        DMPAPER_FIRST = DMPAPER_LETTER,
-
-        /// <summary>
-        /// Letter 8 1/2 x 11 in.
-        /// </summary>
-        DMPAPER_LETTER = 1,
-
-        /// <summary>
-        /// Letter Small 8 1/2 x 11 in.
-        /// </summary>
-        DMPAPER_LETTERSMALL = 2,
-
-        /// <summary>
-        /// Tabloid 11 x 17 in.
-        /// </summary>
-        DMPAPER_TABLOID = 3,
-
-        /// <summary>
-        /// Ledger 17 x 11 in.
-        /// </summary>
-        DMPAPER_LEDGER = 4,
-
-        /// <summary>
-        /// Legal 8 1/2 x 14 in.
-        /// </summary>
-        DMPAPER_LEGAL = 5,
-
-        /// <summary>
-        /// Statement 5 1/2 x 8 1/2 in.
-        /// </summary>
-        DMPAPER_STATEMENT = 6,
-
-        /// <summary>
-        /// Executive 7 1/4 x 10 1/2 in.
-        /// </summary>
-        DMPAPER_EXECUTIVE = 7,
-
-        /// <summary>
-        /// A3 297 x 420 mm.
-        /// </summary>
-        DMPAPER_A3 = 8,
-
-        /// <summary>
-        /// A4 210 x 297 mm.
-        /// </summary>
-        DMPAPER_A4 = 9,
-
-        /// <summary>
-        /// A4 Small 210 x 297 mm.
-        /// </summary>
-        DMPAPER_A4SMALL = 10,
-
-        /// <summary>
-        /// A5 148 x 210 mm.
-        /// </summary>
-        DMPAPER_A5 = 11,
-
-        /// <summary>
-        /// B4 (JIS) 250 x 354.
-        /// </summary>
-        DMPAPER_B4 = 12,
-
-        /// <summary>
-        /// B5 (JIS) 182 x 257 mm.
-        /// </summary>
-        DMPAPER_B5 = 13,
-
-        /// <summary>
-        /// Folio 8 1/2 x 13 in.
-        /// </summary>
-        DMPAPER_FOLIO = 14,
-
-        /// <summary>
-        /// Quarto 215 x 275 mm.
-        /// </summary>
-        DMPAPER_QUARTO = 15,
-
-        /// <summary>
-        /// 10x14 in.
-        /// </summary>
-        DMPAPER_10X14 = 16,
-
-        /// <summary>
-        /// 11x17 in.
-        /// </summary>
-        DMPAPER_11X17 = 17,
-
-        /// <summary>
-        /// Note 8 1/2 x 11 in.
-        /// </summary>
-        DMPAPER_NOTE = 18,
-
-        /// <summary>
-        /// Envelope #9 3 7/8 x 8 7/8.
-        /// </summary>
-        DMPAPER_ENV_9 = 19,
-
-        /// <summary>
-        /// Envelope #10 4 1/8 x 9 1/2.
-        /// </summary>
-        DMPAPER_ENV_10 = 20,
-
-        /// <summary>
-        /// Envelope #11 4 1/2 x 10 3/8.
-        /// </summary>
-        DMPAPER_ENV_11 = 21,
-
-        /// <summary>
-        /// Envelope #12 4 \276 x 11.
-        /// </summary>
-        DMPAPER_ENV_12 = 22,
-
-        /// <summary>
-        /// Envelope #14 5 x 11 1/2.
-        /// </summary>
-        DMPAPER_ENV_14 = 23,
-
-        /// <summary>
-        /// C size sheet.
-        /// </summary>
-        DMPAPER_CSHEET = 24,
-
-        /// <summary>
-        /// D size sheet.
-        /// </summary>
-        DMPAPER_DSHEET = 25,
-
-        /// <summary>
-        /// E size sheet.
-        /// </summary>
-        DMPAPER_ESHEET = 26,
-
-        /// <summary>
-        /// Envelope DL 110 x 220mm.
-        /// </summary>
-        DMPAPER_ENV_DL = 27,
-
-        /// <summary>
-        /// Envelope C5 162 x 229 mm.
-        /// </summary>
-        DMPAPER_ENV_C5 = 28,
-
-        /// <summary>
-        /// Envelope C3  324 x 458 mm.
-        /// </summary>
-        DMPAPER_ENV_C3 = 29,
-
-        /// <summary>
-        /// Envelope C4  229 x 324 mm.
-        /// </summary>
-        DMPAPER_ENV_C4 = 30,
-
-        /// <summary>
-        /// Envelope C6  114 x 162 mm.
-        /// </summary>
-        DMPAPER_ENV_C6 = 31,
-
-        /// <summary>
-        /// Envelope C65 114 x 229 mm.
-        /// </summary>
-        DMPAPER_ENV_C65 = 32,
-
-        /// <summary>
-        /// Envelope B4  250 x 353 mm.
-        /// </summary>
-        DMPAPER_ENV_B4 = 33,
-
-        /// <summary>
-        /// Envelope B5  176 x 250 mm.
-        /// </summary>
-        DMPAPER_ENV_B5 = 34,
-
-        /// <summary>
-        /// Envelope B6  176 x 125 mm.
-        /// </summary>
-        DMPAPER_ENV_B6 = 35,
-
-        /// <summary>
-        /// Envelope 110 x 230 mm.
-        /// </summary>
-        DMPAPER_ENV_ITALY = 36,
-
-        /// <summary>
-        /// Envelope Monarch 3.875 x 7.5 in.
-        /// </summary>
-        DMPAPER_ENV_MONARCH = 37,
-
-        /// <summary>
-        /// 6 3/4 Envelope 3 5/8 x 6 1/2 in.
-        /// </summary>
-        DMPAPER_ENV_PERSONAL = 38,
-
-        /// <summary>
-        /// US Std Fanfold 14 7/8 x 11 in.
-        /// </summary>
-        DMPAPER_FANFOLD_US = 39,
-
-        /// <summary>
-        /// German Std Fanfold 8 1/2 x 12 in.
-        /// </summary>
-        DMPAPER_FANFOLD_STD_GERMAN = 40,
-
-        /// <summary>
-        /// German Legal Fanfold 8 1/2 x 13 in.
-        /// </summary>
-        DMPAPER_FANFOLD_LGL_GERMAN = 41,
-
-        /// <summary>
-        /// B4 (ISO) 250 x 353 mm.
-        /// </summary>
-        DMPAPER_ISO_B4 = 42,
-
-        /// <summary>
-        /// Japanese Postcard 100 x 148 mm.
-        /// </summary>
-        DMPAPER_JAPANESE_POSTCARD = 43,
-
-        /// <summary>
-        /// 9 x 11 in.
-        /// </summary>
-        DMPAPER_9X11 = 44,
-
-        /// <summary>
-        /// 10 x 11 in.
-        /// </summary>
-        DMPAPER_10X11 = 45,
-
-        /// <summary>
-        /// 15 x 11 in.
-        /// </summary>
-        DMPAPER_15X11 = 46,
-
-        /// <summary>
-        /// Envelope Invite 220 x 220 mm.
-        /// </summary>
-        DMPAPER_ENV_INVITE = 47,
-
-        /// <summary>
-        /// RESERVED--DO NOT USE.
-        /// </summary>
-        DMPAPER_RESERVED_48 = 48,
-
-        /// <summary>
-        /// RESERVED--DO NOT USE.
-        /// </summary>
-        DMPAPER_RESERVED_49 = 49,
-
-        /// <summary>
-        /// Letter Extra 9 \275 x 12 in.
-        /// </summary>
-        DMPAPER_LETTER_EXTRA = 50,
-
-        /// <summary>
-        /// Legal Extra 9 \275 x 15 in.
-        /// </summary>
-        DMPAPER_LEGAL_EXTRA = 51,
-
-        /// <summary>
-        /// Tabloid Extra 11.69 x 18 in.
-        /// </summary>
-        DMPAPER_TABLOID_EXTRA = 52,
-
-        /// <summary>
-        /// A4 Extra 9.27 x 12.69 in.
-        /// </summary>
-        DMPAPER_A4_EXTRA = 53,
-
-        /// <summary>
-        /// Letter Transverse 8 \275 x 11 in.
-        /// </summary>
-        DMPAPER_LETTER_TRANSVERSE = 54,
-
-        /// <summary>
-        /// A4 Transverse 210 x 297 mm.
-        /// </summary>
-        DMPAPER_A4_TRANSVERSE = 55,
-
-        /// <summary>
-        /// Letter Extra Transverse 9\275 x 12 in.
-        /// </summary>
-        DMPAPER_LETTER_EXTRA_TRANSVERSE = 56,
-
-        /// <summary>
-        /// SuperA/SuperA/A4 227 x 356 mm.
-        /// </summary>
-        DMPAPER_A_PLUS = 57,
-
-        /// <summary>
-        /// SuperB/SuperB/A3 305 x 487 mm.
-        /// </summary>
-        DMPAPER_B_PLUS = 58,
-
-        /// <summary>
-        /// Letter Plus 8.5 x 12.69 in.
-        /// </summary>
-        DMPAPER_LETTER_PLUS = 59,
-
-        /// <summary>
-        /// A4 Plus 210 x 330 mm.
-        /// </summary>
-        DMPAPER_A4_PLUS = 60,
-
-        /// <summary>
-        /// A5 Transverse 148 x 210 mm.
-        /// </summary>
-        DMPAPER_A5_TRANSVERSE = 61,
-
-        /// <summary>
-        /// B5 (JIS) Transverse 182 x 257 mm.
-        /// </summary>
-        DMPAPER_B5_TRANSVERSE = 62,
-
-        /// <summary>
-        /// A3 Extra 322 x 445 mm.
-        /// </summary>
-        DMPAPER_A3_EXTRA = 63,
-
-        /// <summary>
-        /// A5 Extra 174 x 235 mm.
-        /// </summary>
-        DMPAPER_A5_EXTRA = 64,
-
-        /// <summary>
-        /// B5 (ISO) Extra 201 x 276 mm.
-        /// </summary>
-        DMPAPER_B5_EXTRA = 65,
-
-        /// <summary>
-        /// A2 420 x 594 mm.
-        /// </summary>
-        DMPAPER_A2 = 66,
-
-        /// <summary>
-        /// A3 Transverse 297 x 420 mm.
-        /// </summary>
-        DMPAPER_A3_TRANSVERSE = 67,
-
-        /// <summary>
-        /// A3 Extra Transverse 322 x 445 mm.
-        /// </summary>
-        DMPAPER_A3_EXTRA_TRANSVERSE = 68,
-
-        /// <summary>
-        /// Japanese Double Postcard 200 x 148 mm.
-        /// </summary>
-        DMPAPER_DBL_JAPANESE_POSTCARD = 69,
-
-        /// <summary>
-        /// A6 105 x 148 mm.
-        /// </summary>
-        DMPAPER_A6 = 70,
-
-        /// <summary>
-        /// Japanese Envelope Kaku #2.
-        /// </summary>
-        DMPAPER_JENV_KAKU2 = 71,
-
-        /// <summary>
-        /// Japanese Envelope Kaku #3.
-        /// </summary>
-        DMPAPER_JENV_KAKU3 = 72,
-
-        /// <summary>
-        /// Japanese Envelope Chou #3.
-        /// </summary>
-        DMPAPER_JENV_CHOU3 = 73,
-
-        /// <summary>
-        /// Japanese Envelope Chou #4.
-        /// </summary>
-        DMPAPER_JENV_CHOU4 = 74,
-
-        /// <summary>
-        /// Letter Rotated 11 x 8 1/2 11 in.
-        /// </summary>
-        DMPAPER_LETTER_ROTATED = 75,
-
-        /// <summary>
-        /// A3 Rotated 420 x 297 mm.
-        /// </summary>
-        DMPAPER_A3_ROTATED = 76,
-
-        /// <summary>
-        /// A4 Rotated 297 x 210 mm.
-        /// </summary>
-        DMPAPER_A4_ROTATED = 77,
-
-        /// <summary>
-        /// A5 Rotated 210 x 148 mm.
-        /// </summary>
-        DMPAPER_A5_ROTATED = 78,
-
-        /// <summary>
-        /// B4 (JIS) Rotated 364 x 257 mm.
-        /// </summary>
-        DMPAPER_B4_JIS_ROTATED = 79,
-
-        /// <summary>
-        /// B5 (JIS) Rotated 257 x 182 mm.
-        /// </summary>
-        DMPAPER_B5_JIS_ROTATED = 80,
-
-        /// <summary>
-        /// Japanese Postcard Rotated 148 x 100 mm.
-        /// </summary>
-        DMPAPER_JAPANESE_POSTCARD_ROTATED = 81,
-
-        /// <summary>
-        /// Double Japanese Postcard Rotated 148 x 200 mm.
-        /// </summary>
-        DMPAPER_DBL_JAPANESE_POSTCARD_ROTATED = 82,
-
-        /// <summary>
-        /// A6 Rotated 148 x 105 mm.
-        /// </summary>
-        DMPAPER_A6_ROTATED = 83,
-
-        /// <summary>
-        /// Japanese Envelope Kaku #2 Rotated.
-        /// </summary>
-        DMPAPER_JENV_KAKU2_ROTATED = 84,
-
-        /// <summary>
-        /// Japanese Envelope Kaku #3 Rotated.
-        /// </summary>
-        DMPAPER_JENV_KAKU3_ROTATED = 85,
-
-        /// <summary>
-        /// Japanese Envelope Chou #3 Rotated.
-        /// </summary>
-        DMPAPER_JENV_CHOU3_ROTATED = 86,
-
-        /// <summary>
-        /// Japanese Envelope Chou #4 Rotated.
-        /// </summary>
-        DMPAPER_JENV_CHOU4_ROTATED = 87,
-
-        /// <summary>
-        /// B6 (JIS) 128 x 182 mm.
-        /// </summary>
-        DMPAPER_B6_JIS = 88,
-
-        /// <summary>
-        /// B6 (JIS) Rotated 182 x 128 mm.
-        /// </summary>
-        DMPAPER_B6_JIS_ROTATED = 89,
-
-        /// <summary>
-        /// 12 x 11 in.
-        /// </summary>
-        DMPAPER_12X11 = 90,
-
-        /// <summary>
-        /// Japanese Envelope You #4.
-        /// </summary>
-        DMPAPER_JENV_YOU4 = 91,
-
-        /// <summary>
-        /// Japanese Envelope You #4 Rotated.
-        /// </summary>
-        DMPAPER_JENV_YOU4_ROTATED = 92,
-
-        /// <summary>
-        /// PRC 16K 146 x 215 mm.
-        /// </summary>
-        DMPAPER_P16K = 93,
-
-        /// <summary>
-        /// PRC 32K 97 x 151 mm.
-        /// </summary>
-        DMPAPER_P32K = 94,
-
-        /// <summary>
-        /// PRC 32K(Big) 97 x 151 mm.
-        /// </summary>
-        DMPAPER_P32KBIG = 95,
-
-        /// <summary>
-        /// PRC Envelope #1 102 x 165 mm.
-        /// </summary>
-        DMPAPER_PENV_1 = 96,
-
-        /// <summary>
-        /// PRC Envelope #2 102 x 176 mm.
-        /// </summary>
-        DMPAPER_PENV_2 = 97,
-
-        /// <summary>
-        /// PRC Envelope #3 125 x 176 mm.
-        /// </summary>
-        DMPAPER_PENV_3 = 98,
-
-        /// <summary>
-        /// PRC Envelope #4 110 x 208 mm.
-        /// </summary>
-        DMPAPER_PENV_4 = 99,
-
-        /// <summary>
-        /// PRC Envelope #5 110 x 220 mm.
-        /// </summary>
-        DMPAPER_PENV_5 = 100,
-
-        /// <summary>
-        /// PRC Envelope #6 120 x 230 mm.
-        /// </summary>
-        DMPAPER_PENV_6 = 101,
-
-        /// <summary>
-        /// PRC Envelope #7 160 x 230 mm.
-        /// </summary>
-        DMPAPER_PENV_7 = 102,
-
-        /// <summary>
-        /// PRC Envelope #8 120 x 309 mm.
-        /// </summary>
-        DMPAPER_PENV_8 = 103,
-
-        /// <summary>
-        /// PRC Envelope #9 229 x 324 mm.
-        /// </summary>
-        DMPAPER_PENV_9 = 104,
-
-        /// <summary>
-        /// PRC Envelope #10 324 x 458 mm.
-        /// </summary>
-        DMPAPER_PENV_10 = 105,
-
-        /// <summary>
-        /// PRC 16K Rotated.
-        /// </summary>
-        DMPAPER_P16K_ROTATED = 106,
-
-        /// <summary>
-        /// PRC 32K Rotated.
-        /// </summary>
-        DMPAPER_P32K_ROTATED = 107,
-
-        /// <summary>
-        /// PRC 32K(Big) Rotated.
-        /// </summary>
-        DMPAPER_P32KBIG_ROTATED = 108,
-
-        /// <summary>
-        /// PRC Envelope #1 Rotated 165 x 102 mm.
-        /// </summary>
-        DMPAPER_PENV_1_ROTATED = 109,
-
-        /// <summary>
-        /// PRC Envelope #2 Rotated 176 x 102 mm.
-        /// </summary>
-        DMPAPER_PENV_2_ROTATED = 110,
-
-        /// <summary>
-        /// PRC Envelope #3 Rotated 176 x 125 mm.
-        /// </summary>
-        DMPAPER_PENV_3_ROTATED = 111,
-
-        /// <summary>
-        /// PRC Envelope #4 Rotated 208 x 110 mm.
-        /// </summary>
-        DMPAPER_PENV_4_ROTATED = 112,
-
-        /// <summary>
-        /// PRC Envelope #5 Rotated 220 x 110 mm.
-        /// </summary>
-        DMPAPER_PENV_5_ROTATED = 113,
-
-        /// <summary>
-        /// PRC Envelope #6 Rotated 230 x 120 mm.
-        /// </summary>
-        DMPAPER_PENV_6_ROTATED = 114,
-
-        /// <summary>
-        /// PRC Envelope #7 Rotated 230 x 160 mm.
-        /// </summary>
-        DMPAPER_PENV_7_ROTATED = 115,
-
-        /// <summary>
-        /// PRC Envelope #8 Rotated 309 x 120 mm.
-        /// </summary>
-        DMPAPER_PENV_8_ROTATED = 116,
-
-        /// <summary>
-        /// PRC Envelope #9 Rotated 324 x 229 mm.
-        /// </summary>
-        DMPAPER_PENV_9_ROTATED = 117,
-
-        /// <summary>
-        /// PRC Envelope #10 Rotated 458 x 324 mm.
-        /// </summary>
-        DMPAPER_PENV_10_ROTATED = 118,
-
-        /// <summary>
-        /// DMPAPER_LAST.
-        /// </summary>
-        DMPAPER_LAST = DMPAPER_PENV_10_ROTATED,
-
-        /// <summary>
-        /// DMPAPER_USER.
-        /// </summary>
-        DMPAPER_USER = 256,
-    }
-
-    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmDefaultSource" /> member.</summary>
-    public enum DEVMODE_PrintBinSelectionOptions : short
-    {
-        DMBIN_FIRST = DMBIN_UPPER,
-        DMBIN_UPPER = 1,
-        DMBIN_ONLYONE = 1,
-        DMBIN_LOWER = 2,
-        DMBIN_MIDDLE = 3,
-        DMBIN_MANUAL = 4,
-        DMBIN_ENVELOPE = 5,
-        DMBIN_ENVMANUAL = 6,
-        DMBIN_AUTO = 7,
-        DMBIN_TRACTOR = 8,
-        DMBIN_SMALLFMT = 9,
-        DMBIN_LARGEFMT = 10,
-        DMBIN_LARGECAPACITY = 11,
-        DMBIN_CASSETTE = 14,
-        DMBIN_FORMSOURCE = 15,
-        DMBIN_LAST = DMBIN_FORMSOURCE,
-
-        DMBIN_USER = 256,    /* device specific bins start here */
-    }
-
-    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmPrintQuality" /> member.</summary>
-    public enum DEVMODE_PrintQualityOptions : short
-    {
-        DMRES_HIGH = -4,
-        DMRES_MEDIUM = -3,
-        DMRES_LOW = -2,
-        DMRES_DRAFT = -1,
-    }
-
-    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmDisplayOrientation" /> member.</summary>
-    public enum DEVMODE_DisplayOrientationOptions : uint
-    {
-        /// <summary>
-        /// The current mode's display device orientation is the natural orientation of the device, and should be used as the default.
-        /// </summary>
-        DMDO_DEFAULT = 0,
-
-        /// <summary>
-        /// The display device orientation is 90 degrees (measured clockwise) from that of <see cref="DMDO_DEFAULT"/>.
-        /// </summary>
-        DMDO_90 = 1,
-
-        /// <summary>
-        /// The display device orientation is 180 degrees (measured clockwise) from that of <see cref="DMDO_DEFAULT"/>.
-        /// </summary>
-        DMDO_180 = 2,
-
-        /// <summary>
-        /// The display device orientation is 270 degrees (measured clockwise) from that of <see cref="DMDO_DEFAULT"/>.
-        /// </summary>
-        DMDO_270 = 3,
-    }
-
-    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmDisplayFixedOutput" /> member.</summary>
-    public enum DEVMODE_DisplayFixedOutputOptions : uint
-    {
-        /// <summary>
-        /// The display's default setting.
-        /// </summary>
-        DMDFO_DEFAULT = 0,
-
-        /// <summary>
-        /// The display device presents a lower-resolution mode image by stretching it to fill the larger screen space.
-        /// </summary>
-        DMDFO_STRETCH = 1,
-
-        /// <summary>
-        /// The display device presents a lower resolution mode image by centering it in the larger screen space.
-        /// </summary>
-        DMDFO_CENTER = 2,
-    }
-
-    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmColor" /> member.</summary>
-    public enum DEVMODE_PrintColorOptions : short
-    {
-        DMCOLOR_MONOCHROME = 1,
-        DMCOLOR_COLOR = 2,
-    }
-
-    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmDuplex" /> member.</summary>
-    public enum DEVMODE_PrintDuplexOptions : short
-    {
-        /// <summary>
-        /// Print single-sided.
-        /// </summary>
-        DMDUP_SIMPLEX = 1,
-
-        /// <summary>
-        /// Print double-sided, using long edge binding.
-        /// </summary>
-        DMDUP_VERTICAL = 2,
-
-        /// <summary>
-        /// Print double-sided, using short edge binding.
-        /// </summary>
-        DMDUP_HORIZONTAL = 3,
-    }
-
-    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmTTOption" /> member.</summary>
-    public enum DEVMODE_TrueTypeOptions : short
-    {
-        /// <summary>
-        /// Print TT fonts as graphics.
-        /// </summary>
-        DMTT_BITMAP = 1,
-
-        /// <summary>
-        /// Download TT fonts as soft fonts.
-        /// </summary>
-        DMTT_DOWNLOAD = 2,
-
-        /// <summary>
-        /// Substitute device fonts for TT fonts.
-        /// </summary>
-        DMTT_SUBDEV = 3,
-
-        // #if (WINVER >= 0x0400)
-
-        /// <summary>
-        /// Download TT fonts as outline soft fonts.
-        /// </summary>
-        DMTT_DOWNLOAD_OUTLINE = 4,
-    }
-
-    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmCollate" /> member.</summary>
-    public enum DEVMODE_CollationSelectionOptions : short
-    {
-        /// <summary>
-        /// Do not collate when printing multiple copies.
-        /// </summary>
-        DMCOLLATE_FALSE = 0,
-
-        /// <summary>
-        /// Collate when printing multiple copies.
-        /// </summary>
-        DMCOLLATE_TRUE = 1,
-    }
-
-    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmDisplayFlags" /> member.</summary>
-    [Flags]
-    public enum DEVMODE_DisplayOptions : uint
-    {
-        /// <summary>
-        /// Not set.
-        /// </summary>
-        NONE = 0x00000000,
-
-        /// <summary>
-        /// Specifies that the display is a noncolor device.
-        /// If this flag is not set, color is assumed.
-        /// </summary>
-        DM_INTERLACED = 0x00000002,
-
-        /// <summary>
-        /// Specifies that the display mode is interlaced.
-        /// If the flag is not set, noninterlaced is assumed.
-        /// </summary>
-        DMDISPLAYFLAGS_TEXTMODE = 0x00000004,
-    }
-
-    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmNup" /> member.</summary>
-    public enum DEVMODE_PrinterOptions : uint
-    {
-        /// <summary>
-        /// The print system handles "N-up" printing.
-        /// </summary>
-        DMNUP_SYSTEM = 1,
-
-        /// <summary>
-        /// The print system does not handle "N-up" printing. An application can set <see cref="DEVMODE.dmNup"/> to <see cref="DMNUP_ONEUP"/> if it intends to carry out "N-up" printing on its own.
-        /// </summary>
-        DMNUP_ONEUP = 2,
-    }
-
-    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmICMMethod" /> member.</summary>
-    public enum DEVMODE_DeviceIcmMethodOptions : uint
-    {
-        /// <summary>
-        /// ICM disabled.
-        /// </summary>
-        DMICMMETHOD_NONE = 1,
-
-        /// <summary>
-        /// ICM handled by system.
-        /// </summary>
-        DMICMMETHOD_SYSTEM = 2,
-
-        /// <summary>
-        /// ICM handled by driver.
-        /// </summary>
-        DMICMMETHOD_DRIVER = 3,
-
-        /// <summary>
-        /// ICM handled by device.
-        /// </summary>
-        DMICMMETHOD_DEVICE = 4,
-
-        /// <summary>
-        /// Device-specific methods start here.
-        /// </summary>
-        DMICMMETHOD_USER = 256,
-    }
-
-    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmICMIntent" /> member.</summary>
-    public enum DEVMODE_DeviceIcmIntentOptions : uint
-    {
-        /// <summary>
-        /// Maximize color saturation.
-        /// </summary>
-        DMICM_SATURATE = 1,
-
-        /// <summary>
-        /// Maximize color contrast.
-        /// </summary>
-        DMICM_CONTRAST = 2,
-
-        /// <summary>
-        /// Use specific color metric.
-        /// </summary>
-        DMICM_COLORIMETRIC = 3,
-
-        /// <summary>
-        /// Use specific color metric.
-        /// </summary>
-        DMICM_ABS_COLORIMETRIC = 4,
-
-        /// <summary>
-        /// Device-specific intents start here.
-        /// </summary>
-        DMICM_USER = 256,
-    }
-
-    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmMediaType" /> member.</summary>
-    public enum DEVMODE_DeviceMediaTypeOptions : uint
-    {
-        /// <summary>
-        /// Standard paper.
-        /// </summary>
-        DMMEDIA_STANDARD = 1,
-
-        /// <summary>
-        /// Transparency.
-        /// </summary>
-        DMMEDIA_TRANSPARENCY = 2,
-
-        /// <summary>
-        /// Glossy paper.
-        /// </summary>
-        DMMEDIA_GLOSSY = 3,
-
-        /// <summary>
-        /// Device-specific media start here.
-        /// </summary>
-        DMMEDIA_USER = 256,
-    }
-
-    /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmDitherType" /> member.</summary>
-    public enum DEVMODE_DitherTypeOptions : uint
-    {
-        /// <summary>
-        /// No dithering.
-        /// </summary>
-        DMDITHER_NONE = 1,
-
-        /// <summary>
-        /// Dither with a coarse brush.
-        /// </summary>
-        DMDITHER_COARSE = 2,
-
-        /// <summary>
-        /// Dither with a fine brush.
-        /// </summary>
-        DMDITHER_FINE = 3,
-
-        /// <summary>
-        /// LineArt dithering.
-        /// </summary>
-        DMDITHER_LINEART = 4,
-
-        /// <summary>
-        /// LineArt dithering.
-        /// </summary>
-        DMDITHER_ERRORDIFFUSION = 5,
-
-        /// <summary>
-        /// LineArt dithering.
-        /// </summary>
-        DMDITHER_RESERVED6 = 6,
-
-        /// <summary>
-        /// LineArt dithering.
-        /// </summary>
-        DMDITHER_RESERVED7 = 7,
-
-        /// <summary>
-        /// LineArt dithering.
-        /// </summary>
-        DMDITHER_RESERVED8 = 8,
-
-        /// <summary>
-        /// LineArt dithering.
-        /// </summary>
-        DMDITHER_RESERVED9 = 9,
-
-        /// <summary>
-        /// Device does grayscaling.
-        /// </summary>
-        DMDITHER_GRAYSCALE = 10,
-
-        /// <summary>
-        /// Device-specific dithers start here.
-        /// </summary>
-        DMDITHER_USER = 256,
+
+        /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmFields" /> member.</summary>
+        [Flags]
+        [SuppressMessage("Compiler", "SA1201:Elements should appear in the correct order", Justification = "Special")]
+        public enum FieldUseFlags : uint
+        {
+            /// <summary>
+            /// Not set.
+            /// </summary>
+            NONE = 0,
+            DM_ORIENTATION = 0x00000001,
+            DM_PAPERSIZE = 0x00000002,
+            DM_PAPERLENGTH = 0x00000004,
+            DM_PAPERWIDTH = 0x00000008,
+            DM_SCALE = 0x00000010,
+
+            // #if (WINVER >= 0x0500)
+            DM_POSITION = 0x00000020,
+            DM_NUP = 0x00000040,
+
+            // #endif /* WINVER >= 0x0500 */
+
+            // #if (WINVER >= 0x0501)
+            DM_DISPLAYORIENTATION = 0x00000080,
+
+            // #endif /* WINVER >= 0x0501 */
+            DM_COPIES = 0x00000100,
+            DM_DEFAULTSOURCE = 0x00000200,
+            DM_PRINTQUALITY = 0x00000400,
+            DM_COLOR = 0x00000800,
+            DM_DUPLEX = 0x00001000,
+            DM_YRESOLUTION = 0x00002000,
+            DM_TTOPTION = 0x00004000,
+            DM_COLLATE = 0x00008000,
+            DM_FORMNAME = 0x00010000,
+            DM_LOGPIXELS = 0x00020000,
+            DM_BITSPERPEL = 0x00040000,
+            DM_PELSWIDTH = 0x00080000,
+            DM_PELSHEIGHT = 0x00100000,
+            DM_DISPLAYFLAGS = 0x00200000,
+            DM_DISPLAYFREQUENCY = 0x00400000,
+
+            // #if (WINVER >= 0x0400)
+            DM_ICMMETHOD = 0x00800000,
+            DM_ICMINTENT = 0x01000000,
+            DM_MEDIATYPE = 0x02000000,
+            DM_DITHERTYPE = 0x04000000,
+            DM_PANNINGWIDTH = 0x08000000,
+            DM_PANNINGHEIGHT = 0x10000000,
+
+            // #endif /* WINVER >= 0x0400 */
+
+            // #if (WINVER >= 0x0501)
+            DM_DISPLAYFIXEDOUTPUT = 0x20000000,
+        }
+
+        /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmOrientation" /> member.</summary>
+        public enum PrinterOrientationOptions : short
+        {
+            DMORIENT_PORTRAIT = 1,
+            DMORIENT_LANDSCAPE = 2,
+        }
+
+        /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmPaperSize" /> member.</summary>
+        public enum PrintPaperOptions : short
+        {
+            /// <summary>
+            ///  If the length and width of the paper are both set by the <see cref="DEVMODE.dmPaperLength"/> and <see cref="DEVMODE.dmPaperWidth"/> members.
+            /// </summary>
+            NONE = 0,
+
+            /// <summary>
+            /// DMPAPER_FIRST.
+            /// </summary>
+            DMPAPER_FIRST = DMPAPER_LETTER,
+
+            /// <summary>
+            /// Letter 8 1/2 x 11 in.
+            /// </summary>
+            DMPAPER_LETTER = 1,
+
+            /// <summary>
+            /// Letter Small 8 1/2 x 11 in.
+            /// </summary>
+            DMPAPER_LETTERSMALL = 2,
+
+            /// <summary>
+            /// Tabloid 11 x 17 in.
+            /// </summary>
+            DMPAPER_TABLOID = 3,
+
+            /// <summary>
+            /// Ledger 17 x 11 in.
+            /// </summary>
+            DMPAPER_LEDGER = 4,
+
+            /// <summary>
+            /// Legal 8 1/2 x 14 in.
+            /// </summary>
+            DMPAPER_LEGAL = 5,
+
+            /// <summary>
+            /// Statement 5 1/2 x 8 1/2 in.
+            /// </summary>
+            DMPAPER_STATEMENT = 6,
+
+            /// <summary>
+            /// Executive 7 1/4 x 10 1/2 in.
+            /// </summary>
+            DMPAPER_EXECUTIVE = 7,
+
+            /// <summary>
+            /// A3 297 x 420 mm.
+            /// </summary>
+            DMPAPER_A3 = 8,
+
+            /// <summary>
+            /// A4 210 x 297 mm.
+            /// </summary>
+            DMPAPER_A4 = 9,
+
+            /// <summary>
+            /// A4 Small 210 x 297 mm.
+            /// </summary>
+            DMPAPER_A4SMALL = 10,
+
+            /// <summary>
+            /// A5 148 x 210 mm.
+            /// </summary>
+            DMPAPER_A5 = 11,
+
+            /// <summary>
+            /// B4 (JIS) 250 x 354.
+            /// </summary>
+            DMPAPER_B4 = 12,
+
+            /// <summary>
+            /// B5 (JIS) 182 x 257 mm.
+            /// </summary>
+            DMPAPER_B5 = 13,
+
+            /// <summary>
+            /// Folio 8 1/2 x 13 in.
+            /// </summary>
+            DMPAPER_FOLIO = 14,
+
+            /// <summary>
+            /// Quarto 215 x 275 mm.
+            /// </summary>
+            DMPAPER_QUARTO = 15,
+
+            /// <summary>
+            /// 10x14 in.
+            /// </summary>
+            DMPAPER_10X14 = 16,
+
+            /// <summary>
+            /// 11x17 in.
+            /// </summary>
+            DMPAPER_11X17 = 17,
+
+            /// <summary>
+            /// Note 8 1/2 x 11 in.
+            /// </summary>
+            DMPAPER_NOTE = 18,
+
+            /// <summary>
+            /// Envelope #9 3 7/8 x 8 7/8.
+            /// </summary>
+            DMPAPER_ENV_9 = 19,
+
+            /// <summary>
+            /// Envelope #10 4 1/8 x 9 1/2.
+            /// </summary>
+            DMPAPER_ENV_10 = 20,
+
+            /// <summary>
+            /// Envelope #11 4 1/2 x 10 3/8.
+            /// </summary>
+            DMPAPER_ENV_11 = 21,
+
+            /// <summary>
+            /// Envelope #12 4 \276 x 11.
+            /// </summary>
+            DMPAPER_ENV_12 = 22,
+
+            /// <summary>
+            /// Envelope #14 5 x 11 1/2.
+            /// </summary>
+            DMPAPER_ENV_14 = 23,
+
+            /// <summary>
+            /// C size sheet.
+            /// </summary>
+            DMPAPER_CSHEET = 24,
+
+            /// <summary>
+            /// D size sheet.
+            /// </summary>
+            DMPAPER_DSHEET = 25,
+
+            /// <summary>
+            /// E size sheet.
+            /// </summary>
+            DMPAPER_ESHEET = 26,
+
+            /// <summary>
+            /// Envelope DL 110 x 220mm.
+            /// </summary>
+            DMPAPER_ENV_DL = 27,
+
+            /// <summary>
+            /// Envelope C5 162 x 229 mm.
+            /// </summary>
+            DMPAPER_ENV_C5 = 28,
+
+            /// <summary>
+            /// Envelope C3  324 x 458 mm.
+            /// </summary>
+            DMPAPER_ENV_C3 = 29,
+
+            /// <summary>
+            /// Envelope C4  229 x 324 mm.
+            /// </summary>
+            DMPAPER_ENV_C4 = 30,
+
+            /// <summary>
+            /// Envelope C6  114 x 162 mm.
+            /// </summary>
+            DMPAPER_ENV_C6 = 31,
+
+            /// <summary>
+            /// Envelope C65 114 x 229 mm.
+            /// </summary>
+            DMPAPER_ENV_C65 = 32,
+
+            /// <summary>
+            /// Envelope B4  250 x 353 mm.
+            /// </summary>
+            DMPAPER_ENV_B4 = 33,
+
+            /// <summary>
+            /// Envelope B5  176 x 250 mm.
+            /// </summary>
+            DMPAPER_ENV_B5 = 34,
+
+            /// <summary>
+            /// Envelope B6  176 x 125 mm.
+            /// </summary>
+            DMPAPER_ENV_B6 = 35,
+
+            /// <summary>
+            /// Envelope 110 x 230 mm.
+            /// </summary>
+            DMPAPER_ENV_ITALY = 36,
+
+            /// <summary>
+            /// Envelope Monarch 3.875 x 7.5 in.
+            /// </summary>
+            DMPAPER_ENV_MONARCH = 37,
+
+            /// <summary>
+            /// 6 3/4 Envelope 3 5/8 x 6 1/2 in.
+            /// </summary>
+            DMPAPER_ENV_PERSONAL = 38,
+
+            /// <summary>
+            /// US Std Fanfold 14 7/8 x 11 in.
+            /// </summary>
+            DMPAPER_FANFOLD_US = 39,
+
+            /// <summary>
+            /// German Std Fanfold 8 1/2 x 12 in.
+            /// </summary>
+            DMPAPER_FANFOLD_STD_GERMAN = 40,
+
+            /// <summary>
+            /// German Legal Fanfold 8 1/2 x 13 in.
+            /// </summary>
+            DMPAPER_FANFOLD_LGL_GERMAN = 41,
+
+            /// <summary>
+            /// B4 (ISO) 250 x 353 mm.
+            /// </summary>
+            DMPAPER_ISO_B4 = 42,
+
+            /// <summary>
+            /// Japanese Postcard 100 x 148 mm.
+            /// </summary>
+            DMPAPER_JAPANESE_POSTCARD = 43,
+
+            /// <summary>
+            /// 9 x 11 in.
+            /// </summary>
+            DMPAPER_9X11 = 44,
+
+            /// <summary>
+            /// 10 x 11 in.
+            /// </summary>
+            DMPAPER_10X11 = 45,
+
+            /// <summary>
+            /// 15 x 11 in.
+            /// </summary>
+            DMPAPER_15X11 = 46,
+
+            /// <summary>
+            /// Envelope Invite 220 x 220 mm.
+            /// </summary>
+            DMPAPER_ENV_INVITE = 47,
+
+            /// <summary>
+            /// RESERVED--DO NOT USE.
+            /// </summary>
+            DMPAPER_RESERVED_48 = 48,
+
+            /// <summary>
+            /// RESERVED--DO NOT USE.
+            /// </summary>
+            DMPAPER_RESERVED_49 = 49,
+
+            /// <summary>
+            /// Letter Extra 9 \275 x 12 in.
+            /// </summary>
+            DMPAPER_LETTER_EXTRA = 50,
+
+            /// <summary>
+            /// Legal Extra 9 \275 x 15 in.
+            /// </summary>
+            DMPAPER_LEGAL_EXTRA = 51,
+
+            /// <summary>
+            /// Tabloid Extra 11.69 x 18 in.
+            /// </summary>
+            DMPAPER_TABLOID_EXTRA = 52,
+
+            /// <summary>
+            /// A4 Extra 9.27 x 12.69 in.
+            /// </summary>
+            DMPAPER_A4_EXTRA = 53,
+
+            /// <summary>
+            /// Letter Transverse 8 \275 x 11 in.
+            /// </summary>
+            DMPAPER_LETTER_TRANSVERSE = 54,
+
+            /// <summary>
+            /// A4 Transverse 210 x 297 mm.
+            /// </summary>
+            DMPAPER_A4_TRANSVERSE = 55,
+
+            /// <summary>
+            /// Letter Extra Transverse 9\275 x 12 in.
+            /// </summary>
+            DMPAPER_LETTER_EXTRA_TRANSVERSE = 56,
+
+            /// <summary>
+            /// SuperA/SuperA/A4 227 x 356 mm.
+            /// </summary>
+            DMPAPER_A_PLUS = 57,
+
+            /// <summary>
+            /// SuperB/SuperB/A3 305 x 487 mm.
+            /// </summary>
+            DMPAPER_B_PLUS = 58,
+
+            /// <summary>
+            /// Letter Plus 8.5 x 12.69 in.
+            /// </summary>
+            DMPAPER_LETTER_PLUS = 59,
+
+            /// <summary>
+            /// A4 Plus 210 x 330 mm.
+            /// </summary>
+            DMPAPER_A4_PLUS = 60,
+
+            /// <summary>
+            /// A5 Transverse 148 x 210 mm.
+            /// </summary>
+            DMPAPER_A5_TRANSVERSE = 61,
+
+            /// <summary>
+            /// B5 (JIS) Transverse 182 x 257 mm.
+            /// </summary>
+            DMPAPER_B5_TRANSVERSE = 62,
+
+            /// <summary>
+            /// A3 Extra 322 x 445 mm.
+            /// </summary>
+            DMPAPER_A3_EXTRA = 63,
+
+            /// <summary>
+            /// A5 Extra 174 x 235 mm.
+            /// </summary>
+            DMPAPER_A5_EXTRA = 64,
+
+            /// <summary>
+            /// B5 (ISO) Extra 201 x 276 mm.
+            /// </summary>
+            DMPAPER_B5_EXTRA = 65,
+
+            /// <summary>
+            /// A2 420 x 594 mm.
+            /// </summary>
+            DMPAPER_A2 = 66,
+
+            /// <summary>
+            /// A3 Transverse 297 x 420 mm.
+            /// </summary>
+            DMPAPER_A3_TRANSVERSE = 67,
+
+            /// <summary>
+            /// A3 Extra Transverse 322 x 445 mm.
+            /// </summary>
+            DMPAPER_A3_EXTRA_TRANSVERSE = 68,
+
+            /// <summary>
+            /// Japanese Double Postcard 200 x 148 mm.
+            /// </summary>
+            DMPAPER_DBL_JAPANESE_POSTCARD = 69,
+
+            /// <summary>
+            /// A6 105 x 148 mm.
+            /// </summary>
+            DMPAPER_A6 = 70,
+
+            /// <summary>
+            /// Japanese Envelope Kaku #2.
+            /// </summary>
+            DMPAPER_JENV_KAKU2 = 71,
+
+            /// <summary>
+            /// Japanese Envelope Kaku #3.
+            /// </summary>
+            DMPAPER_JENV_KAKU3 = 72,
+
+            /// <summary>
+            /// Japanese Envelope Chou #3.
+            /// </summary>
+            DMPAPER_JENV_CHOU3 = 73,
+
+            /// <summary>
+            /// Japanese Envelope Chou #4.
+            /// </summary>
+            DMPAPER_JENV_CHOU4 = 74,
+
+            /// <summary>
+            /// Letter Rotated 11 x 8 1/2 11 in.
+            /// </summary>
+            DMPAPER_LETTER_ROTATED = 75,
+
+            /// <summary>
+            /// A3 Rotated 420 x 297 mm.
+            /// </summary>
+            DMPAPER_A3_ROTATED = 76,
+
+            /// <summary>
+            /// A4 Rotated 297 x 210 mm.
+            /// </summary>
+            DMPAPER_A4_ROTATED = 77,
+
+            /// <summary>
+            /// A5 Rotated 210 x 148 mm.
+            /// </summary>
+            DMPAPER_A5_ROTATED = 78,
+
+            /// <summary>
+            /// B4 (JIS) Rotated 364 x 257 mm.
+            /// </summary>
+            DMPAPER_B4_JIS_ROTATED = 79,
+
+            /// <summary>
+            /// B5 (JIS) Rotated 257 x 182 mm.
+            /// </summary>
+            DMPAPER_B5_JIS_ROTATED = 80,
+
+            /// <summary>
+            /// Japanese Postcard Rotated 148 x 100 mm.
+            /// </summary>
+            DMPAPER_JAPANESE_POSTCARD_ROTATED = 81,
+
+            /// <summary>
+            /// Double Japanese Postcard Rotated 148 x 200 mm.
+            /// </summary>
+            DMPAPER_DBL_JAPANESE_POSTCARD_ROTATED = 82,
+
+            /// <summary>
+            /// A6 Rotated 148 x 105 mm.
+            /// </summary>
+            DMPAPER_A6_ROTATED = 83,
+
+            /// <summary>
+            /// Japanese Envelope Kaku #2 Rotated.
+            /// </summary>
+            DMPAPER_JENV_KAKU2_ROTATED = 84,
+
+            /// <summary>
+            /// Japanese Envelope Kaku #3 Rotated.
+            /// </summary>
+            DMPAPER_JENV_KAKU3_ROTATED = 85,
+
+            /// <summary>
+            /// Japanese Envelope Chou #3 Rotated.
+            /// </summary>
+            DMPAPER_JENV_CHOU3_ROTATED = 86,
+
+            /// <summary>
+            /// Japanese Envelope Chou #4 Rotated.
+            /// </summary>
+            DMPAPER_JENV_CHOU4_ROTATED = 87,
+
+            /// <summary>
+            /// B6 (JIS) 128 x 182 mm.
+            /// </summary>
+            DMPAPER_B6_JIS = 88,
+
+            /// <summary>
+            /// B6 (JIS) Rotated 182 x 128 mm.
+            /// </summary>
+            DMPAPER_B6_JIS_ROTATED = 89,
+
+            /// <summary>
+            /// 12 x 11 in.
+            /// </summary>
+            DMPAPER_12X11 = 90,
+
+            /// <summary>
+            /// Japanese Envelope You #4.
+            /// </summary>
+            DMPAPER_JENV_YOU4 = 91,
+
+            /// <summary>
+            /// Japanese Envelope You #4 Rotated.
+            /// </summary>
+            DMPAPER_JENV_YOU4_ROTATED = 92,
+
+            /// <summary>
+            /// PRC 16K 146 x 215 mm.
+            /// </summary>
+            DMPAPER_P16K = 93,
+
+            /// <summary>
+            /// PRC 32K 97 x 151 mm.
+            /// </summary>
+            DMPAPER_P32K = 94,
+
+            /// <summary>
+            /// PRC 32K(Big) 97 x 151 mm.
+            /// </summary>
+            DMPAPER_P32KBIG = 95,
+
+            /// <summary>
+            /// PRC Envelope #1 102 x 165 mm.
+            /// </summary>
+            DMPAPER_PENV_1 = 96,
+
+            /// <summary>
+            /// PRC Envelope #2 102 x 176 mm.
+            /// </summary>
+            DMPAPER_PENV_2 = 97,
+
+            /// <summary>
+            /// PRC Envelope #3 125 x 176 mm.
+            /// </summary>
+            DMPAPER_PENV_3 = 98,
+
+            /// <summary>
+            /// PRC Envelope #4 110 x 208 mm.
+            /// </summary>
+            DMPAPER_PENV_4 = 99,
+
+            /// <summary>
+            /// PRC Envelope #5 110 x 220 mm.
+            /// </summary>
+            DMPAPER_PENV_5 = 100,
+
+            /// <summary>
+            /// PRC Envelope #6 120 x 230 mm.
+            /// </summary>
+            DMPAPER_PENV_6 = 101,
+
+            /// <summary>
+            /// PRC Envelope #7 160 x 230 mm.
+            /// </summary>
+            DMPAPER_PENV_7 = 102,
+
+            /// <summary>
+            /// PRC Envelope #8 120 x 309 mm.
+            /// </summary>
+            DMPAPER_PENV_8 = 103,
+
+            /// <summary>
+            /// PRC Envelope #9 229 x 324 mm.
+            /// </summary>
+            DMPAPER_PENV_9 = 104,
+
+            /// <summary>
+            /// PRC Envelope #10 324 x 458 mm.
+            /// </summary>
+            DMPAPER_PENV_10 = 105,
+
+            /// <summary>
+            /// PRC 16K Rotated.
+            /// </summary>
+            DMPAPER_P16K_ROTATED = 106,
+
+            /// <summary>
+            /// PRC 32K Rotated.
+            /// </summary>
+            DMPAPER_P32K_ROTATED = 107,
+
+            /// <summary>
+            /// PRC 32K(Big) Rotated.
+            /// </summary>
+            DMPAPER_P32KBIG_ROTATED = 108,
+
+            /// <summary>
+            /// PRC Envelope #1 Rotated 165 x 102 mm.
+            /// </summary>
+            DMPAPER_PENV_1_ROTATED = 109,
+
+            /// <summary>
+            /// PRC Envelope #2 Rotated 176 x 102 mm.
+            /// </summary>
+            DMPAPER_PENV_2_ROTATED = 110,
+
+            /// <summary>
+            /// PRC Envelope #3 Rotated 176 x 125 mm.
+            /// </summary>
+            DMPAPER_PENV_3_ROTATED = 111,
+
+            /// <summary>
+            /// PRC Envelope #4 Rotated 208 x 110 mm.
+            /// </summary>
+            DMPAPER_PENV_4_ROTATED = 112,
+
+            /// <summary>
+            /// PRC Envelope #5 Rotated 220 x 110 mm.
+            /// </summary>
+            DMPAPER_PENV_5_ROTATED = 113,
+
+            /// <summary>
+            /// PRC Envelope #6 Rotated 230 x 120 mm.
+            /// </summary>
+            DMPAPER_PENV_6_ROTATED = 114,
+
+            /// <summary>
+            /// PRC Envelope #7 Rotated 230 x 160 mm.
+            /// </summary>
+            DMPAPER_PENV_7_ROTATED = 115,
+
+            /// <summary>
+            /// PRC Envelope #8 Rotated 309 x 120 mm.
+            /// </summary>
+            DMPAPER_PENV_8_ROTATED = 116,
+
+            /// <summary>
+            /// PRC Envelope #9 Rotated 324 x 229 mm.
+            /// </summary>
+            DMPAPER_PENV_9_ROTATED = 117,
+
+            /// <summary>
+            /// PRC Envelope #10 Rotated 458 x 324 mm.
+            /// </summary>
+            DMPAPER_PENV_10_ROTATED = 118,
+
+            /// <summary>
+            /// DMPAPER_LAST.
+            /// </summary>
+            DMPAPER_LAST = DMPAPER_PENV_10_ROTATED,
+
+            /// <summary>
+            /// DMPAPER_USER.
+            /// </summary>
+            DMPAPER_USER = 256,
+        }
+
+        /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmDefaultSource" /> member.</summary>
+        public enum PrintBinSelectionOptions : short
+        {
+            DMBIN_FIRST = DMBIN_UPPER,
+            DMBIN_UPPER = 1,
+            DMBIN_ONLYONE = 1,
+            DMBIN_LOWER = 2,
+            DMBIN_MIDDLE = 3,
+            DMBIN_MANUAL = 4,
+            DMBIN_ENVELOPE = 5,
+            DMBIN_ENVMANUAL = 6,
+            DMBIN_AUTO = 7,
+            DMBIN_TRACTOR = 8,
+            DMBIN_SMALLFMT = 9,
+            DMBIN_LARGEFMT = 10,
+            DMBIN_LARGECAPACITY = 11,
+            DMBIN_CASSETTE = 14,
+            DMBIN_FORMSOURCE = 15,
+            DMBIN_LAST = DMBIN_FORMSOURCE,
+
+            DMBIN_USER = 256,    /* device specific bins start here */
+        }
+
+        /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmPrintQuality" /> member.</summary>
+        public enum PrintQualityOptions : short
+        {
+            DMRES_HIGH = -4,
+            DMRES_MEDIUM = -3,
+            DMRES_LOW = -2,
+            DMRES_DRAFT = -1,
+        }
+
+        /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmDisplayOrientation" /> member.</summary>
+        public enum DisplayOrientationOptions : uint
+        {
+            /// <summary>
+            /// The current mode's display device orientation is the natural orientation of the device, and should be used as the default.
+            /// </summary>
+            DMDO_DEFAULT = 0,
+
+            /// <summary>
+            /// The display device orientation is 90 degrees (measured clockwise) from that of <see cref="DMDO_DEFAULT"/>.
+            /// </summary>
+            DMDO_90 = 1,
+
+            /// <summary>
+            /// The display device orientation is 180 degrees (measured clockwise) from that of <see cref="DMDO_DEFAULT"/>.
+            /// </summary>
+            DMDO_180 = 2,
+
+            /// <summary>
+            /// The display device orientation is 270 degrees (measured clockwise) from that of <see cref="DMDO_DEFAULT"/>.
+            /// </summary>
+            DMDO_270 = 3,
+        }
+
+        /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmDisplayFixedOutput" /> member.</summary>
+        public enum DisplayFixedOutputOptions : uint
+        {
+            /// <summary>
+            /// The display's default setting.
+            /// </summary>
+            DMDFO_DEFAULT = 0,
+
+            /// <summary>
+            /// The display device presents a lower-resolution mode image by stretching it to fill the larger screen space.
+            /// </summary>
+            DMDFO_STRETCH = 1,
+
+            /// <summary>
+            /// The display device presents a lower resolution mode image by centering it in the larger screen space.
+            /// </summary>
+            DMDFO_CENTER = 2,
+        }
+
+        /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmColor" /> member.</summary>
+        public enum PrintColorOptions : short
+        {
+            DMCOLOR_MONOCHROME = 1,
+            DMCOLOR_COLOR = 2,
+        }
+
+        /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmDuplex" /> member.</summary>
+        public enum PrintDuplexOptions : short
+        {
+            /// <summary>
+            /// Print single-sided.
+            /// </summary>
+            DMDUP_SIMPLEX = 1,
+
+            /// <summary>
+            /// Print double-sided, using long edge binding.
+            /// </summary>
+            DMDUP_VERTICAL = 2,
+
+            /// <summary>
+            /// Print double-sided, using short edge binding.
+            /// </summary>
+            DMDUP_HORIZONTAL = 3,
+        }
+
+        /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmTTOption" /> member.</summary>
+        public enum TrueTypeOptions : short
+        {
+            /// <summary>
+            /// Print TT fonts as graphics.
+            /// </summary>
+            DMTT_BITMAP = 1,
+
+            /// <summary>
+            /// Download TT fonts as soft fonts.
+            /// </summary>
+            DMTT_DOWNLOAD = 2,
+
+            /// <summary>
+            /// Substitute device fonts for TT fonts.
+            /// </summary>
+            DMTT_SUBDEV = 3,
+
+            // #if (WINVER >= 0x0400)
+
+            /// <summary>
+            /// Download TT fonts as outline soft fonts.
+            /// </summary>
+            DMTT_DOWNLOAD_OUTLINE = 4,
+        }
+
+        /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmCollate" /> member.</summary>
+        public enum CollationSelectionOptions : short
+        {
+            /// <summary>
+            /// Do not collate when printing multiple copies.
+            /// </summary>
+            DMCOLLATE_FALSE = 0,
+
+            /// <summary>
+            /// Collate when printing multiple copies.
+            /// </summary>
+            DMCOLLATE_TRUE = 1,
+        }
+
+        /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmDisplayFlags" /> member.</summary>
+        [Flags]
+        public enum DisplayOptions : uint
+        {
+            /// <summary>
+            /// Not set.
+            /// </summary>
+            NONE = 0x00000000,
+
+            /// <summary>
+            /// Specifies that the display is a noncolor device.
+            /// If this flag is not set, color is assumed.
+            /// </summary>
+            DM_INTERLACED = 0x00000002,
+
+            /// <summary>
+            /// Specifies that the display mode is interlaced.
+            /// If the flag is not set, noninterlaced is assumed.
+            /// </summary>
+            DMDISPLAYFLAGS_TEXTMODE = 0x00000004,
+        }
+
+        /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmNup" /> member.</summary>
+        public enum PrinterOptions : uint
+        {
+            /// <summary>
+            /// The print system handles "N-up" printing.
+            /// </summary>
+            DMNUP_SYSTEM = 1,
+
+            /// <summary>
+            /// The print system does not handle "N-up" printing. An application can set <see cref="DEVMODE.dmNup"/> to <see cref="DMNUP_ONEUP"/> if it intends to carry out "N-up" printing on its own.
+            /// </summary>
+            DMNUP_ONEUP = 2,
+        }
+
+        /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmICMMethod" /> member.</summary>
+        public enum DeviceIcmMethodOptions : uint
+        {
+            /// <summary>
+            /// ICM disabled.
+            /// </summary>
+            DMICMMETHOD_NONE = 1,
+
+            /// <summary>
+            /// ICM handled by system.
+            /// </summary>
+            DMICMMETHOD_SYSTEM = 2,
+
+            /// <summary>
+            /// ICM handled by driver.
+            /// </summary>
+            DMICMMETHOD_DRIVER = 3,
+
+            /// <summary>
+            /// ICM handled by device.
+            /// </summary>
+            DMICMMETHOD_DEVICE = 4,
+
+            /// <summary>
+            /// Device-specific methods start here.
+            /// </summary>
+            DMICMMETHOD_USER = 256,
+        }
+
+        /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmICMIntent" /> member.</summary>
+        public enum DeviceIcmIntentOptions : uint
+        {
+            /// <summary>
+            /// Maximize color saturation.
+            /// </summary>
+            DMICM_SATURATE = 1,
+
+            /// <summary>
+            /// Maximize color contrast.
+            /// </summary>
+            DMICM_CONTRAST = 2,
+
+            /// <summary>
+            /// Use specific color metric.
+            /// </summary>
+            DMICM_COLORIMETRIC = 3,
+
+            /// <summary>
+            /// Use specific color metric.
+            /// </summary>
+            DMICM_ABS_COLORIMETRIC = 4,
+
+            /// <summary>
+            /// Device-specific intents start here.
+            /// </summary>
+            DMICM_USER = 256,
+        }
+
+        /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmMediaType" /> member.</summary>
+        public enum DeviceMediaTypeOptions : uint
+        {
+            /// <summary>
+            /// Standard paper.
+            /// </summary>
+            DMMEDIA_STANDARD = 1,
+
+            /// <summary>
+            /// Transparency.
+            /// </summary>
+            DMMEDIA_TRANSPARENCY = 2,
+
+            /// <summary>
+            /// Glossy paper.
+            /// </summary>
+            DMMEDIA_GLOSSY = 3,
+
+            /// <summary>
+            /// Device-specific media start here.
+            /// </summary>
+            DMMEDIA_USER = 256,
+        }
+
+        /// <summary>Defines the values that may be used in the <see cref="DEVMODE.dmDitherType" /> member.</summary>
+        public enum DitherTypeOptions : uint
+        {
+            /// <summary>
+            /// No dithering.
+            /// </summary>
+            DMDITHER_NONE = 1,
+
+            /// <summary>
+            /// Dither with a coarse brush.
+            /// </summary>
+            DMDITHER_COARSE = 2,
+
+            /// <summary>
+            /// Dither with a fine brush.
+            /// </summary>
+            DMDITHER_FINE = 3,
+
+            /// <summary>
+            /// LineArt dithering.
+            /// </summary>
+            DMDITHER_LINEART = 4,
+
+            /// <summary>
+            /// LineArt dithering.
+            /// </summary>
+            DMDITHER_ERRORDIFFUSION = 5,
+
+            /// <summary>
+            /// LineArt dithering.
+            /// </summary>
+            DMDITHER_RESERVED6 = 6,
+
+            /// <summary>
+            /// LineArt dithering.
+            /// </summary>
+            DMDITHER_RESERVED7 = 7,
+
+            /// <summary>
+            /// LineArt dithering.
+            /// </summary>
+            DMDITHER_RESERVED8 = 8,
+
+            /// <summary>
+            /// LineArt dithering.
+            /// </summary>
+            DMDITHER_RESERVED9 = 9,
+
+            /// <summary>
+            /// Device does grayscaling.
+            /// </summary>
+            DMDITHER_GRAYSCALE = 10,
+
+            /// <summary>
+            /// Device-specific dithers start here.
+            /// </summary>
+            DMDITHER_USER = 256,
+        }
     }
 }

--- a/src/Windows.Core/PublicAPI.Unshipped.txt
+++ b/src/Windows.Core/PublicAPI.Unshipped.txt
@@ -1,284 +1,284 @@
 PInvoke.DEVMODE
+PInvoke.DEVMODE.CollationSelectionOptions
+PInvoke.DEVMODE.CollationSelectionOptions.DMCOLLATE_FALSE = 0 -> PInvoke.DEVMODE.CollationSelectionOptions
+PInvoke.DEVMODE.CollationSelectionOptions.DMCOLLATE_TRUE = 1 -> PInvoke.DEVMODE.CollationSelectionOptions
 PInvoke.DEVMODE.DEVMODE() -> void
+PInvoke.DEVMODE.DeviceIcmIntentOptions
+PInvoke.DEVMODE.DeviceIcmIntentOptions.DMICM_ABS_COLORIMETRIC = 4 -> PInvoke.DEVMODE.DeviceIcmIntentOptions
+PInvoke.DEVMODE.DeviceIcmIntentOptions.DMICM_COLORIMETRIC = 3 -> PInvoke.DEVMODE.DeviceIcmIntentOptions
+PInvoke.DEVMODE.DeviceIcmIntentOptions.DMICM_CONTRAST = 2 -> PInvoke.DEVMODE.DeviceIcmIntentOptions
+PInvoke.DEVMODE.DeviceIcmIntentOptions.DMICM_SATURATE = 1 -> PInvoke.DEVMODE.DeviceIcmIntentOptions
+PInvoke.DEVMODE.DeviceIcmIntentOptions.DMICM_USER = 256 -> PInvoke.DEVMODE.DeviceIcmIntentOptions
+PInvoke.DEVMODE.DeviceIcmMethodOptions
+PInvoke.DEVMODE.DeviceIcmMethodOptions.DMICMMETHOD_DEVICE = 4 -> PInvoke.DEVMODE.DeviceIcmMethodOptions
+PInvoke.DEVMODE.DeviceIcmMethodOptions.DMICMMETHOD_DRIVER = 3 -> PInvoke.DEVMODE.DeviceIcmMethodOptions
+PInvoke.DEVMODE.DeviceIcmMethodOptions.DMICMMETHOD_NONE = 1 -> PInvoke.DEVMODE.DeviceIcmMethodOptions
+PInvoke.DEVMODE.DeviceIcmMethodOptions.DMICMMETHOD_SYSTEM = 2 -> PInvoke.DEVMODE.DeviceIcmMethodOptions
+PInvoke.DEVMODE.DeviceIcmMethodOptions.DMICMMETHOD_USER = 256 -> PInvoke.DEVMODE.DeviceIcmMethodOptions
+PInvoke.DEVMODE.DeviceMediaTypeOptions
+PInvoke.DEVMODE.DeviceMediaTypeOptions.DMMEDIA_GLOSSY = 3 -> PInvoke.DEVMODE.DeviceMediaTypeOptions
+PInvoke.DEVMODE.DeviceMediaTypeOptions.DMMEDIA_STANDARD = 1 -> PInvoke.DEVMODE.DeviceMediaTypeOptions
+PInvoke.DEVMODE.DeviceMediaTypeOptions.DMMEDIA_TRANSPARENCY = 2 -> PInvoke.DEVMODE.DeviceMediaTypeOptions
+PInvoke.DEVMODE.DeviceMediaTypeOptions.DMMEDIA_USER = 256 -> PInvoke.DEVMODE.DeviceMediaTypeOptions
+PInvoke.DEVMODE.DisplayFixedOutputOptions
+PInvoke.DEVMODE.DisplayFixedOutputOptions.DMDFO_CENTER = 2 -> PInvoke.DEVMODE.DisplayFixedOutputOptions
+PInvoke.DEVMODE.DisplayFixedOutputOptions.DMDFO_DEFAULT = 0 -> PInvoke.DEVMODE.DisplayFixedOutputOptions
+PInvoke.DEVMODE.DisplayFixedOutputOptions.DMDFO_STRETCH = 1 -> PInvoke.DEVMODE.DisplayFixedOutputOptions
+PInvoke.DEVMODE.DisplayOptions
+PInvoke.DEVMODE.DisplayOptions.DMDISPLAYFLAGS_TEXTMODE = 4 -> PInvoke.DEVMODE.DisplayOptions
+PInvoke.DEVMODE.DisplayOptions.DM_INTERLACED = 2 -> PInvoke.DEVMODE.DisplayOptions
+PInvoke.DEVMODE.DisplayOptions.NONE = 0 -> PInvoke.DEVMODE.DisplayOptions
+PInvoke.DEVMODE.DisplayOrientationOptions
+PInvoke.DEVMODE.DisplayOrientationOptions.DMDO_180 = 2 -> PInvoke.DEVMODE.DisplayOrientationOptions
+PInvoke.DEVMODE.DisplayOrientationOptions.DMDO_270 = 3 -> PInvoke.DEVMODE.DisplayOrientationOptions
+PInvoke.DEVMODE.DisplayOrientationOptions.DMDO_90 = 1 -> PInvoke.DEVMODE.DisplayOrientationOptions
+PInvoke.DEVMODE.DisplayOrientationOptions.DMDO_DEFAULT = 0 -> PInvoke.DEVMODE.DisplayOrientationOptions
+PInvoke.DEVMODE.DitherTypeOptions
+PInvoke.DEVMODE.DitherTypeOptions.DMDITHER_COARSE = 2 -> PInvoke.DEVMODE.DitherTypeOptions
+PInvoke.DEVMODE.DitherTypeOptions.DMDITHER_ERRORDIFFUSION = 5 -> PInvoke.DEVMODE.DitherTypeOptions
+PInvoke.DEVMODE.DitherTypeOptions.DMDITHER_FINE = 3 -> PInvoke.DEVMODE.DitherTypeOptions
+PInvoke.DEVMODE.DitherTypeOptions.DMDITHER_GRAYSCALE = 10 -> PInvoke.DEVMODE.DitherTypeOptions
+PInvoke.DEVMODE.DitherTypeOptions.DMDITHER_LINEART = 4 -> PInvoke.DEVMODE.DitherTypeOptions
+PInvoke.DEVMODE.DitherTypeOptions.DMDITHER_NONE = 1 -> PInvoke.DEVMODE.DitherTypeOptions
+PInvoke.DEVMODE.DitherTypeOptions.DMDITHER_RESERVED6 = 6 -> PInvoke.DEVMODE.DitherTypeOptions
+PInvoke.DEVMODE.DitherTypeOptions.DMDITHER_RESERVED7 = 7 -> PInvoke.DEVMODE.DitherTypeOptions
+PInvoke.DEVMODE.DitherTypeOptions.DMDITHER_RESERVED8 = 8 -> PInvoke.DEVMODE.DitherTypeOptions
+PInvoke.DEVMODE.DitherTypeOptions.DMDITHER_RESERVED9 = 9 -> PInvoke.DEVMODE.DitherTypeOptions
+PInvoke.DEVMODE.DitherTypeOptions.DMDITHER_USER = 256 -> PInvoke.DEVMODE.DitherTypeOptions
+PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_BITSPERPEL = 262144 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_COLLATE = 32768 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_COLOR = 2048 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_COPIES = 256 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_DEFAULTSOURCE = 512 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_DISPLAYFIXEDOUTPUT = 536870912 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_DISPLAYFLAGS = 2097152 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_DISPLAYFREQUENCY = 4194304 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_DISPLAYORIENTATION = 128 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_DITHERTYPE = 67108864 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_DUPLEX = 4096 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_FORMNAME = 65536 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_ICMINTENT = 16777216 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_ICMMETHOD = 8388608 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_LOGPIXELS = 131072 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_MEDIATYPE = 33554432 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_NUP = 64 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_ORIENTATION = 1 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_PANNINGHEIGHT = 268435456 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_PANNINGWIDTH = 134217728 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_PAPERLENGTH = 4 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_PAPERSIZE = 2 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_PAPERWIDTH = 8 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_PELSHEIGHT = 1048576 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_PELSWIDTH = 524288 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_POSITION = 32 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_PRINTQUALITY = 1024 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_SCALE = 16 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_TTOPTION = 16384 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.DM_YRESOLUTION = 8192 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.FieldUseFlags.NONE = 0 -> PInvoke.DEVMODE.FieldUseFlags
+PInvoke.DEVMODE.PrintBinSelectionOptions
+PInvoke.DEVMODE.PrintBinSelectionOptions.DMBIN_AUTO = 7 -> PInvoke.DEVMODE.PrintBinSelectionOptions
+PInvoke.DEVMODE.PrintBinSelectionOptions.DMBIN_CASSETTE = 14 -> PInvoke.DEVMODE.PrintBinSelectionOptions
+PInvoke.DEVMODE.PrintBinSelectionOptions.DMBIN_ENVELOPE = 5 -> PInvoke.DEVMODE.PrintBinSelectionOptions
+PInvoke.DEVMODE.PrintBinSelectionOptions.DMBIN_ENVMANUAL = 6 -> PInvoke.DEVMODE.PrintBinSelectionOptions
+PInvoke.DEVMODE.PrintBinSelectionOptions.DMBIN_FIRST = 1 -> PInvoke.DEVMODE.PrintBinSelectionOptions
+PInvoke.DEVMODE.PrintBinSelectionOptions.DMBIN_FORMSOURCE = 15 -> PInvoke.DEVMODE.PrintBinSelectionOptions
+PInvoke.DEVMODE.PrintBinSelectionOptions.DMBIN_LARGECAPACITY = 11 -> PInvoke.DEVMODE.PrintBinSelectionOptions
+PInvoke.DEVMODE.PrintBinSelectionOptions.DMBIN_LARGEFMT = 10 -> PInvoke.DEVMODE.PrintBinSelectionOptions
+PInvoke.DEVMODE.PrintBinSelectionOptions.DMBIN_LAST = 15 -> PInvoke.DEVMODE.PrintBinSelectionOptions
+PInvoke.DEVMODE.PrintBinSelectionOptions.DMBIN_LOWER = 2 -> PInvoke.DEVMODE.PrintBinSelectionOptions
+PInvoke.DEVMODE.PrintBinSelectionOptions.DMBIN_MANUAL = 4 -> PInvoke.DEVMODE.PrintBinSelectionOptions
+PInvoke.DEVMODE.PrintBinSelectionOptions.DMBIN_MIDDLE = 3 -> PInvoke.DEVMODE.PrintBinSelectionOptions
+PInvoke.DEVMODE.PrintBinSelectionOptions.DMBIN_ONLYONE = 1 -> PInvoke.DEVMODE.PrintBinSelectionOptions
+PInvoke.DEVMODE.PrintBinSelectionOptions.DMBIN_SMALLFMT = 9 -> PInvoke.DEVMODE.PrintBinSelectionOptions
+PInvoke.DEVMODE.PrintBinSelectionOptions.DMBIN_TRACTOR = 8 -> PInvoke.DEVMODE.PrintBinSelectionOptions
+PInvoke.DEVMODE.PrintBinSelectionOptions.DMBIN_UPPER = 1 -> PInvoke.DEVMODE.PrintBinSelectionOptions
+PInvoke.DEVMODE.PrintBinSelectionOptions.DMBIN_USER = 256 -> PInvoke.DEVMODE.PrintBinSelectionOptions
+PInvoke.DEVMODE.PrintColorOptions
+PInvoke.DEVMODE.PrintColorOptions.DMCOLOR_COLOR = 2 -> PInvoke.DEVMODE.PrintColorOptions
+PInvoke.DEVMODE.PrintColorOptions.DMCOLOR_MONOCHROME = 1 -> PInvoke.DEVMODE.PrintColorOptions
+PInvoke.DEVMODE.PrintDuplexOptions
+PInvoke.DEVMODE.PrintDuplexOptions.DMDUP_HORIZONTAL = 3 -> PInvoke.DEVMODE.PrintDuplexOptions
+PInvoke.DEVMODE.PrintDuplexOptions.DMDUP_SIMPLEX = 1 -> PInvoke.DEVMODE.PrintDuplexOptions
+PInvoke.DEVMODE.PrintDuplexOptions.DMDUP_VERTICAL = 2 -> PInvoke.DEVMODE.PrintDuplexOptions
+PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_10X11 = 45 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_10X14 = 16 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_11X17 = 17 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_12X11 = 90 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_15X11 = 46 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_9X11 = 44 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_A2 = 66 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_A3 = 8 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_A3_EXTRA = 63 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_A3_EXTRA_TRANSVERSE = 68 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_A3_ROTATED = 76 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_A3_TRANSVERSE = 67 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_A4 = 9 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_A4SMALL = 10 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_A4_EXTRA = 53 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_A4_PLUS = 60 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_A4_ROTATED = 77 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_A4_TRANSVERSE = 55 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_A5 = 11 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_A5_EXTRA = 64 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_A5_ROTATED = 78 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_A5_TRANSVERSE = 61 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_A6 = 70 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_A6_ROTATED = 83 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_A_PLUS = 57 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_B4 = 12 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_B4_JIS_ROTATED = 79 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_B5 = 13 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_B5_EXTRA = 65 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_B5_JIS_ROTATED = 80 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_B5_TRANSVERSE = 62 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_B6_JIS = 88 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_B6_JIS_ROTATED = 89 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_B_PLUS = 58 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_CSHEET = 24 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_DBL_JAPANESE_POSTCARD = 69 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_DBL_JAPANESE_POSTCARD_ROTATED = 82 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_DSHEET = 25 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_ENV_10 = 20 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_ENV_11 = 21 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_ENV_12 = 22 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_ENV_14 = 23 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_ENV_9 = 19 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_ENV_B4 = 33 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_ENV_B5 = 34 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_ENV_B6 = 35 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_ENV_C3 = 29 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_ENV_C4 = 30 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_ENV_C5 = 28 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_ENV_C6 = 31 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_ENV_C65 = 32 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_ENV_DL = 27 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_ENV_INVITE = 47 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_ENV_ITALY = 36 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_ENV_MONARCH = 37 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_ENV_PERSONAL = 38 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_ESHEET = 26 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_EXECUTIVE = 7 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_FANFOLD_LGL_GERMAN = 41 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_FANFOLD_STD_GERMAN = 40 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_FANFOLD_US = 39 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_FIRST = 1 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_FOLIO = 14 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_ISO_B4 = 42 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_JAPANESE_POSTCARD = 43 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_JAPANESE_POSTCARD_ROTATED = 81 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_JENV_CHOU3 = 73 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_JENV_CHOU3_ROTATED = 86 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_JENV_CHOU4 = 74 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_JENV_CHOU4_ROTATED = 87 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_JENV_KAKU2 = 71 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_JENV_KAKU2_ROTATED = 84 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_JENV_KAKU3 = 72 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_JENV_KAKU3_ROTATED = 85 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_JENV_YOU4 = 91 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_JENV_YOU4_ROTATED = 92 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_LAST = 118 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_LEDGER = 4 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_LEGAL = 5 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_LEGAL_EXTRA = 51 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_LETTER = 1 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_LETTERSMALL = 2 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_LETTER_EXTRA = 50 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_LETTER_EXTRA_TRANSVERSE = 56 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_LETTER_PLUS = 59 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_LETTER_ROTATED = 75 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_LETTER_TRANSVERSE = 54 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_NOTE = 18 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_P16K = 93 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_P16K_ROTATED = 106 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_P32K = 94 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_P32KBIG = 95 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_P32KBIG_ROTATED = 108 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_P32K_ROTATED = 107 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_PENV_1 = 96 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_PENV_10 = 105 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_PENV_10_ROTATED = 118 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_PENV_1_ROTATED = 109 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_PENV_2 = 97 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_PENV_2_ROTATED = 110 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_PENV_3 = 98 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_PENV_3_ROTATED = 111 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_PENV_4 = 99 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_PENV_4_ROTATED = 112 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_PENV_5 = 100 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_PENV_5_ROTATED = 113 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_PENV_6 = 101 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_PENV_6_ROTATED = 114 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_PENV_7 = 102 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_PENV_7_ROTATED = 115 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_PENV_8 = 103 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_PENV_8_ROTATED = 116 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_PENV_9 = 104 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_PENV_9_ROTATED = 117 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_QUARTO = 15 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_RESERVED_48 = 48 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_RESERVED_49 = 49 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_STATEMENT = 6 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_TABLOID = 3 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_TABLOID_EXTRA = 52 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.DMPAPER_USER = 256 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintPaperOptions.NONE = 0 -> PInvoke.DEVMODE.PrintPaperOptions
+PInvoke.DEVMODE.PrintQualityOptions
+PInvoke.DEVMODE.PrintQualityOptions.DMRES_DRAFT = -1 -> PInvoke.DEVMODE.PrintQualityOptions
+PInvoke.DEVMODE.PrintQualityOptions.DMRES_HIGH = -4 -> PInvoke.DEVMODE.PrintQualityOptions
+PInvoke.DEVMODE.PrintQualityOptions.DMRES_LOW = -2 -> PInvoke.DEVMODE.PrintQualityOptions
+PInvoke.DEVMODE.PrintQualityOptions.DMRES_MEDIUM = -3 -> PInvoke.DEVMODE.PrintQualityOptions
+PInvoke.DEVMODE.PrinterOptions
+PInvoke.DEVMODE.PrinterOptions.DMNUP_ONEUP = 2 -> PInvoke.DEVMODE.PrinterOptions
+PInvoke.DEVMODE.PrinterOptions.DMNUP_SYSTEM = 1 -> PInvoke.DEVMODE.PrinterOptions
+PInvoke.DEVMODE.PrinterOrientationOptions
+PInvoke.DEVMODE.PrinterOrientationOptions.DMORIENT_LANDSCAPE = 2 -> PInvoke.DEVMODE.PrinterOrientationOptions
+PInvoke.DEVMODE.PrinterOrientationOptions.DMORIENT_PORTRAIT = 1 -> PInvoke.DEVMODE.PrinterOrientationOptions
+PInvoke.DEVMODE.TrueTypeOptions
+PInvoke.DEVMODE.TrueTypeOptions.DMTT_BITMAP = 1 -> PInvoke.DEVMODE.TrueTypeOptions
+PInvoke.DEVMODE.TrueTypeOptions.DMTT_DOWNLOAD = 2 -> PInvoke.DEVMODE.TrueTypeOptions
+PInvoke.DEVMODE.TrueTypeOptions.DMTT_DOWNLOAD_OUTLINE = 4 -> PInvoke.DEVMODE.TrueTypeOptions
+PInvoke.DEVMODE.TrueTypeOptions.DMTT_SUBDEV = 3 -> PInvoke.DEVMODE.TrueTypeOptions
 PInvoke.DEVMODE.dmBitsPerPel -> uint
-PInvoke.DEVMODE.dmCollate -> PInvoke.DEVMODE_CollationSelectionOptions
-PInvoke.DEVMODE.dmColor -> PInvoke.DEVMODE_PrintColorOptions
+PInvoke.DEVMODE.dmCollate -> PInvoke.DEVMODE.CollationSelectionOptions
+PInvoke.DEVMODE.dmColor -> PInvoke.DEVMODE.PrintColorOptions
 PInvoke.DEVMODE.dmCopies -> short
-PInvoke.DEVMODE.dmDefaultSource -> PInvoke.DEVMODE_PrintBinSelectionOptions
+PInvoke.DEVMODE.dmDefaultSource -> PInvoke.DEVMODE.PrintBinSelectionOptions
 PInvoke.DEVMODE.dmDeviceName -> char*
-PInvoke.DEVMODE.dmDisplayFixedOutput -> PInvoke.DEVMODE_DisplayFixedOutputOptions
-PInvoke.DEVMODE.dmDisplayFlags -> PInvoke.DEVMODE_DisplayOptions
+PInvoke.DEVMODE.dmDisplayFixedOutput -> PInvoke.DEVMODE.DisplayFixedOutputOptions
+PInvoke.DEVMODE.dmDisplayFlags -> PInvoke.DEVMODE.DisplayOptions
 PInvoke.DEVMODE.dmDisplayFrequency -> uint
-PInvoke.DEVMODE.dmDisplayOrientation -> PInvoke.DEVMODE_DisplayOrientationOptions
-PInvoke.DEVMODE.dmDitherType -> PInvoke.DEVMODE_DitherTypeOptions
+PInvoke.DEVMODE.dmDisplayOrientation -> PInvoke.DEVMODE.DisplayOrientationOptions
+PInvoke.DEVMODE.dmDitherType -> PInvoke.DEVMODE.DitherTypeOptions
 PInvoke.DEVMODE.dmDriverExtra -> ushort
 PInvoke.DEVMODE.dmDriverVersion -> ushort
-PInvoke.DEVMODE.dmDuplex -> PInvoke.DEVMODE_PrintDuplexOptions
-PInvoke.DEVMODE.dmFields -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE.dmDuplex -> PInvoke.DEVMODE.PrintDuplexOptions
+PInvoke.DEVMODE.dmFields -> PInvoke.DEVMODE.FieldUseFlags
 PInvoke.DEVMODE.dmFormName -> char*
-PInvoke.DEVMODE.dmICMIntent -> PInvoke.DEVMODE_DeviceIcmIntentOptions
-PInvoke.DEVMODE.dmICMMethod -> PInvoke.DEVMODE_DeviceIcmMethodOptions
+PInvoke.DEVMODE.dmICMIntent -> PInvoke.DEVMODE.DeviceIcmIntentOptions
+PInvoke.DEVMODE.dmICMMethod -> PInvoke.DEVMODE.DeviceIcmMethodOptions
 PInvoke.DEVMODE.dmLogPixels -> ushort
-PInvoke.DEVMODE.dmMediaType -> PInvoke.DEVMODE_DeviceMediaTypeOptions
-PInvoke.DEVMODE.dmNup -> PInvoke.DEVMODE_PrinterOptions
-PInvoke.DEVMODE.dmOrientation -> PInvoke.DEVMODE_PrinterOrientationOptions
+PInvoke.DEVMODE.dmMediaType -> PInvoke.DEVMODE.DeviceMediaTypeOptions
+PInvoke.DEVMODE.dmNup -> PInvoke.DEVMODE.PrinterOptions
+PInvoke.DEVMODE.dmOrientation -> PInvoke.DEVMODE.PrinterOrientationOptions
 PInvoke.DEVMODE.dmPanningHeight -> uint
 PInvoke.DEVMODE.dmPanningWidth -> uint
 PInvoke.DEVMODE.dmPaperLength -> short
-PInvoke.DEVMODE.dmPaperSize -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE.dmPaperSize -> PInvoke.DEVMODE.PrintPaperOptions
 PInvoke.DEVMODE.dmPaperWidth -> short
 PInvoke.DEVMODE.dmPelsHeight -> uint
 PInvoke.DEVMODE.dmPelsWidth -> uint
 PInvoke.DEVMODE.dmPosition -> PInvoke.POINT
-PInvoke.DEVMODE.dmPrintQuality -> PInvoke.DEVMODE_PrintQualityOptions
+PInvoke.DEVMODE.dmPrintQuality -> PInvoke.DEVMODE.PrintQualityOptions
 PInvoke.DEVMODE.dmReserved1 -> uint
 PInvoke.DEVMODE.dmReserved2 -> uint
 PInvoke.DEVMODE.dmScale -> short
 PInvoke.DEVMODE.dmSize -> ushort
 PInvoke.DEVMODE.dmSpecVersion -> ushort
-PInvoke.DEVMODE.dmTTOption -> PInvoke.DEVMODE_TrueTypeOptions
+PInvoke.DEVMODE.dmTTOption -> PInvoke.DEVMODE.TrueTypeOptions
 PInvoke.DEVMODE.dmYResolution -> short
-PInvoke.DEVMODE_CollationSelectionOptions
-PInvoke.DEVMODE_CollationSelectionOptions.DMCOLLATE_FALSE = 0 -> PInvoke.DEVMODE_CollationSelectionOptions
-PInvoke.DEVMODE_CollationSelectionOptions.DMCOLLATE_TRUE = 1 -> PInvoke.DEVMODE_CollationSelectionOptions
-PInvoke.DEVMODE_DeviceIcmIntentOptions
-PInvoke.DEVMODE_DeviceIcmIntentOptions.DMICM_ABS_COLORIMETRIC = 4 -> PInvoke.DEVMODE_DeviceIcmIntentOptions
-PInvoke.DEVMODE_DeviceIcmIntentOptions.DMICM_COLORIMETRIC = 3 -> PInvoke.DEVMODE_DeviceIcmIntentOptions
-PInvoke.DEVMODE_DeviceIcmIntentOptions.DMICM_CONTRAST = 2 -> PInvoke.DEVMODE_DeviceIcmIntentOptions
-PInvoke.DEVMODE_DeviceIcmIntentOptions.DMICM_SATURATE = 1 -> PInvoke.DEVMODE_DeviceIcmIntentOptions
-PInvoke.DEVMODE_DeviceIcmIntentOptions.DMICM_USER = 256 -> PInvoke.DEVMODE_DeviceIcmIntentOptions
-PInvoke.DEVMODE_DeviceIcmMethodOptions
-PInvoke.DEVMODE_DeviceIcmMethodOptions.DMICMMETHOD_DEVICE = 4 -> PInvoke.DEVMODE_DeviceIcmMethodOptions
-PInvoke.DEVMODE_DeviceIcmMethodOptions.DMICMMETHOD_DRIVER = 3 -> PInvoke.DEVMODE_DeviceIcmMethodOptions
-PInvoke.DEVMODE_DeviceIcmMethodOptions.DMICMMETHOD_NONE = 1 -> PInvoke.DEVMODE_DeviceIcmMethodOptions
-PInvoke.DEVMODE_DeviceIcmMethodOptions.DMICMMETHOD_SYSTEM = 2 -> PInvoke.DEVMODE_DeviceIcmMethodOptions
-PInvoke.DEVMODE_DeviceIcmMethodOptions.DMICMMETHOD_USER = 256 -> PInvoke.DEVMODE_DeviceIcmMethodOptions
-PInvoke.DEVMODE_DeviceMediaTypeOptions
-PInvoke.DEVMODE_DeviceMediaTypeOptions.DMMEDIA_GLOSSY = 3 -> PInvoke.DEVMODE_DeviceMediaTypeOptions
-PInvoke.DEVMODE_DeviceMediaTypeOptions.DMMEDIA_STANDARD = 1 -> PInvoke.DEVMODE_DeviceMediaTypeOptions
-PInvoke.DEVMODE_DeviceMediaTypeOptions.DMMEDIA_TRANSPARENCY = 2 -> PInvoke.DEVMODE_DeviceMediaTypeOptions
-PInvoke.DEVMODE_DeviceMediaTypeOptions.DMMEDIA_USER = 256 -> PInvoke.DEVMODE_DeviceMediaTypeOptions
-PInvoke.DEVMODE_DisplayFixedOutputOptions
-PInvoke.DEVMODE_DisplayFixedOutputOptions.DMDFO_CENTER = 2 -> PInvoke.DEVMODE_DisplayFixedOutputOptions
-PInvoke.DEVMODE_DisplayFixedOutputOptions.DMDFO_DEFAULT = 0 -> PInvoke.DEVMODE_DisplayFixedOutputOptions
-PInvoke.DEVMODE_DisplayFixedOutputOptions.DMDFO_STRETCH = 1 -> PInvoke.DEVMODE_DisplayFixedOutputOptions
-PInvoke.DEVMODE_DisplayOptions
-PInvoke.DEVMODE_DisplayOptions.DMDISPLAYFLAGS_TEXTMODE = 4 -> PInvoke.DEVMODE_DisplayOptions
-PInvoke.DEVMODE_DisplayOptions.DM_INTERLACED = 2 -> PInvoke.DEVMODE_DisplayOptions
-PInvoke.DEVMODE_DisplayOptions.NONE = 0 -> PInvoke.DEVMODE_DisplayOptions
-PInvoke.DEVMODE_DisplayOrientationOptions
-PInvoke.DEVMODE_DisplayOrientationOptions.DMDO_180 = 2 -> PInvoke.DEVMODE_DisplayOrientationOptions
-PInvoke.DEVMODE_DisplayOrientationOptions.DMDO_270 = 3 -> PInvoke.DEVMODE_DisplayOrientationOptions
-PInvoke.DEVMODE_DisplayOrientationOptions.DMDO_90 = 1 -> PInvoke.DEVMODE_DisplayOrientationOptions
-PInvoke.DEVMODE_DisplayOrientationOptions.DMDO_DEFAULT = 0 -> PInvoke.DEVMODE_DisplayOrientationOptions
-PInvoke.DEVMODE_DitherTypeOptions
-PInvoke.DEVMODE_DitherTypeOptions.DMDITHER_COARSE = 2 -> PInvoke.DEVMODE_DitherTypeOptions
-PInvoke.DEVMODE_DitherTypeOptions.DMDITHER_ERRORDIFFUSION = 5 -> PInvoke.DEVMODE_DitherTypeOptions
-PInvoke.DEVMODE_DitherTypeOptions.DMDITHER_FINE = 3 -> PInvoke.DEVMODE_DitherTypeOptions
-PInvoke.DEVMODE_DitherTypeOptions.DMDITHER_GRAYSCALE = 10 -> PInvoke.DEVMODE_DitherTypeOptions
-PInvoke.DEVMODE_DitherTypeOptions.DMDITHER_LINEART = 4 -> PInvoke.DEVMODE_DitherTypeOptions
-PInvoke.DEVMODE_DitherTypeOptions.DMDITHER_NONE = 1 -> PInvoke.DEVMODE_DitherTypeOptions
-PInvoke.DEVMODE_DitherTypeOptions.DMDITHER_RESERVED6 = 6 -> PInvoke.DEVMODE_DitherTypeOptions
-PInvoke.DEVMODE_DitherTypeOptions.DMDITHER_RESERVED7 = 7 -> PInvoke.DEVMODE_DitherTypeOptions
-PInvoke.DEVMODE_DitherTypeOptions.DMDITHER_RESERVED8 = 8 -> PInvoke.DEVMODE_DitherTypeOptions
-PInvoke.DEVMODE_DitherTypeOptions.DMDITHER_RESERVED9 = 9 -> PInvoke.DEVMODE_DitherTypeOptions
-PInvoke.DEVMODE_DitherTypeOptions.DMDITHER_USER = 256 -> PInvoke.DEVMODE_DitherTypeOptions
-PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_BITSPERPEL = 262144 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_COLLATE = 32768 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_COLOR = 2048 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_COPIES = 256 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_DEFAULTSOURCE = 512 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_DISPLAYFIXEDOUTPUT = 536870912 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_DISPLAYFLAGS = 2097152 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_DISPLAYFREQUENCY = 4194304 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_DISPLAYORIENTATION = 128 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_DITHERTYPE = 67108864 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_DUPLEX = 4096 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_FORMNAME = 65536 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_ICMINTENT = 16777216 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_ICMMETHOD = 8388608 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_LOGPIXELS = 131072 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_MEDIATYPE = 33554432 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_NUP = 64 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_ORIENTATION = 1 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_PANNINGHEIGHT = 268435456 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_PANNINGWIDTH = 134217728 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_PAPERLENGTH = 4 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_PAPERSIZE = 2 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_PAPERWIDTH = 8 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_PELSHEIGHT = 1048576 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_PELSWIDTH = 524288 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_POSITION = 32 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_PRINTQUALITY = 1024 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_SCALE = 16 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_TTOPTION = 16384 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.DM_YRESOLUTION = 8192 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_FieldUseFlags.NONE = 0 -> PInvoke.DEVMODE_FieldUseFlags
-PInvoke.DEVMODE_PrintBinSelectionOptions
-PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_AUTO = 7 -> PInvoke.DEVMODE_PrintBinSelectionOptions
-PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_CASSETTE = 14 -> PInvoke.DEVMODE_PrintBinSelectionOptions
-PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_ENVELOPE = 5 -> PInvoke.DEVMODE_PrintBinSelectionOptions
-PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_ENVMANUAL = 6 -> PInvoke.DEVMODE_PrintBinSelectionOptions
-PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_FIRST = 1 -> PInvoke.DEVMODE_PrintBinSelectionOptions
-PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_FORMSOURCE = 15 -> PInvoke.DEVMODE_PrintBinSelectionOptions
-PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_LARGECAPACITY = 11 -> PInvoke.DEVMODE_PrintBinSelectionOptions
-PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_LARGEFMT = 10 -> PInvoke.DEVMODE_PrintBinSelectionOptions
-PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_LAST = 15 -> PInvoke.DEVMODE_PrintBinSelectionOptions
-PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_LOWER = 2 -> PInvoke.DEVMODE_PrintBinSelectionOptions
-PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_MANUAL = 4 -> PInvoke.DEVMODE_PrintBinSelectionOptions
-PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_MIDDLE = 3 -> PInvoke.DEVMODE_PrintBinSelectionOptions
-PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_ONLYONE = 1 -> PInvoke.DEVMODE_PrintBinSelectionOptions
-PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_SMALLFMT = 9 -> PInvoke.DEVMODE_PrintBinSelectionOptions
-PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_TRACTOR = 8 -> PInvoke.DEVMODE_PrintBinSelectionOptions
-PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_UPPER = 1 -> PInvoke.DEVMODE_PrintBinSelectionOptions
-PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_USER = 256 -> PInvoke.DEVMODE_PrintBinSelectionOptions
-PInvoke.DEVMODE_PrintColorOptions
-PInvoke.DEVMODE_PrintColorOptions.DMCOLOR_COLOR = 2 -> PInvoke.DEVMODE_PrintColorOptions
-PInvoke.DEVMODE_PrintColorOptions.DMCOLOR_MONOCHROME = 1 -> PInvoke.DEVMODE_PrintColorOptions
-PInvoke.DEVMODE_PrintDuplexOptions
-PInvoke.DEVMODE_PrintDuplexOptions.DMDUP_HORIZONTAL = 3 -> PInvoke.DEVMODE_PrintDuplexOptions
-PInvoke.DEVMODE_PrintDuplexOptions.DMDUP_SIMPLEX = 1 -> PInvoke.DEVMODE_PrintDuplexOptions
-PInvoke.DEVMODE_PrintDuplexOptions.DMDUP_VERTICAL = 2 -> PInvoke.DEVMODE_PrintDuplexOptions
-PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_10X11 = 45 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_10X14 = 16 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_11X17 = 17 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_12X11 = 90 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_15X11 = 46 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_9X11 = 44 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A2 = 66 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A3 = 8 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A3_EXTRA = 63 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A3_EXTRA_TRANSVERSE = 68 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A3_ROTATED = 76 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A3_TRANSVERSE = 67 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A4 = 9 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A4SMALL = 10 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A4_EXTRA = 53 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A4_PLUS = 60 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A4_ROTATED = 77 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A4_TRANSVERSE = 55 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A5 = 11 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A5_EXTRA = 64 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A5_ROTATED = 78 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A5_TRANSVERSE = 61 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A6 = 70 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A6_ROTATED = 83 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A_PLUS = 57 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_B4 = 12 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_B4_JIS_ROTATED = 79 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_B5 = 13 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_B5_EXTRA = 65 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_B5_JIS_ROTATED = 80 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_B5_TRANSVERSE = 62 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_B6_JIS = 88 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_B6_JIS_ROTATED = 89 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_B_PLUS = 58 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_CSHEET = 24 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_DBL_JAPANESE_POSTCARD = 69 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_DBL_JAPANESE_POSTCARD_ROTATED = 82 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_DSHEET = 25 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_10 = 20 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_11 = 21 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_12 = 22 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_14 = 23 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_9 = 19 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_B4 = 33 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_B5 = 34 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_B6 = 35 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_C3 = 29 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_C4 = 30 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_C5 = 28 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_C6 = 31 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_C65 = 32 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_DL = 27 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_INVITE = 47 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_ITALY = 36 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_MONARCH = 37 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_PERSONAL = 38 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ESHEET = 26 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_EXECUTIVE = 7 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_FANFOLD_LGL_GERMAN = 41 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_FANFOLD_STD_GERMAN = 40 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_FANFOLD_US = 39 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_FIRST = 1 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_FOLIO = 14 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ISO_B4 = 42 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_JAPANESE_POSTCARD = 43 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_JAPANESE_POSTCARD_ROTATED = 81 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_JENV_CHOU3 = 73 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_JENV_CHOU3_ROTATED = 86 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_JENV_CHOU4 = 74 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_JENV_CHOU4_ROTATED = 87 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_JENV_KAKU2 = 71 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_JENV_KAKU2_ROTATED = 84 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_JENV_KAKU3 = 72 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_JENV_KAKU3_ROTATED = 85 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_JENV_YOU4 = 91 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_JENV_YOU4_ROTATED = 92 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_LAST = 118 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_LEDGER = 4 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_LEGAL = 5 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_LEGAL_EXTRA = 51 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_LETTER = 1 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_LETTERSMALL = 2 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_LETTER_EXTRA = 50 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_LETTER_EXTRA_TRANSVERSE = 56 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_LETTER_PLUS = 59 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_LETTER_ROTATED = 75 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_LETTER_TRANSVERSE = 54 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_NOTE = 18 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_P16K = 93 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_P16K_ROTATED = 106 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_P32K = 94 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_P32KBIG = 95 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_P32KBIG_ROTATED = 108 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_P32K_ROTATED = 107 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_1 = 96 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_10 = 105 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_10_ROTATED = 118 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_1_ROTATED = 109 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_2 = 97 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_2_ROTATED = 110 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_3 = 98 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_3_ROTATED = 111 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_4 = 99 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_4_ROTATED = 112 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_5 = 100 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_5_ROTATED = 113 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_6 = 101 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_6_ROTATED = 114 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_7 = 102 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_7_ROTATED = 115 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_8 = 103 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_8_ROTATED = 116 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_9 = 104 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_9_ROTATED = 117 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_QUARTO = 15 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_RESERVED_48 = 48 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_RESERVED_49 = 49 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_STATEMENT = 6 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_TABLOID = 3 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_TABLOID_EXTRA = 52 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_USER = 256 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintPaperOptions.NONE = 0 -> PInvoke.DEVMODE_PrintPaperOptions
-PInvoke.DEVMODE_PrintQualityOptions
-PInvoke.DEVMODE_PrintQualityOptions.DMRES_DRAFT = -1 -> PInvoke.DEVMODE_PrintQualityOptions
-PInvoke.DEVMODE_PrintQualityOptions.DMRES_HIGH = -4 -> PInvoke.DEVMODE_PrintQualityOptions
-PInvoke.DEVMODE_PrintQualityOptions.DMRES_LOW = -2 -> PInvoke.DEVMODE_PrintQualityOptions
-PInvoke.DEVMODE_PrintQualityOptions.DMRES_MEDIUM = -3 -> PInvoke.DEVMODE_PrintQualityOptions
-PInvoke.DEVMODE_PrinterOptions
-PInvoke.DEVMODE_PrinterOptions.DMNUP_ONEUP = 2 -> PInvoke.DEVMODE_PrinterOptions
-PInvoke.DEVMODE_PrinterOptions.DMNUP_SYSTEM = 1 -> PInvoke.DEVMODE_PrinterOptions
-PInvoke.DEVMODE_PrinterOrientationOptions
-PInvoke.DEVMODE_PrinterOrientationOptions.DMORIENT_LANDSCAPE = 2 -> PInvoke.DEVMODE_PrinterOrientationOptions
-PInvoke.DEVMODE_PrinterOrientationOptions.DMORIENT_PORTRAIT = 1 -> PInvoke.DEVMODE_PrinterOrientationOptions
-PInvoke.DEVMODE_TrueTypeOptions
-PInvoke.DEVMODE_TrueTypeOptions.DMTT_BITMAP = 1 -> PInvoke.DEVMODE_TrueTypeOptions
-PInvoke.DEVMODE_TrueTypeOptions.DMTT_DOWNLOAD = 2 -> PInvoke.DEVMODE_TrueTypeOptions
-PInvoke.DEVMODE_TrueTypeOptions.DMTT_DOWNLOAD_OUTLINE = 4 -> PInvoke.DEVMODE_TrueTypeOptions
-PInvoke.DEVMODE_TrueTypeOptions.DMTT_SUBDEV = 3 -> PInvoke.DEVMODE_TrueTypeOptions
 PInvoke.DISPLAY_DEVICE
 PInvoke.DISPLAY_DEVICE.DISPLAY_DEVICE() -> void
 PInvoke.DISPLAY_DEVICE.DeviceID -> char*

--- a/src/Windows.Core/PublicAPI.Unshipped.txt
+++ b/src/Windows.Core/PublicAPI.Unshipped.txt
@@ -1,3 +1,284 @@
+PInvoke.DEVMODE
+PInvoke.DEVMODE.DEVMODE() -> void
+PInvoke.DEVMODE.dmBitsPerPel -> uint
+PInvoke.DEVMODE.dmCollate -> PInvoke.DEVMODE_CollationSelectionOptions
+PInvoke.DEVMODE.dmColor -> PInvoke.DEVMODE_PrintColorOptions
+PInvoke.DEVMODE.dmCopies -> short
+PInvoke.DEVMODE.dmDefaultSource -> PInvoke.DEVMODE_PrintBinSelectionOptions
+PInvoke.DEVMODE.dmDeviceName -> char*
+PInvoke.DEVMODE.dmDisplayFixedOutput -> PInvoke.DEVMODE_DisplayFixedOutputOptions
+PInvoke.DEVMODE.dmDisplayFlags -> PInvoke.DEVMODE_DisplayOptions
+PInvoke.DEVMODE.dmDisplayFrequency -> uint
+PInvoke.DEVMODE.dmDisplayOrientation -> PInvoke.DEVMODE_DisplayOrientationOptions
+PInvoke.DEVMODE.dmDitherType -> PInvoke.DEVMODE_DitherTypeOptions
+PInvoke.DEVMODE.dmDriverExtra -> ushort
+PInvoke.DEVMODE.dmDriverVersion -> ushort
+PInvoke.DEVMODE.dmDuplex -> PInvoke.DEVMODE_PrintDuplexOptions
+PInvoke.DEVMODE.dmFields -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE.dmFormName -> char*
+PInvoke.DEVMODE.dmICMIntent -> PInvoke.DEVMODE_DeviceIcmIntentOptions
+PInvoke.DEVMODE.dmICMMethod -> PInvoke.DEVMODE_DeviceIcmMethodOptions
+PInvoke.DEVMODE.dmLogPixels -> ushort
+PInvoke.DEVMODE.dmMediaType -> PInvoke.DEVMODE_DeviceMediaTypeOptions
+PInvoke.DEVMODE.dmNup -> PInvoke.DEVMODE_PrinterOptions
+PInvoke.DEVMODE.dmOrientation -> PInvoke.DEVMODE_PrinterOrientationOptions
+PInvoke.DEVMODE.dmPanningHeight -> uint
+PInvoke.DEVMODE.dmPanningWidth -> uint
+PInvoke.DEVMODE.dmPaperLength -> short
+PInvoke.DEVMODE.dmPaperSize -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE.dmPaperWidth -> short
+PInvoke.DEVMODE.dmPelsHeight -> uint
+PInvoke.DEVMODE.dmPelsWidth -> uint
+PInvoke.DEVMODE.dmPosition -> PInvoke.POINT
+PInvoke.DEVMODE.dmPrintQuality -> PInvoke.DEVMODE_PrintQualityOptions
+PInvoke.DEVMODE.dmReserved1 -> uint
+PInvoke.DEVMODE.dmReserved2 -> uint
+PInvoke.DEVMODE.dmScale -> short
+PInvoke.DEVMODE.dmSize -> ushort
+PInvoke.DEVMODE.dmSpecVersion -> ushort
+PInvoke.DEVMODE.dmTTOption -> PInvoke.DEVMODE_TrueTypeOptions
+PInvoke.DEVMODE.dmYResolution -> short
+PInvoke.DEVMODE_CollationSelectionOptions
+PInvoke.DEVMODE_CollationSelectionOptions.DMCOLLATE_FALSE = 0 -> PInvoke.DEVMODE_CollationSelectionOptions
+PInvoke.DEVMODE_CollationSelectionOptions.DMCOLLATE_TRUE = 1 -> PInvoke.DEVMODE_CollationSelectionOptions
+PInvoke.DEVMODE_DeviceIcmIntentOptions
+PInvoke.DEVMODE_DeviceIcmIntentOptions.DMICM_ABS_COLORIMETRIC = 4 -> PInvoke.DEVMODE_DeviceIcmIntentOptions
+PInvoke.DEVMODE_DeviceIcmIntentOptions.DMICM_COLORIMETRIC = 3 -> PInvoke.DEVMODE_DeviceIcmIntentOptions
+PInvoke.DEVMODE_DeviceIcmIntentOptions.DMICM_CONTRAST = 2 -> PInvoke.DEVMODE_DeviceIcmIntentOptions
+PInvoke.DEVMODE_DeviceIcmIntentOptions.DMICM_SATURATE = 1 -> PInvoke.DEVMODE_DeviceIcmIntentOptions
+PInvoke.DEVMODE_DeviceIcmIntentOptions.DMICM_USER = 256 -> PInvoke.DEVMODE_DeviceIcmIntentOptions
+PInvoke.DEVMODE_DeviceIcmMethodOptions
+PInvoke.DEVMODE_DeviceIcmMethodOptions.DMICMMETHOD_DEVICE = 4 -> PInvoke.DEVMODE_DeviceIcmMethodOptions
+PInvoke.DEVMODE_DeviceIcmMethodOptions.DMICMMETHOD_DRIVER = 3 -> PInvoke.DEVMODE_DeviceIcmMethodOptions
+PInvoke.DEVMODE_DeviceIcmMethodOptions.DMICMMETHOD_NONE = 1 -> PInvoke.DEVMODE_DeviceIcmMethodOptions
+PInvoke.DEVMODE_DeviceIcmMethodOptions.DMICMMETHOD_SYSTEM = 2 -> PInvoke.DEVMODE_DeviceIcmMethodOptions
+PInvoke.DEVMODE_DeviceIcmMethodOptions.DMICMMETHOD_USER = 256 -> PInvoke.DEVMODE_DeviceIcmMethodOptions
+PInvoke.DEVMODE_DeviceMediaTypeOptions
+PInvoke.DEVMODE_DeviceMediaTypeOptions.DMMEDIA_GLOSSY = 3 -> PInvoke.DEVMODE_DeviceMediaTypeOptions
+PInvoke.DEVMODE_DeviceMediaTypeOptions.DMMEDIA_STANDARD = 1 -> PInvoke.DEVMODE_DeviceMediaTypeOptions
+PInvoke.DEVMODE_DeviceMediaTypeOptions.DMMEDIA_TRANSPARENCY = 2 -> PInvoke.DEVMODE_DeviceMediaTypeOptions
+PInvoke.DEVMODE_DeviceMediaTypeOptions.DMMEDIA_USER = 256 -> PInvoke.DEVMODE_DeviceMediaTypeOptions
+PInvoke.DEVMODE_DisplayFixedOutputOptions
+PInvoke.DEVMODE_DisplayFixedOutputOptions.DMDFO_CENTER = 2 -> PInvoke.DEVMODE_DisplayFixedOutputOptions
+PInvoke.DEVMODE_DisplayFixedOutputOptions.DMDFO_DEFAULT = 0 -> PInvoke.DEVMODE_DisplayFixedOutputOptions
+PInvoke.DEVMODE_DisplayFixedOutputOptions.DMDFO_STRETCH = 1 -> PInvoke.DEVMODE_DisplayFixedOutputOptions
+PInvoke.DEVMODE_DisplayOptions
+PInvoke.DEVMODE_DisplayOptions.DMDISPLAYFLAGS_TEXTMODE = 4 -> PInvoke.DEVMODE_DisplayOptions
+PInvoke.DEVMODE_DisplayOptions.DM_INTERLACED = 2 -> PInvoke.DEVMODE_DisplayOptions
+PInvoke.DEVMODE_DisplayOptions.NONE = 0 -> PInvoke.DEVMODE_DisplayOptions
+PInvoke.DEVMODE_DisplayOrientationOptions
+PInvoke.DEVMODE_DisplayOrientationOptions.DMDO_180 = 2 -> PInvoke.DEVMODE_DisplayOrientationOptions
+PInvoke.DEVMODE_DisplayOrientationOptions.DMDO_270 = 3 -> PInvoke.DEVMODE_DisplayOrientationOptions
+PInvoke.DEVMODE_DisplayOrientationOptions.DMDO_90 = 1 -> PInvoke.DEVMODE_DisplayOrientationOptions
+PInvoke.DEVMODE_DisplayOrientationOptions.DMDO_DEFAULT = 0 -> PInvoke.DEVMODE_DisplayOrientationOptions
+PInvoke.DEVMODE_DitherTypeOptions
+PInvoke.DEVMODE_DitherTypeOptions.DMDITHER_COARSE = 2 -> PInvoke.DEVMODE_DitherTypeOptions
+PInvoke.DEVMODE_DitherTypeOptions.DMDITHER_ERRORDIFFUSION = 5 -> PInvoke.DEVMODE_DitherTypeOptions
+PInvoke.DEVMODE_DitherTypeOptions.DMDITHER_FINE = 3 -> PInvoke.DEVMODE_DitherTypeOptions
+PInvoke.DEVMODE_DitherTypeOptions.DMDITHER_GRAYSCALE = 10 -> PInvoke.DEVMODE_DitherTypeOptions
+PInvoke.DEVMODE_DitherTypeOptions.DMDITHER_LINEART = 4 -> PInvoke.DEVMODE_DitherTypeOptions
+PInvoke.DEVMODE_DitherTypeOptions.DMDITHER_NONE = 1 -> PInvoke.DEVMODE_DitherTypeOptions
+PInvoke.DEVMODE_DitherTypeOptions.DMDITHER_RESERVED6 = 6 -> PInvoke.DEVMODE_DitherTypeOptions
+PInvoke.DEVMODE_DitherTypeOptions.DMDITHER_RESERVED7 = 7 -> PInvoke.DEVMODE_DitherTypeOptions
+PInvoke.DEVMODE_DitherTypeOptions.DMDITHER_RESERVED8 = 8 -> PInvoke.DEVMODE_DitherTypeOptions
+PInvoke.DEVMODE_DitherTypeOptions.DMDITHER_RESERVED9 = 9 -> PInvoke.DEVMODE_DitherTypeOptions
+PInvoke.DEVMODE_DitherTypeOptions.DMDITHER_USER = 256 -> PInvoke.DEVMODE_DitherTypeOptions
+PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_BITSPERPEL = 262144 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_COLLATE = 32768 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_COLOR = 2048 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_COPIES = 256 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_DEFAULTSOURCE = 512 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_DISPLAYFIXEDOUTPUT = 536870912 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_DISPLAYFLAGS = 2097152 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_DISPLAYFREQUENCY = 4194304 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_DISPLAYORIENTATION = 128 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_DITHERTYPE = 67108864 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_DUPLEX = 4096 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_FORMNAME = 65536 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_ICMINTENT = 16777216 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_ICMMETHOD = 8388608 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_LOGPIXELS = 131072 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_MEDIATYPE = 33554432 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_NUP = 64 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_ORIENTATION = 1 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_PANNINGHEIGHT = 268435456 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_PANNINGWIDTH = 134217728 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_PAPERLENGTH = 4 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_PAPERSIZE = 2 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_PAPERWIDTH = 8 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_PELSHEIGHT = 1048576 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_PELSWIDTH = 524288 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_POSITION = 32 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_PRINTQUALITY = 1024 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_SCALE = 16 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_TTOPTION = 16384 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.DM_YRESOLUTION = 8192 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_FieldUseFlags.NONE = 0 -> PInvoke.DEVMODE_FieldUseFlags
+PInvoke.DEVMODE_PrintBinSelectionOptions
+PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_AUTO = 7 -> PInvoke.DEVMODE_PrintBinSelectionOptions
+PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_CASSETTE = 14 -> PInvoke.DEVMODE_PrintBinSelectionOptions
+PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_ENVELOPE = 5 -> PInvoke.DEVMODE_PrintBinSelectionOptions
+PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_ENVMANUAL = 6 -> PInvoke.DEVMODE_PrintBinSelectionOptions
+PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_FIRST = 1 -> PInvoke.DEVMODE_PrintBinSelectionOptions
+PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_FORMSOURCE = 15 -> PInvoke.DEVMODE_PrintBinSelectionOptions
+PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_LARGECAPACITY = 11 -> PInvoke.DEVMODE_PrintBinSelectionOptions
+PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_LARGEFMT = 10 -> PInvoke.DEVMODE_PrintBinSelectionOptions
+PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_LAST = 15 -> PInvoke.DEVMODE_PrintBinSelectionOptions
+PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_LOWER = 2 -> PInvoke.DEVMODE_PrintBinSelectionOptions
+PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_MANUAL = 4 -> PInvoke.DEVMODE_PrintBinSelectionOptions
+PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_MIDDLE = 3 -> PInvoke.DEVMODE_PrintBinSelectionOptions
+PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_ONLYONE = 1 -> PInvoke.DEVMODE_PrintBinSelectionOptions
+PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_SMALLFMT = 9 -> PInvoke.DEVMODE_PrintBinSelectionOptions
+PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_TRACTOR = 8 -> PInvoke.DEVMODE_PrintBinSelectionOptions
+PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_UPPER = 1 -> PInvoke.DEVMODE_PrintBinSelectionOptions
+PInvoke.DEVMODE_PrintBinSelectionOptions.DMBIN_USER = 256 -> PInvoke.DEVMODE_PrintBinSelectionOptions
+PInvoke.DEVMODE_PrintColorOptions
+PInvoke.DEVMODE_PrintColorOptions.DMCOLOR_COLOR = 2 -> PInvoke.DEVMODE_PrintColorOptions
+PInvoke.DEVMODE_PrintColorOptions.DMCOLOR_MONOCHROME = 1 -> PInvoke.DEVMODE_PrintColorOptions
+PInvoke.DEVMODE_PrintDuplexOptions
+PInvoke.DEVMODE_PrintDuplexOptions.DMDUP_HORIZONTAL = 3 -> PInvoke.DEVMODE_PrintDuplexOptions
+PInvoke.DEVMODE_PrintDuplexOptions.DMDUP_SIMPLEX = 1 -> PInvoke.DEVMODE_PrintDuplexOptions
+PInvoke.DEVMODE_PrintDuplexOptions.DMDUP_VERTICAL = 2 -> PInvoke.DEVMODE_PrintDuplexOptions
+PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_10X11 = 45 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_10X14 = 16 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_11X17 = 17 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_12X11 = 90 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_15X11 = 46 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_9X11 = 44 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A2 = 66 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A3 = 8 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A3_EXTRA = 63 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A3_EXTRA_TRANSVERSE = 68 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A3_ROTATED = 76 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A3_TRANSVERSE = 67 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A4 = 9 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A4SMALL = 10 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A4_EXTRA = 53 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A4_PLUS = 60 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A4_ROTATED = 77 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A4_TRANSVERSE = 55 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A5 = 11 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A5_EXTRA = 64 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A5_ROTATED = 78 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A5_TRANSVERSE = 61 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A6 = 70 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A6_ROTATED = 83 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_A_PLUS = 57 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_B4 = 12 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_B4_JIS_ROTATED = 79 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_B5 = 13 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_B5_EXTRA = 65 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_B5_JIS_ROTATED = 80 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_B5_TRANSVERSE = 62 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_B6_JIS = 88 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_B6_JIS_ROTATED = 89 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_B_PLUS = 58 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_CSHEET = 24 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_DBL_JAPANESE_POSTCARD = 69 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_DBL_JAPANESE_POSTCARD_ROTATED = 82 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_DSHEET = 25 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_10 = 20 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_11 = 21 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_12 = 22 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_14 = 23 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_9 = 19 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_B4 = 33 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_B5 = 34 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_B6 = 35 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_C3 = 29 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_C4 = 30 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_C5 = 28 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_C6 = 31 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_C65 = 32 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_DL = 27 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_INVITE = 47 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_ITALY = 36 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_MONARCH = 37 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ENV_PERSONAL = 38 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ESHEET = 26 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_EXECUTIVE = 7 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_FANFOLD_LGL_GERMAN = 41 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_FANFOLD_STD_GERMAN = 40 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_FANFOLD_US = 39 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_FIRST = 1 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_FOLIO = 14 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_ISO_B4 = 42 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_JAPANESE_POSTCARD = 43 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_JAPANESE_POSTCARD_ROTATED = 81 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_JENV_CHOU3 = 73 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_JENV_CHOU3_ROTATED = 86 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_JENV_CHOU4 = 74 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_JENV_CHOU4_ROTATED = 87 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_JENV_KAKU2 = 71 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_JENV_KAKU2_ROTATED = 84 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_JENV_KAKU3 = 72 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_JENV_KAKU3_ROTATED = 85 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_JENV_YOU4 = 91 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_JENV_YOU4_ROTATED = 92 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_LAST = 118 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_LEDGER = 4 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_LEGAL = 5 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_LEGAL_EXTRA = 51 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_LETTER = 1 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_LETTERSMALL = 2 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_LETTER_EXTRA = 50 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_LETTER_EXTRA_TRANSVERSE = 56 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_LETTER_PLUS = 59 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_LETTER_ROTATED = 75 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_LETTER_TRANSVERSE = 54 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_NOTE = 18 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_P16K = 93 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_P16K_ROTATED = 106 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_P32K = 94 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_P32KBIG = 95 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_P32KBIG_ROTATED = 108 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_P32K_ROTATED = 107 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_1 = 96 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_10 = 105 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_10_ROTATED = 118 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_1_ROTATED = 109 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_2 = 97 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_2_ROTATED = 110 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_3 = 98 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_3_ROTATED = 111 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_4 = 99 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_4_ROTATED = 112 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_5 = 100 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_5_ROTATED = 113 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_6 = 101 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_6_ROTATED = 114 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_7 = 102 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_7_ROTATED = 115 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_8 = 103 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_8_ROTATED = 116 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_9 = 104 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_PENV_9_ROTATED = 117 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_QUARTO = 15 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_RESERVED_48 = 48 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_RESERVED_49 = 49 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_STATEMENT = 6 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_TABLOID = 3 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_TABLOID_EXTRA = 52 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.DMPAPER_USER = 256 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintPaperOptions.NONE = 0 -> PInvoke.DEVMODE_PrintPaperOptions
+PInvoke.DEVMODE_PrintQualityOptions
+PInvoke.DEVMODE_PrintQualityOptions.DMRES_DRAFT = -1 -> PInvoke.DEVMODE_PrintQualityOptions
+PInvoke.DEVMODE_PrintQualityOptions.DMRES_HIGH = -4 -> PInvoke.DEVMODE_PrintQualityOptions
+PInvoke.DEVMODE_PrintQualityOptions.DMRES_LOW = -2 -> PInvoke.DEVMODE_PrintQualityOptions
+PInvoke.DEVMODE_PrintQualityOptions.DMRES_MEDIUM = -3 -> PInvoke.DEVMODE_PrintQualityOptions
+PInvoke.DEVMODE_PrinterOptions
+PInvoke.DEVMODE_PrinterOptions.DMNUP_ONEUP = 2 -> PInvoke.DEVMODE_PrinterOptions
+PInvoke.DEVMODE_PrinterOptions.DMNUP_SYSTEM = 1 -> PInvoke.DEVMODE_PrinterOptions
+PInvoke.DEVMODE_PrinterOrientationOptions
+PInvoke.DEVMODE_PrinterOrientationOptions.DMORIENT_LANDSCAPE = 2 -> PInvoke.DEVMODE_PrinterOrientationOptions
+PInvoke.DEVMODE_PrinterOrientationOptions.DMORIENT_PORTRAIT = 1 -> PInvoke.DEVMODE_PrinterOrientationOptions
+PInvoke.DEVMODE_TrueTypeOptions
+PInvoke.DEVMODE_TrueTypeOptions.DMTT_BITMAP = 1 -> PInvoke.DEVMODE_TrueTypeOptions
+PInvoke.DEVMODE_TrueTypeOptions.DMTT_DOWNLOAD = 2 -> PInvoke.DEVMODE_TrueTypeOptions
+PInvoke.DEVMODE_TrueTypeOptions.DMTT_DOWNLOAD_OUTLINE = 4 -> PInvoke.DEVMODE_TrueTypeOptions
+PInvoke.DEVMODE_TrueTypeOptions.DMTT_SUBDEV = 3 -> PInvoke.DEVMODE_TrueTypeOptions
 PInvoke.DISPLAY_DEVICE
 PInvoke.DISPLAY_DEVICE.DISPLAY_DEVICE() -> void
 PInvoke.DISPLAY_DEVICE.DeviceID -> char*
@@ -13,4 +294,7 @@ PInvoke.DisplayDeviceFlags.DISPLAY_DEVICE_MODESPRUNED = 134217728 -> PInvoke.Dis
 PInvoke.DisplayDeviceFlags.DISPLAY_DEVICE_PRIMARY_DEVICE = 4 -> PInvoke.DisplayDeviceFlags
 PInvoke.DisplayDeviceFlags.DISPLAY_DEVICE_REMOVABLE = 32 -> PInvoke.DisplayDeviceFlags
 PInvoke.DisplayDeviceFlags.DISPLAY_DEVICE_VGA_COMPATIBLE = 16 -> PInvoke.DisplayDeviceFlags
+const PInvoke.DEVMODE.CCHDEVICENAME = 32 -> int
+const PInvoke.DEVMODE.CCHFORMNAME = 32 -> int
+static PInvoke.DEVMODE.Create() -> PInvoke.DEVMODE
 static PInvoke.DISPLAY_DEVICE.Create() -> PInvoke.DISPLAY_DEVICE


### PR DESCRIPTION
This PR adds two functions and their underlying types:

- [`EnumDisplaySettings`](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-enumdisplaysettingsw)
- [`EnumDisplaySettingsEx`](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-enumdisplaysettingsexw)
- [`DEVMODE`](https://docs.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-devmode)

There must be a problem, probably fixable easily, but the test I added [here](https://github.com/dotnet/pinvoke/compare/master...weitzhandler:feature/additional-functions?expand=1#diff-91650ee7838996e1477a028ecc838259) doesn't pass.

@AArnott can you please and have a look and/or checkout my branch?