### PR TITLE
Fix DwmGetWindowAttribute method signature

### DIFF
--- a/src/DwmApi/DwmApi.cs
+++ b/src/DwmApi/DwmApi.cs
@@ -87,7 +87,7 @@ namespace PInvoke
         /// <param name="cbAttribute">The size of the <see cref="DWMWINDOWATTRIBUTE"/> value being retrieved. The size is dependent on the type of the <paramref name="pvAttribute"/> parameter.</param>
         /// <returns>If this function succeeds, it returns <see cref="HResult.Code.S_OK"/>. Otherwise, it returns an <see cref="HResult"/> error code.</returns>
         [DllImport(nameof(DwmApi))]
-        public static unsafe extern HResult DwmGetWindowAttribute(IntPtr hwnd, DWMWINDOWATTRIBUTE dwAttribute, out void* pvAttribute, int cbAttribute);
+        public static unsafe extern HResult DwmGetWindowAttribute(IntPtr hwnd, DWMWINDOWATTRIBUTE dwAttribute, void* pvAttribute, int cbAttribute);
 
         /// <summary>
         /// Extends the window frame into the client area.

--- a/src/DwmApi/PublicAPI.Shipped.txt
+++ b/src/DwmApi/PublicAPI.Shipped.txt
@@ -36,11 +36,11 @@ PInvoke.DwmApi.DwmEnableCompositionFlags.DWM_EC_DISABLECOMPOSITION = 0 -> PInvok
 PInvoke.DwmApi.DwmEnableCompositionFlags.DWM_EC_ENABLECOMPOSITION = 1 -> PInvoke.DwmApi.DwmEnableCompositionFlags
 static PInvoke.DwmApi.DwmEnableBlurBehindWindow(System.IntPtr hWnd, PInvoke.DwmApi.DWM_BLURBEHIND pBlurBehind) -> PInvoke.HResult
 static PInvoke.DwmApi.DwmEnableBlurBehindWindow(System.IntPtr hWnd, System.IntPtr pBlurBehind) -> PInvoke.HResult
-static PInvoke.DwmApi.DwmGetWindowAttribute(System.IntPtr hwnd, PInvoke.DwmApi.DWMWINDOWATTRIBUTE dwAttribute, out System.IntPtr pvAttribute, int cbAttribute) -> PInvoke.HResult
+static PInvoke.DwmApi.DwmGetWindowAttribute(System.IntPtr hwnd, PInvoke.DwmApi.DWMWINDOWATTRIBUTE dwAttribute, System.IntPtr pvAttribute, int cbAttribute) -> PInvoke.HResult
 static extern PInvoke.DwmApi.DwmDefWindowProc(System.IntPtr hwnd, uint msg, System.IntPtr wParam, System.IntPtr lParam, out System.IntPtr plResult) -> bool
 static extern PInvoke.DwmApi.DwmEnableBlurBehindWindow(System.IntPtr hWnd, PInvoke.DwmApi.DWM_BLURBEHIND* pBlurBehind) -> PInvoke.HResult
 static extern PInvoke.DwmApi.DwmEnableComposition(PInvoke.DwmApi.DwmEnableCompositionFlags uCompositionAction) -> PInvoke.HResult
 static extern PInvoke.DwmApi.DwmFlush() -> PInvoke.HResult
 static extern PInvoke.DwmApi.DwmGetColorizationColor(out uint pcrColorization, out bool pfOpaqueBlend) -> PInvoke.HResult
-static extern PInvoke.DwmApi.DwmGetWindowAttribute(System.IntPtr hwnd, PInvoke.DwmApi.DWMWINDOWATTRIBUTE dwAttribute, out void* pvAttribute, int cbAttribute) -> PInvoke.HResult
+static extern PInvoke.DwmApi.DwmGetWindowAttribute(System.IntPtr hwnd, PInvoke.DwmApi.DWMWINDOWATTRIBUTE dwAttribute, void* pvAttribute, int cbAttribute) -> PInvoke.HResult
 static extern PInvoke.DwmApi.DwmExtendFrameIntoClientArea(System.IntPtr hWnd, PInvoke.UxTheme.MARGINS margins) -> PInvoke.HResult


### PR DESCRIPTION
The native type for the pvAttribute parameter is PVOID but we were using out as well as oid* so we were effectively using double-pointers.

Fixes #527
