### PR TITLE
Fix faulty User32 LoadString p/invoke

### DIFF
--- a/src/User32/PublicAPI.Shipped.txt
+++ b/src/User32/PublicAPI.Shipped.txt
@@ -1818,7 +1818,6 @@ static PInvoke.User32.GetWindowText(System.IntPtr hWnd, System.IntPtr lpString, 
 static PInvoke.User32.GetWindowText(System.IntPtr hWnd, char[] lpString, int nMaxCount) -> int
 static PInvoke.User32.HELPINFO.Create() -> PInvoke.User32.HELPINFO
 static PInvoke.User32.IsDialogMessage(System.IntPtr hDlg, System.IntPtr lpMsg) -> bool
-static PInvoke.User32.LoadString(System.IntPtr hInstance, uint uID, out System.IntPtr lpBuffer, int cchBufferMax) -> int
 static PInvoke.User32.LookupIconIdFromDirectory(System.IntPtr presbits, bool fIcon) -> int
 static PInvoke.User32.LookupIconIdFromDirectory(byte[] presbits, bool fIcon) -> int
 static PInvoke.User32.LookupIconIdFromDirectoryEx(System.IntPtr presbits, bool fIcon, int cxDesired, int cyDesired, PInvoke.User32.LookupIconIdFromDirectoryExFlags Flags) -> int
@@ -1916,7 +1915,6 @@ static extern PInvoke.User32.IsWindowVisible(System.IntPtr hWnd) -> bool
 static extern PInvoke.User32.IsZoomed(System.IntPtr hWnd) -> bool
 static extern PInvoke.User32.LoadIcon(System.IntPtr hInstance, System.IntPtr lpIconName) -> System.IntPtr
 static extern PInvoke.User32.LoadIcon(System.IntPtr hInstance, string lpIconName) -> System.IntPtr
-static extern PInvoke.User32.LoadString(System.IntPtr hInstance, uint uID, out char* lpBuffer, int cchBufferMax) -> int
 static extern PInvoke.User32.LogicalToPhysicalPoint(System.IntPtr hwnd, ref PInvoke.POINT lpPoint) -> bool
 static extern PInvoke.User32.LogicalToPhysicalPointForPerMonitorDPI(System.IntPtr hwnd, ref PInvoke.POINT lpPoint) -> bool
 static extern PInvoke.User32.LookupIconIdFromDirectory(byte* presbits, bool fIcon) -> int

--- a/src/User32/PublicAPI.Unshipped.txt
+++ b/src/User32/PublicAPI.Unshipped.txt
@@ -11,8 +11,11 @@ static PInvoke.User32.EnumDisplaySettings(System.IntPtr lpszDeviceName, uint iMo
 static PInvoke.User32.EnumDisplaySettings(char[] lpszDeviceName, uint iModeNum, ref PInvoke.DEVMODE lpDevMode) -> bool
 static PInvoke.User32.EnumDisplaySettingsEx(System.IntPtr lpszDeviceName, uint iModeNum, System.IntPtr lpDevMode, PInvoke.User32.EnumDisplaySettingsExFlags dwFlags) -> bool
 static PInvoke.User32.EnumDisplaySettingsEx(char[] lpszDeviceName, uint iModeNum, ref PInvoke.DEVMODE lpDevMode, PInvoke.User32.EnumDisplaySettingsExFlags dwFlags) -> bool
+static PInvoke.User32.LoadString(System.IntPtr hInstance, uint uID, char[] lpBuffer, int cchBufferMax) -> int
+static PInvoke.User32.LoadString(System.IntPtr hInstance, uint uID, System.IntPtr lpBuffer, int cchBufferMax) -> int
 static extern PInvoke.User32.EnumDisplayDevices(char* lpDevice, uint iDevNum, PInvoke.DISPLAY_DEVICE* lpDisplayDevice, PInvoke.User32.EnumDisplayDevicesFlags dwFlags) -> bool
 static extern PInvoke.User32.EnumDisplaySettings(char* lpszDeviceName, uint iModeNum, PInvoke.DEVMODE* lpDevMode) -> bool
 static extern PInvoke.User32.EnumDisplaySettingsEx(char* lpszDeviceName, uint iModeNum, PInvoke.DEVMODE* lpDevMode, PInvoke.User32.EnumDisplaySettingsExFlags dwFlags) -> bool
+static extern PInvoke.User32.LoadString(System.IntPtr hInstance, uint uID, char* lpBuffer, int cchBufferMax) -> int
 static extern PInvoke.User32.UnregisterClass(string lpClassName, System.IntPtr hInstance) -> bool
 static readonly PInvoke.User32.DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED -> System.IntPtr

--- a/src/User32/User32.cs
+++ b/src/User32/User32.cs
@@ -2915,11 +2915,11 @@ namespace PInvoke
         ///     The identifier of the string to be loaded.
         /// </param>
         /// <param name="lpBuffer">
-        ///     The buffer is to receive the string. Must be of sufficient length to hold a pointer (8 bytes).
+        /// The buffer to receive the string (if <paramref name="cchBufferMax" /> is non-zero) or a read-only pointer to the string resource itself (if <paramref name="cchBufferMax" /> is zero). Must be of sufficient length to hold a pointer (8 bytes).
         /// </param>
         /// <param name="cchBufferMax">
         ///     The size of the buffer, in characters. The string is truncated and null-terminated if it is longer than the
-        ///     number of characters specified. If this parameter is 0, then lpBuffer receives a read-only pointer to the
+        ///     number of characters specified. If this parameter is 0, then <paramref name="lpBuffer" /> receives a read-only pointer to the
         ///     resource itself.
         /// </param>
         /// <returns>
@@ -2928,7 +2928,11 @@ namespace PInvoke
         ///     error information, call <see cref="Kernel32.GetLastError"/>.
         /// </returns>
         [DllImport(nameof(User32), CharSet = CharSet.Unicode, SetLastError = true)]
-        public static extern unsafe int LoadString(IntPtr hInstance, uint uID, out char* lpBuffer, int cchBufferMax);
+        public static extern unsafe int LoadString(
+            IntPtr hInstance,
+            uint uID,
+            [Friendly(FriendlyFlags.Out | FriendlyFlags.Array)] char* lpBuffer,
+            int cchBufferMax);
 
         /// <summary>
         /// Retrieves the length, in characters, of the specified window's title bar text (if the window has a title bar).


### PR DESCRIPTION
It incorrectly used `out char*` as if the native module allocated the string. It does not.