### PR TITLE
Fix Kernel32.ReadConsole method signature

### DIFF
--- a/src/Kernel32/PublicAPI.Shipped.txt
+++ b/src/Kernel32/PublicAPI.Shipped.txt
@@ -1225,7 +1225,6 @@ static PInvoke.Kernel32.Process32Next(PInvoke.Kernel32.SafeObjectHandle hSnapsho
 static PInvoke.Kernel32.QueryFullProcessImageName(PInvoke.Kernel32.SafeObjectHandle hProcess, PInvoke.Kernel32.QueryFullProcessImageNameFlags dwFlags = PInvoke.Kernel32.QueryFullProcessImageNameFlags.None) -> string
 static PInvoke.Kernel32.QueryFullProcessImageName(PInvoke.Kernel32.SafeObjectHandle hProcess, PInvoke.Kernel32.QueryFullProcessImageNameFlags dwFlags, System.IntPtr lpExeName, ref int lpdwSize) -> bool
 static PInvoke.Kernel32.QueryFullProcessImageName(PInvoke.Kernel32.SafeObjectHandle hProcess, PInvoke.Kernel32.QueryFullProcessImageNameFlags dwFlags, char[] lpExeName, ref int lpdwSize) -> bool
-static PInvoke.Kernel32.ReadConsole(System.IntPtr hConsoleInput, System.IntPtr lpBuffer, int nNumberOfCharsToRead, int lpNumberOfCharsRead, System.IntPtr lpReserved) -> bool
 static PInvoke.Kernel32.ReadFile(PInvoke.Kernel32.SafeObjectHandle hFile, System.ArraySegment<byte> lpBuffer) -> int
 static PInvoke.Kernel32.ReadFile(PInvoke.Kernel32.SafeObjectHandle hFile, System.IntPtr lpBuffer, int nNumberOfBytesToRead) -> int
 static PInvoke.Kernel32.ReadFile(PInvoke.Kernel32.SafeObjectHandle hFile, System.IntPtr lpBuffer, int nNumberOfBytesToRead, System.IntPtr lpNumberOfBytesRead, System.IntPtr lpOverlapped) -> bool
@@ -1372,7 +1371,6 @@ static extern PInvoke.Kernel32.Process32First(PInvoke.Kernel32.SafeObjectHandle 
 static extern PInvoke.Kernel32.Process32Next(PInvoke.Kernel32.SafeObjectHandle hSnapshot, PInvoke.Kernel32.PROCESSENTRY32* lppe) -> bool
 static extern PInvoke.Kernel32.QueryFullProcessImageName(PInvoke.Kernel32.SafeObjectHandle hProcess, PInvoke.Kernel32.QueryFullProcessImageNameFlags dwFlags, System.Text.StringBuilder lpExeName, ref int lpdwSize) -> bool
 static extern PInvoke.Kernel32.QueryFullProcessImageName(PInvoke.Kernel32.SafeObjectHandle hProcess, PInvoke.Kernel32.QueryFullProcessImageNameFlags dwFlags, char* lpExeName, ref int lpdwSize) -> bool
-static extern PInvoke.Kernel32.ReadConsole(System.IntPtr hConsoleInput, void* lpBuffer, int nNumberOfCharsToRead, int lpNumberOfCharsRead, System.IntPtr lpReserved) -> bool
 static extern PInvoke.Kernel32.ReadConsoleInput(System.IntPtr hConsoleInput, out PInvoke.Kernel32.INPUT_RECORD lpBuffer, int nLength, out int lpNumberOfEventsRead) -> bool
 static extern PInvoke.Kernel32.ReadConsoleOutput(System.IntPtr hConsoleOutput, out PInvoke.Kernel32.CHAR_INFO lpBuffer, PInvoke.COORD dwBufferSize, PInvoke.COORD dwBufferCoord, ref PInvoke.SMALL_RECT lpReadRegion) -> bool
 static extern PInvoke.Kernel32.ReadFile(PInvoke.Kernel32.SafeObjectHandle hFile, void* lpBuffer, int nNumberOfBytesToRead, int* lpNumberOfBytesRead, PInvoke.Kernel32.OVERLAPPED* lpOverlapped) -> bool

--- a/src/Kernel32/PublicAPI.Unshipped.txt
+++ b/src/Kernel32/PublicAPI.Unshipped.txt
@@ -4,6 +4,12 @@ PInvoke.Kernel32.APP_MEMORY_INFORMATION.AvailableCommit -> ulong
 PInvoke.Kernel32.APP_MEMORY_INFORMATION.PeakPrivateCommitUsage -> ulong
 PInvoke.Kernel32.APP_MEMORY_INFORMATION.PrivateCommitUsage -> ulong
 PInvoke.Kernel32.APP_MEMORY_INFORMATION.TotalCommitUsage -> ulong
+PInvoke.Kernel32.CONSOLE_READCONSOLE_CONTROL
+PInvoke.Kernel32.CONSOLE_READCONSOLE_CONTROL.CONSOLE_READCONSOLE_CONTROL() -> void
+PInvoke.Kernel32.CONSOLE_READCONSOLE_CONTROL.dwControlKeyState -> PInvoke.Kernel32.ControlKeyStates
+PInvoke.Kernel32.CONSOLE_READCONSOLE_CONTROL.dwCtrlWakeupMask -> uint
+PInvoke.Kernel32.CONSOLE_READCONSOLE_CONTROL.nInitialChars -> uint
+PInvoke.Kernel32.CONSOLE_READCONSOLE_CONTROL.nLength -> int
 PInvoke.Kernel32.CreatePseudoConsoleFlags
 PInvoke.Kernel32.CreatePseudoConsoleFlags.None = 0 -> PInvoke.Kernel32.CreatePseudoConsoleFlags
 PInvoke.Kernel32.CreatePseudoConsoleFlags.PSEUDOCONSOLE_INHERIT_CURSOR = 1 -> PInvoke.Kernel32.CreatePseudoConsoleFlags
@@ -203,6 +209,7 @@ const PInvoke.Kernel32.PROCESS_MEMORY_EXHAUSTION_INFO.PME_CURRENT_VERSION = 1 ->
 const PInvoke.Kernel32.PROCESS_POWER_THROTTLING_STATE.PROCESS_POWER_THROTTLING_CURRENT_VERSION = 1 -> uint
 override PInvoke.Kernel32.SafePseudoConsoleHandle.IsInvalid.get -> bool
 override PInvoke.Kernel32.SafePseudoConsoleHandle.ReleaseHandle() -> bool
+static PInvoke.Kernel32.CONSOLE_READCONSOLE_CONTROL.Create() -> PInvoke.Kernel32.CONSOLE_READCONSOLE_CONTROL
 static PInvoke.Kernel32.CancelIoEx(PInvoke.Kernel32.SafeObjectHandle hFile, System.Threading.NativeOverlapped* lpOverlapped) -> bool
 static PInvoke.Kernel32.CreateRemoteThread(System.IntPtr hProcess, PInvoke.Kernel32.SECURITY_ATTRIBUTES? lpThreadAttributes, System.UIntPtr dwStackSize, PInvoke.Kernel32.THREAD_START_ROUTINE lpStartAddress, System.IntPtr lpParameter, PInvoke.Kernel32.CreateThreadFlags dwCreationFlags, ref uint? lpThreadId) -> PInvoke.Kernel32.SafeObjectHandle
 static PInvoke.Kernel32.CreateRemoteThread(System.IntPtr hProcess, PInvoke.Kernel32.SECURITY_ATTRIBUTES? lpThreadAttributes, System.UIntPtr dwStackSize, PInvoke.Kernel32.THREAD_START_ROUTINE lpStartAddress, void* lpParameter, PInvoke.Kernel32.CreateThreadFlags dwCreationFlags, ref uint? lpThreadId) -> PInvoke.Kernel32.SafeObjectHandle
@@ -245,6 +252,9 @@ static PInvoke.Kernel32.GetVolumeInformation(string lpRootPathName, System.Span<
 static PInvoke.Kernel32.GetVolumeInformation(string lpRootPathName, char[] lpVolumeNameBuffer, int nVolumeNameSize, out uint lpVolumeSerialNumber, out int lpMaximumComponentLength, out PInvoke.Kernel32.FileSystemFlags lpFileSystemFlags, char[] lpFileSystemNameBuffer, int nFileSystemNameSize) -> bool
 static PInvoke.Kernel32.OSVERSIONINFO.Create() -> PInvoke.Kernel32.OSVERSIONINFO
 static PInvoke.Kernel32.QueryFullProcessImageName(PInvoke.Kernel32.SafeObjectHandle hProcess, PInvoke.Kernel32.QueryFullProcessImageNameFlags dwFlags, System.Span<char> lpExeName, int lpdwSize) -> bool
+static PInvoke.Kernel32.ReadConsole(System.IntPtr hConsoleInput, System.IntPtr lpBuffer, int nNumberOfCharsToRead, out int lpNumberOfCharsRead, System.IntPtr pInputControl) -> bool
+static PInvoke.Kernel32.ReadConsole(System.IntPtr hConsoleInput, System.Span<char> lpBuffer, out int lpNumberOfCharsRead, PInvoke.Kernel32.CONSOLE_READCONSOLE_CONTROL? pInputControl) -> bool
+static PInvoke.Kernel32.ReadConsole(System.IntPtr hConsoleInput, char[] lpBuffer, int nNumberOfCharsToRead, out int lpNumberOfCharsRead, PInvoke.Kernel32.CONSOLE_READCONSOLE_CONTROL? pInputControl) -> bool
 static PInvoke.Kernel32.ReadFile(PInvoke.Kernel32.SafeObjectHandle hFile, void* lpBuffer, int nNumberOfBytesToRead, int* lpNumberOfBytesRead, System.Threading.NativeOverlapped* lpOverlapped) -> bool
 static PInvoke.Kernel32.ReadProcessMemory(PInvoke.Kernel32.SafeObjectHandle hProcess, System.IntPtr lpBaseAddress, System.IntPtr lpBuffer, System.UIntPtr nSize, out System.UIntPtr lpNumberOfBytesRead) -> bool
 static PInvoke.Kernel32.SetFilePointer(PInvoke.Kernel32.SafeObjectHandle hFile, int lDistanceToMove, System.IntPtr lpDistanceToMoveHigh, System.IO.SeekOrigin dwMoveMethod) -> int
@@ -271,6 +281,7 @@ static extern PInvoke.Kernel32.GetProcessHandleCount(PInvoke.Kernel32.SafeObject
 static extern PInvoke.Kernel32.GetProcessIdOfThread(PInvoke.Kernel32.SafeObjectHandle hThread) -> uint
 static extern PInvoke.Kernel32.GetProcessInformation(PInvoke.Kernel32.SafeObjectHandle hProcess, PInvoke.Kernel32.PROCESS_INFORMATION_CLASS ProcessInformationClass, void* ProcessInformation, uint ProcessInformationSize) -> bool
 static extern PInvoke.Kernel32.GetVolumeInformation(string lpRootPathName, char* lpVolumeNameBuffer, int nVolumeNameSize, out uint lpVolumeSerialNumber, out int lpMaximumComponentLength, out PInvoke.Kernel32.FileSystemFlags lpFileSystemFlags, char* lpFileSystemNameBuffer, int nFileSystemNameSize) -> bool
+static extern PInvoke.Kernel32.ReadConsole(System.IntPtr hConsoleInput, char* lpBuffer, int nNumberOfCharsToRead, out int lpNumberOfCharsRead, PInvoke.Kernel32.CONSOLE_READCONSOLE_CONTROL* pInputControl) -> bool
 static extern PInvoke.Kernel32.ReadProcessMemory(PInvoke.Kernel32.SafeObjectHandle hProcess, void* lpBaseAddress, void* lpBuffer, System.UIntPtr nSize, out System.UIntPtr lpNumberOfBytesRead) -> bool
 static extern PInvoke.Kernel32.ResizePseudoConsole(PInvoke.Kernel32.SafePseudoConsoleHandle hPC, PInvoke.COORD size) -> PInvoke.HResult
 static extern PInvoke.Kernel32.SetFilePointer(PInvoke.Kernel32.SafeObjectHandle hFile, int lDistanceToMove, int* lpDistanceToMoveHigh, System.IO.SeekOrigin dwMoveMethod) -> int

--- a/src/Kernel32/storebanned/Kernel32+CONSOLE_READCONSOLE_CONTROL.cs
+++ b/src/Kernel32/storebanned/Kernel32+CONSOLE_READCONSOLE_CONTROL.cs
@@ -1,0 +1,45 @@
+﻿// Copyright © .NET Foundation and Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace PInvoke
+{
+    /// <content>
+    /// Contains the <see cref="CONSOLE_READCONSOLE_CONTROL"/> nested type.
+    /// </content>
+    public partial class Kernel32
+    {
+        /// <summary>
+        /// Contains information for a console read operation.
+        /// </summary>
+        public struct CONSOLE_READCONSOLE_CONTROL
+        {
+            /// <summary>
+            /// The size of the structure. Set this member to <c>sizeof(<see cref="CONSOLE_READCONSOLE_CONTROL"/>)</c>.
+            /// </summary>
+            public int nLength;
+
+            /// <summary>
+            /// The number of characters to skip (and thus preserve) before writing newly read input in the buffer passed to the <see cref="ReadConsole(System.IntPtr, char*, int, out int, CONSOLE_READCONSOLE_CONTROL*)"/>
+            /// function. This value must be less than the nNumberOfCharsToRead parameter of the <see cref="ReadConsole(System.IntPtr, char*, int, out int, CONSOLE_READCONSOLE_CONTROL*)"/> function.
+            /// </summary>
+            public uint nInitialChars;
+
+            /// <summary>
+            /// A user-defined control character used to signal that the read is complete.
+            /// </summary>
+            public uint dwCtrlWakeupMask;
+
+            /// <summary>
+            /// The state of the control keys.
+            /// </summary>
+            public ControlKeyStates dwControlKeyState;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="CONSOLE_READCONSOLE_CONTROL"/> struct
+            /// with the <see cref="nLength"/> field initialized.
+            /// </summary>
+            /// <returns>The newly initialized struct.</returns>
+            public static unsafe CONSOLE_READCONSOLE_CONTROL Create() => new CONSOLE_READCONSOLE_CONTROL { nLength = sizeof(CONSOLE_READCONSOLE_CONTROL) };
+        }
+    }
+}

--- a/src/Kernel32/storebanned/Kernel32+ConsoleBufferModes.cs
+++ b/src/Kernel32/storebanned/Kernel32+ConsoleBufferModes.cs
@@ -18,27 +18,27 @@ namespace PInvoke
         {
             /// <summary>
             /// CTRL+C is processed by the system and is not placed in the input buffer.
-            /// If the input buffer is being read by <see cref="ReadFile(SafeObjectHandle, void*, int)"/> or <see cref="ReadConsole(IntPtr, void*, int, int, IntPtr)"/>,
-            /// other control keys are processed by the system and are not returned in the <see cref="ReadFile(SafeObjectHandle, void*, int)"/> or <see cref="ReadConsole(IntPtr, void*, int, int, IntPtr)"/> buffer.
+            /// If the input buffer is being read by <see cref="ReadFile(SafeObjectHandle, void*, int)"/> or <see cref="ReadConsole(IntPtr, char*, int, out int, CONSOLE_READCONSOLE_CONTROL*)"/>,
+            /// other control keys are processed by the system and are not returned in the <see cref="ReadFile(SafeObjectHandle, void*, int)"/> or <see cref="ReadConsole(IntPtr, char*, int, out int, CONSOLE_READCONSOLE_CONTROL*)"/> buffer.
             /// If the <see cref="ENABLE_LINE_INPUT"/> mode is also enabled, backspace, carriage return, and line feed characters are handled by the system.
             /// </summary>
             ENABLE_PROCESSED_INPUT = 0x0001,
 
             /// <summary>
             /// Characters written by the <see cref="WriteFile(SafeObjectHandle, void*, int)"/> or <see cref="WriteConsole(IntPtr, void*, int, int*, IntPtr)"/> function
-            /// or echoed by the <see cref="ReadFile(SafeObjectHandle, void*, int)"/> or <see cref="ReadConsole(IntPtr, void*, int, int, IntPtr)"/> function are parsed for ASCII control sequences, and the correct action is performed.
+            /// or echoed by the <see cref="ReadFile(SafeObjectHandle, void*, int)"/> or <see cref="ReadConsole(IntPtr, char*, int, out int, CONSOLE_READCONSOLE_CONTROL*)"/> function are parsed for ASCII control sequences, and the correct action is performed.
             /// Backspace, tab, bell, carriage return, and line feed characters are processed.
             /// </summary>
             ENABLE_PROCESSED_OUTPUT = 0x0001,
 
             /// <summary>
-            /// The <see cref="ReadFile(SafeObjectHandle, void*, int)"/> or <see cref="ReadConsole(IntPtr, void*, int, int, IntPtr)"/> function returns only when a carriage return character is read.
+            /// The <see cref="ReadFile(SafeObjectHandle, void*, int)"/> or <see cref="ReadConsole(IntPtr, char*, int, out int, CONSOLE_READCONSOLE_CONTROL*)"/> function returns only when a carriage return character is read.
             /// If this mode is disabled, the functions return when one or more characters are available.
             /// </summary>
             ENABLE_LINE_INPUT = 0x0002,
 
             /// <summary>
-            /// When writing with <see cref="WriteFile(SafeObjectHandle, void*, int)"/> or <see cref="WriteConsole(IntPtr, void*, int, int*, IntPtr)"/> or echoing with <see cref="ReadFile(SafeObjectHandle, void*, int)"/> or <see cref="ReadConsole(IntPtr, void*, int, int, IntPtr)"/>,
+            /// When writing with <see cref="WriteFile(SafeObjectHandle, void*, int)"/> or <see cref="WriteConsole(IntPtr, void*, int, int*, IntPtr)"/> or echoing with <see cref="ReadFile(SafeObjectHandle, void*, int)"/> or <see cref="ReadConsole(IntPtr, char*, int, out int, CONSOLE_READCONSOLE_CONTROL*)"/>,
             /// the cursor moves to the beginning of the next row when it reaches the end of the current row. This causes the rows displayed in the console window to scroll up automatically when the cursor advances beyond the last row in the window.
             /// It also causes the contents of the console screen buffer to scroll up (discarding the top row of the console screen buffer) when the cursor advances beyond the last row in the console screen buffer.
             /// If this mode is disabled, the last character in the row is overwritten with any subsequent characters.
@@ -46,7 +46,7 @@ namespace PInvoke
             ENABLE_WRAP_AT_EOL_OUTPUT = 0x0002,
 
             /// <summary>
-            /// Characters read by the <see cref="ReadFile(SafeObjectHandle, void*, int)"/> or <see cref="ReadConsole(IntPtr, void*, int, int, IntPtr)"/> function are written to the active screen buffer as they are read.
+            /// Characters read by the <see cref="ReadFile(SafeObjectHandle, void*, int)"/> or <see cref="ReadConsole(IntPtr, char*, int, out int, CONSOLE_READCONSOLE_CONTROL*)"/> function are written to the active screen buffer as they are read.
             /// This mode can be used only if the <see cref="ENABLE_LINE_INPUT"/> mode is also enabled.
             /// </summary>
             ENABLE_ECHO_INPUT = 0x0004,
@@ -59,7 +59,7 @@ namespace PInvoke
 
             /// <summary>
             /// User interactions that change the size of the console screen buffer are reported in the console's input buffer.
-            /// Information about these events can be read from the input buffer by applications using the <see cref="ReadConsoleInput"/> function, but not by those using <see cref="ReadFile(SafeObjectHandle, void*, int)"/> or <see cref="ReadConsole(IntPtr, void*, int, int, IntPtr)"/>.
+            /// Information about these events can be read from the input buffer by applications using the <see cref="ReadConsoleInput"/> function, but not by those using <see cref="ReadFile(SafeObjectHandle, void*, int)"/> or <see cref="ReadConsole(IntPtr, char*, int, out int, CONSOLE_READCONSOLE_CONTROL*)"/>.
             /// </summary>
             ENABLE_WINDOW_INPUT = 0x0008,
 
@@ -74,7 +74,7 @@ namespace PInvoke
 
             /// <summary>
             /// If the mouse pointer is within the borders of the console window and the window has the keyboard focus, mouse events generated by mouse movement and button presses are placed in the input buffer.
-            /// These events are discarded by <see cref="ReadFile(SafeObjectHandle, void*, int)"/> or <see cref="ReadConsole(IntPtr, void*, int, int, IntPtr)"/>, even when this mode is enabled.
+            /// These events are discarded by <see cref="ReadFile(SafeObjectHandle, void*, int)"/> or <see cref="ReadConsole(IntPtr, char*, int, out int, CONSOLE_READCONSOLE_CONTROL*)"/>, even when this mode is enabled.
             /// </summary>
             ENABLE_MOUSE_INPUT = 0x0010,
 

--- a/src/Kernel32/storebanned/Kernel32.cs
+++ b/src/Kernel32/storebanned/Kernel32.cs
@@ -6,6 +6,7 @@
 namespace PInvoke
 {
     using System;
+    using System.Runtime.CompilerServices;
     using System.Runtime.InteropServices;
     using System.Text;
     using static Kernel32.ACCESS_MASK.GenericRight;
@@ -2674,14 +2675,26 @@ namespace PInvoke
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool ReadConsoleOutput(IntPtr hConsoleOutput, out CHAR_INFO lpBuffer, COORD dwBufferSize, COORD dwBufferCoord, ref SMALL_RECT lpReadRegion);
 
+        /// <summary>
+        /// Reads character input from the console input buffer and removes it from the buffer.
+        /// </summary>
+        /// <param name="hConsoleInput">A handle to the console input buffer. The handle must have the GENERIC_READ access right. For more information, see <see href="https://docs.microsoft.com/en-us/windows/console/console-buffer-security-and-access-rights">Console Buffer Security and Access Rights</see>.</param>
+        /// <param name="lpBuffer">A pointer to a buffer that receives the data read from the console input buffer.</param>
+        /// <param name="nNumberOfCharsToRead">The number of characters to be read. The size of the buffer pointed to by the lpBuffer parameter should be at least <c><paramref name="nNumberOfCharsToRead" /> * sizeof(<see cref="char"/>)</c> bytes.</param>
+        /// <param name="lpNumberOfCharsRead">A pointer to a variable that receives the number of characters actually read.</param>
+        /// <param name="pInputControl">A pointer to a <see cref="CONSOLE_READCONSOLE_CONTROL"/> structure that specifies a control character to signal the end of the read operation. This parameter can be NULL.</param>
+        /// <returns>
+        /// If the function succeeds, the return value is nonzero.
+        /// If the function fails, the return value is zero. To get extended error information, call <see cref="Marshal.GetLastWin32Error"/>.
+        /// </returns>
         [DllImport(nameof(Kernel32), CharSet = CharSet.Unicode, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static unsafe extern bool ReadConsole(
             IntPtr hConsoleInput,
-            void* lpBuffer,
+            [Friendly(FriendlyFlags.Array | FriendlyFlags.Out, ArrayLengthParameter = 2)] char* lpBuffer,
             int nNumberOfCharsToRead,
-            [Friendly(FriendlyFlags.Out)] int lpNumberOfCharsRead,
-            IntPtr lpReserved);
+            out int lpNumberOfCharsRead,
+            [Friendly(FriendlyFlags.In | FriendlyFlags.Optional)] CONSOLE_READCONSOLE_CONTROL* pInputControl);
 
         [DllImport(nameof(Kernel32), CharSet = CharSet.Unicode, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]


### PR DESCRIPTION
It was missing the `out` modifier on the `lpNumberOfCharsRead` parameter.
While fixing it, I went ahead and renovated the entire signature to make it easier to use.

Fixes #523