### PR TITLE
CWPSTRUCT, CWPRETSTRUCT, Prop functions and Control Window Style enums

### DIFF
--- a/src/User32/PublicAPI.Unshipped.txt
+++ b/src/User32/PublicAPI.Unshipped.txt
@@ -1,15 +1,178 @@
+PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_3STATE = PInvoke.User32.ButtonWindowStyles.BS_DEFPUSHBUTTON | PInvoke.User32.ButtonWindowStyles.BS_RADIOBUTTON -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_AUTO3STATE = PInvoke.User32.ButtonWindowStyles.BS_CHECKBOX | PInvoke.User32.ButtonWindowStyles.BS_RADIOBUTTON -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_AUTOCHECKBOX = PInvoke.User32.ButtonWindowStyles.BS_DEFPUSHBUTTON | PInvoke.User32.ButtonWindowStyles.BS_CHECKBOX -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_AUTORADIOBUTTON = PInvoke.User32.ButtonWindowStyles.BS_DEFPUSHBUTTON | PInvoke.User32.ButtonWindowStyles.BS_USERBUTTON -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_BITMAP = 128 -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_BOTTOM = 2048 -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_CENTER = PInvoke.User32.ButtonWindowStyles.BS_LEFT | PInvoke.User32.ButtonWindowStyles.BS_RIGHT -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_CHECKBOX = 2 -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_COMMANDLINK = PInvoke.User32.ButtonWindowStyles.BS_CHECKBOX | PInvoke.User32.ButtonWindowStyles.BS_SPLITBUTTON -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_DEFCOMMANDLINK = PInvoke.User32.ButtonWindowStyles.BS_DEFPUSHBUTTON | PInvoke.User32.ButtonWindowStyles.BS_COMMANDLINK -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_DEFPUSHBUTTON = 1 -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_DEFSPLITBUTTON = PInvoke.User32.ButtonWindowStyles.BS_DEFPUSHBUTTON | PInvoke.User32.ButtonWindowStyles.BS_SPLITBUTTON -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_FLAT = 32768 -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_GROUPBOX = PInvoke.User32.ButtonWindowStyles.BS_DEFPUSHBUTTON | PInvoke.User32.ButtonWindowStyles.BS_AUTO3STATE -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_ICON = 64 -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_LEFT = 256 -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_LEFTTEXT = 32 -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_MULTILINE = 8192 -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_NOTIFY = 16384 -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_OWNERDRAW = PInvoke.User32.ButtonWindowStyles.BS_DEFPUSHBUTTON | PInvoke.User32.ButtonWindowStyles.BS_PUSHBOX -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_PUSHBOX = PInvoke.User32.ButtonWindowStyles.BS_CHECKBOX | PInvoke.User32.ButtonWindowStyles.BS_USERBUTTON -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_PUSHBUTTON = 0 -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_PUSHLIKE = 4096 -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_RADIOBUTTON = 4 -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_RIGHT = 512 -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_RIGHTBUTTON = 32 -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_SPLITBUTTON = PInvoke.User32.ButtonWindowStyles.BS_RADIOBUTTON | PInvoke.User32.ButtonWindowStyles.BS_USERBUTTON -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_TEXT = 0 -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_TOP = 1024 -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_TYPEMASK = PInvoke.User32.ButtonWindowStyles.BS_DEFPUSHBUTTON | PInvoke.User32.ButtonWindowStyles.BS_COMMANDLINK -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_USERBUTTON = 8 -> PInvoke.User32.ButtonWindowStyles
+PInvoke.User32.ButtonWindowStyles.BS_VCENTER = PInvoke.User32.ButtonWindowStyles.BS_TOP | PInvoke.User32.ButtonWindowStyles.BS_BOTTOM -> PInvoke.User32.ButtonWindowStyles
 PInvoke.User32.CHANGEFILTERSTRUCT
 PInvoke.User32.CHANGEFILTERSTRUCT.CHANGEFILTERSTRUCT() -> void
 PInvoke.User32.CHANGEFILTERSTRUCT.ExtStatus -> uint
 PInvoke.User32.CHANGEFILTERSTRUCT.cbSize -> uint
+PInvoke.User32.CWPRETSTRUCT
+PInvoke.User32.CWPRETSTRUCT.CWPRETSTRUCT() -> void
+PInvoke.User32.CWPRETSTRUCT.hwnd -> System.IntPtr
+PInvoke.User32.CWPRETSTRUCT.lParam -> System.IntPtr
+PInvoke.User32.CWPRETSTRUCT.lResult -> System.IntPtr
+PInvoke.User32.CWPRETSTRUCT.message -> PInvoke.User32.WindowMessage
+PInvoke.User32.CWPRETSTRUCT.wParam -> System.IntPtr
+PInvoke.User32.CWPSTRUCT
+PInvoke.User32.CWPSTRUCT.CWPSTRUCT() -> void
+PInvoke.User32.CWPSTRUCT.hwnd -> System.IntPtr
+PInvoke.User32.CWPSTRUCT.lParam -> System.IntPtr
+PInvoke.User32.CWPSTRUCT.message -> PInvoke.User32.WindowMessage
+PInvoke.User32.CWPSTRUCT.wParam -> System.IntPtr
+PInvoke.User32.ComboBoxWindowStyles
+PInvoke.User32.ComboBoxWindowStyles.CBS_AUTOHSCROLL = 64 -> PInvoke.User32.ComboBoxWindowStyles
+PInvoke.User32.ComboBoxWindowStyles.CBS_DISABLENOSCROLL = 2048 -> PInvoke.User32.ComboBoxWindowStyles
+PInvoke.User32.ComboBoxWindowStyles.CBS_DROPDOWN = 2 -> PInvoke.User32.ComboBoxWindowStyles
+PInvoke.User32.ComboBoxWindowStyles.CBS_DROPDOWNLIST = PInvoke.User32.ComboBoxWindowStyles.CBS_SIMPLE | PInvoke.User32.ComboBoxWindowStyles.CBS_DROPDOWN -> PInvoke.User32.ComboBoxWindowStyles
+PInvoke.User32.ComboBoxWindowStyles.CBS_HASSTRINGS = 512 -> PInvoke.User32.ComboBoxWindowStyles
+PInvoke.User32.ComboBoxWindowStyles.CBS_LOWERCASE = 16384 -> PInvoke.User32.ComboBoxWindowStyles
+PInvoke.User32.ComboBoxWindowStyles.CBS_NOINTEGRALHEIGHT = 1024 -> PInvoke.User32.ComboBoxWindowStyles
+PInvoke.User32.ComboBoxWindowStyles.CBS_OEMCONVERT = 128 -> PInvoke.User32.ComboBoxWindowStyles
+PInvoke.User32.ComboBoxWindowStyles.CBS_OWNERDRAWFIXED = 16 -> PInvoke.User32.ComboBoxWindowStyles
+PInvoke.User32.ComboBoxWindowStyles.CBS_OWNERDRAWVARIABLE = 32 -> PInvoke.User32.ComboBoxWindowStyles
+PInvoke.User32.ComboBoxWindowStyles.CBS_SIMPLE = 1 -> PInvoke.User32.ComboBoxWindowStyles
+PInvoke.User32.ComboBoxWindowStyles.CBS_SORT = 256 -> PInvoke.User32.ComboBoxWindowStyles
+PInvoke.User32.ComboBoxWindowStyles.CBS_UPPERCASE = 8192 -> PInvoke.User32.ComboBoxWindowStyles
+PInvoke.User32.DialogWindowStyles
+PInvoke.User32.DialogWindowStyles.DS_3DLOOK = 4 -> PInvoke.User32.DialogWindowStyles
+PInvoke.User32.DialogWindowStyles.DS_ABSALIGN = 1 -> PInvoke.User32.DialogWindowStyles
+PInvoke.User32.DialogWindowStyles.DS_CENTER = 2048 -> PInvoke.User32.DialogWindowStyles
+PInvoke.User32.DialogWindowStyles.DS_CENTERMOUSE = 4096 -> PInvoke.User32.DialogWindowStyles
+PInvoke.User32.DialogWindowStyles.DS_CONTEXTHELP = 8192 -> PInvoke.User32.DialogWindowStyles
+PInvoke.User32.DialogWindowStyles.DS_CONTROL = 1024 -> PInvoke.User32.DialogWindowStyles
+PInvoke.User32.DialogWindowStyles.DS_FIXEDSYS = 8 -> PInvoke.User32.DialogWindowStyles
+PInvoke.User32.DialogWindowStyles.DS_LOCALEDIT = 32 -> PInvoke.User32.DialogWindowStyles
+PInvoke.User32.DialogWindowStyles.DS_MODALFRAME = 128 -> PInvoke.User32.DialogWindowStyles
+PInvoke.User32.DialogWindowStyles.DS_NOFAILCREATE = 16 -> PInvoke.User32.DialogWindowStyles
+PInvoke.User32.DialogWindowStyles.DS_NOIDLEMSG = 256 -> PInvoke.User32.DialogWindowStyles
+PInvoke.User32.DialogWindowStyles.DS_SETFONT = 64 -> PInvoke.User32.DialogWindowStyles
+PInvoke.User32.DialogWindowStyles.DS_SETFOREGROUND = 512 -> PInvoke.User32.DialogWindowStyles
+PInvoke.User32.DialogWindowStyles.DS_SHELLFONT = PInvoke.User32.DialogWindowStyles.DS_FIXEDSYS | PInvoke.User32.DialogWindowStyles.DS_SETFONT -> PInvoke.User32.DialogWindowStyles
+PInvoke.User32.DialogWindowStyles.DS_SYSMODAL = 2 -> PInvoke.User32.DialogWindowStyles
+PInvoke.User32.DialogWindowStyles.DS_USEPIXELS = 32768 -> PInvoke.User32.DialogWindowStyles
+PInvoke.User32.EditControlWindowStyles
+PInvoke.User32.EditControlWindowStyles.ES_AUTOHSCROLL = 128 -> PInvoke.User32.EditControlWindowStyles
+PInvoke.User32.EditControlWindowStyles.ES_AUTOVSCROLL = 64 -> PInvoke.User32.EditControlWindowStyles
+PInvoke.User32.EditControlWindowStyles.ES_CENTER = 1 -> PInvoke.User32.EditControlWindowStyles
+PInvoke.User32.EditControlWindowStyles.ES_LEFT = 0 -> PInvoke.User32.EditControlWindowStyles
+PInvoke.User32.EditControlWindowStyles.ES_LOWERCASE = 16 -> PInvoke.User32.EditControlWindowStyles
+PInvoke.User32.EditControlWindowStyles.ES_MULTILINE = 4 -> PInvoke.User32.EditControlWindowStyles
+PInvoke.User32.EditControlWindowStyles.ES_NOHIDESEL = 256 -> PInvoke.User32.EditControlWindowStyles
+PInvoke.User32.EditControlWindowStyles.ES_NUMBER = 8192 -> PInvoke.User32.EditControlWindowStyles
+PInvoke.User32.EditControlWindowStyles.ES_OEMCONVERT = 1024 -> PInvoke.User32.EditControlWindowStyles
+PInvoke.User32.EditControlWindowStyles.ES_PASSWORD = 32 -> PInvoke.User32.EditControlWindowStyles
+PInvoke.User32.EditControlWindowStyles.ES_READONLY = 2048 -> PInvoke.User32.EditControlWindowStyles
+PInvoke.User32.EditControlWindowStyles.ES_RIGHT = 2 -> PInvoke.User32.EditControlWindowStyles
+PInvoke.User32.EditControlWindowStyles.ES_UPPERCASE = 8 -> PInvoke.User32.EditControlWindowStyles
+PInvoke.User32.EditControlWindowStyles.ES_WANTRETURN = 4096 -> PInvoke.User32.EditControlWindowStyles
 PInvoke.User32.EnumDisplayDevicesFlags
 PInvoke.User32.EnumDisplayDevicesFlags.EDD_GET_DEVICE_INTERFACE_NAME = 1 -> PInvoke.User32.EnumDisplayDevicesFlags
 PInvoke.User32.EnumDisplaySettingsExFlags
 PInvoke.User32.EnumDisplaySettingsExFlags.EDS_RAWMODE = 2 -> PInvoke.User32.EnumDisplaySettingsExFlags
 PInvoke.User32.EnumDisplaySettingsExFlags.EDS_ROTATEDMODE = 4 -> PInvoke.User32.EnumDisplaySettingsExFlags
+PInvoke.User32.LASTINPUTINFO
+PInvoke.User32.LASTINPUTINFO.LASTINPUTINFO() -> void
+PInvoke.User32.LASTINPUTINFO.cbSize -> int
+PInvoke.User32.LASTINPUTINFO.dwTime -> uint
+PInvoke.User32.ListBoxWindowStyles
+PInvoke.User32.ListBoxWindowStyles.LBS_COMBOBOX = 32768 -> PInvoke.User32.ListBoxWindowStyles
+PInvoke.User32.ListBoxWindowStyles.LBS_DISABLENOSCROLL = 4096 -> PInvoke.User32.ListBoxWindowStyles
+PInvoke.User32.ListBoxWindowStyles.LBS_EXTENDEDSEL = 2048 -> PInvoke.User32.ListBoxWindowStyles
+PInvoke.User32.ListBoxWindowStyles.LBS_HASSTRINGS = 64 -> PInvoke.User32.ListBoxWindowStyles
+PInvoke.User32.ListBoxWindowStyles.LBS_MULTICOLUMN = 512 -> PInvoke.User32.ListBoxWindowStyles
+PInvoke.User32.ListBoxWindowStyles.LBS_MULTIPLESEL = 8 -> PInvoke.User32.ListBoxWindowStyles
+PInvoke.User32.ListBoxWindowStyles.LBS_NODATA = 8192 -> PInvoke.User32.ListBoxWindowStyles
+PInvoke.User32.ListBoxWindowStyles.LBS_NOINTEGRALHEIGHT = 256 -> PInvoke.User32.ListBoxWindowStyles
+PInvoke.User32.ListBoxWindowStyles.LBS_NOREDRAW = 4 -> PInvoke.User32.ListBoxWindowStyles
+PInvoke.User32.ListBoxWindowStyles.LBS_NOSEL = 16384 -> PInvoke.User32.ListBoxWindowStyles
+PInvoke.User32.ListBoxWindowStyles.LBS_NOTIFY = 1 -> PInvoke.User32.ListBoxWindowStyles
+PInvoke.User32.ListBoxWindowStyles.LBS_OWNERDRAWFIXED = 16 -> PInvoke.User32.ListBoxWindowStyles
+PInvoke.User32.ListBoxWindowStyles.LBS_OWNERDRAWVARIABLE = 32 -> PInvoke.User32.ListBoxWindowStyles
+PInvoke.User32.ListBoxWindowStyles.LBS_SORT = 2 -> PInvoke.User32.ListBoxWindowStyles
+PInvoke.User32.ListBoxWindowStyles.LBS_STANDARD = 10485763 -> PInvoke.User32.ListBoxWindowStyles
+PInvoke.User32.ListBoxWindowStyles.LBS_USETABSTOPS = 128 -> PInvoke.User32.ListBoxWindowStyles
+PInvoke.User32.ListBoxWindowStyles.LBS_WANTKEYBOARDINPUT = 1024 -> PInvoke.User32.ListBoxWindowStyles
 PInvoke.User32.MONITORINFO_Flags
 PInvoke.User32.MONITORINFO_Flags.MONITORINFOF_PRIMARY = 1 -> PInvoke.User32.MONITORINFO_Flags
 PInvoke.User32.MONITORINFO_Flags.None = 0 -> PInvoke.User32.MONITORINFO_Flags
+PInvoke.User32.ProgressBarWindowStyles
+PInvoke.User32.ProgressBarWindowStyles.PBS_MARQUEE = 8 -> PInvoke.User32.ProgressBarWindowStyles
+PInvoke.User32.ProgressBarWindowStyles.PBS_SMOOTH = 1 -> PInvoke.User32.ProgressBarWindowStyles
+PInvoke.User32.ProgressBarWindowStyles.PBS_SMOOTHREVERSE = 16 -> PInvoke.User32.ProgressBarWindowStyles
+PInvoke.User32.ProgressBarWindowStyles.PBS_VERTICAL = 4 -> PInvoke.User32.ProgressBarWindowStyles
+PInvoke.User32.ScrollBarWindowStyles
+PInvoke.User32.ScrollBarWindowStyles.SBS_BOTTOMALIGN = 4 -> PInvoke.User32.ScrollBarWindowStyles
+PInvoke.User32.ScrollBarWindowStyles.SBS_HORZ = 0 -> PInvoke.User32.ScrollBarWindowStyles
+PInvoke.User32.ScrollBarWindowStyles.SBS_LEFTALIGN = 2 -> PInvoke.User32.ScrollBarWindowStyles
+PInvoke.User32.ScrollBarWindowStyles.SBS_RIGHTALIGN = 4 -> PInvoke.User32.ScrollBarWindowStyles
+PInvoke.User32.ScrollBarWindowStyles.SBS_SIZEBOX = 8 -> PInvoke.User32.ScrollBarWindowStyles
+PInvoke.User32.ScrollBarWindowStyles.SBS_SIZEBOXBOTTOMRIGHTALIGN = 4 -> PInvoke.User32.ScrollBarWindowStyles
+PInvoke.User32.ScrollBarWindowStyles.SBS_SIZEBOXTOPLEFTALIGN = 2 -> PInvoke.User32.ScrollBarWindowStyles
+PInvoke.User32.ScrollBarWindowStyles.SBS_SIZEGRIP = 16 -> PInvoke.User32.ScrollBarWindowStyles
+PInvoke.User32.ScrollBarWindowStyles.SBS_TOPALIGN = 2 -> PInvoke.User32.ScrollBarWindowStyles
+PInvoke.User32.ScrollBarWindowStyles.SBS_VERT = 1 -> PInvoke.User32.ScrollBarWindowStyles
+PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_BITMAP = PInvoke.User32.StaticControlWindowStyles.SS_RIGHT | PInvoke.User32.StaticControlWindowStyles.SS_LEFTNOWORDWRAP -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_BLACKFRAME = PInvoke.User32.StaticControlWindowStyles.SS_CENTER | PInvoke.User32.StaticControlWindowStyles.SS_WHITERECT -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_BLACKRECT = 4 -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_CENTER = 1 -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_CENTERIMAGE = 512 -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_EDITCONTROL = 8192 -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_ELLIPSISMASK = PInvoke.User32.StaticControlWindowStyles.SS_ENDELLIPSIS | PInvoke.User32.StaticControlWindowStyles.SS_PATHELLIPSIS -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_ENDELLIPSIS = 16384 -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_ENHMETAFILE = PInvoke.User32.StaticControlWindowStyles.SS_CENTER | PInvoke.User32.StaticControlWindowStyles.SS_BITMAP -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_ETCHEDFRAME = PInvoke.User32.StaticControlWindowStyles.SS_RIGHT | PInvoke.User32.StaticControlWindowStyles.SS_ETCHEDHORZ -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_ETCHEDHORZ = 16 -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_ETCHEDVERT = PInvoke.User32.StaticControlWindowStyles.SS_CENTER | PInvoke.User32.StaticControlWindowStyles.SS_ETCHEDHORZ -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_GRAYFRAME = 8 -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_GRAYRECT = PInvoke.User32.StaticControlWindowStyles.SS_CENTER | PInvoke.User32.StaticControlWindowStyles.SS_BLACKRECT -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_ICON = PInvoke.User32.StaticControlWindowStyles.SS_CENTER | PInvoke.User32.StaticControlWindowStyles.SS_RIGHT -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_LEFT = 0 -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_LEFTNOWORDWRAP = PInvoke.User32.StaticControlWindowStyles.SS_BLACKRECT | PInvoke.User32.StaticControlWindowStyles.SS_GRAYFRAME -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_NOPREFIX = 128 -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_NOTIFY = 256 -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_OWNERDRAW = PInvoke.User32.StaticControlWindowStyles.SS_CENTER | PInvoke.User32.StaticControlWindowStyles.SS_LEFTNOWORDWRAP -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_PATHELLIPSIS = 32768 -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_REALSIZECONTROL = 64 -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_REALSIZEIMAGE = 2048 -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_RIGHT = 2 -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_RIGHTJUST = 1024 -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_SIMPLE = PInvoke.User32.StaticControlWindowStyles.SS_CENTER | PInvoke.User32.StaticControlWindowStyles.SS_USERITEM -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_SUNKEN = 4096 -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_TYPEMASK = PInvoke.User32.StaticControlWindowStyles.SS_OWNERDRAW | PInvoke.User32.StaticControlWindowStyles.SS_ETCHEDFRAME -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_USERITEM = PInvoke.User32.StaticControlWindowStyles.SS_RIGHT | PInvoke.User32.StaticControlWindowStyles.SS_GRAYFRAME -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_WHITEFRAME = PInvoke.User32.StaticControlWindowStyles.SS_CENTER | PInvoke.User32.StaticControlWindowStyles.SS_GRAYFRAME -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_WHITERECT = PInvoke.User32.StaticControlWindowStyles.SS_RIGHT | PInvoke.User32.StaticControlWindowStyles.SS_BLACKRECT -> PInvoke.User32.StaticControlWindowStyles
+PInvoke.User32.StaticControlWindowStyles.SS_WORDELLIPSIS = PInvoke.User32.StaticControlWindowStyles.SS_ENDELLIPSIS | PInvoke.User32.StaticControlWindowStyles.SS_PATHELLIPSIS -> PInvoke.User32.StaticControlWindowStyles
 PInvoke.User32.WindowStylesEx.WS_EX_NOREDIRECTIONBITMAP = 2097152 -> PInvoke.User32.WindowStylesEx
 const PInvoke.User32.ENUM_CURRENT_SETTINGS = 4294967295 -> uint
 const PInvoke.User32.ENUM_REGISTRY_SETTINGS = 4294967294 -> uint
@@ -29,10 +192,13 @@ static PInvoke.User32.EnumDisplaySettingsEx(System.ReadOnlySpan<char> lpszDevice
 static PInvoke.User32.EnumDisplaySettingsEx(char[] lpszDeviceName, uint iModeNum, ref PInvoke.DEVMODE lpDevMode, PInvoke.User32.EnumDisplaySettingsExFlags dwFlags) -> bool
 static PInvoke.User32.GetClassName(System.IntPtr hWnd, System.Span<char> lpClassName) -> int
 static PInvoke.User32.GetClipboardFormatName(int format, System.Span<char> lpszFormatName) -> int
+static PInvoke.User32.GetLastInputInfo(System.IntPtr plii) -> bool
+static PInvoke.User32.GetLastInputInfo(out PInvoke.User32.LASTINPUTINFO plii) -> bool
 static PInvoke.User32.GetMenuString(System.IntPtr hMenu, uint uIDItem, System.Span<char> lpString, PInvoke.User32.GetMenuStateFlags flags) -> int
 static PInvoke.User32.GetMonitorInfo(System.IntPtr hMonitor, PInvoke.User32.MONITORINFOEX* lpmi) -> bool
 static PInvoke.User32.GetMonitorInfo(System.IntPtr hMonitor, out PInvoke.User32.MONITORINFOEX lpmi) -> bool
 static PInvoke.User32.GetWindowText(System.IntPtr hWnd, System.Span<char> lpString) -> int
+static PInvoke.User32.LASTINPUTINFO.Create() -> PInvoke.User32.LASTINPUTINFO
 static PInvoke.User32.LoadCursor(System.IntPtr hInstance, System.ReadOnlySpan<char> lpCursorName) -> PInvoke.User32.SafeCursorHandle
 static PInvoke.User32.LoadImage(System.IntPtr hInst, System.ReadOnlySpan<char> name, PInvoke.User32.ImageType type, int cx, int cy, PInvoke.User32.LoadImageFlags fuLoad) -> System.IntPtr
 static PInvoke.User32.LoadString(System.IntPtr hInstance, uint uID, System.IntPtr lpBuffer, int cchBufferMax) -> int
@@ -50,15 +216,14 @@ static extern PInvoke.User32.EnumChildWindows(System.IntPtr hWndParent, System.I
 static extern PInvoke.User32.EnumDisplayDevices(char* lpDevice, uint iDevNum, PInvoke.DISPLAY_DEVICE* lpDisplayDevice, PInvoke.User32.EnumDisplayDevicesFlags dwFlags) -> bool
 static extern PInvoke.User32.EnumDisplaySettings(char* lpszDeviceName, uint iModeNum, PInvoke.DEVMODE* lpDevMode) -> bool
 static extern PInvoke.User32.EnumDisplaySettingsEx(char* lpszDeviceName, uint iModeNum, PInvoke.DEVMODE* lpDevMode, PInvoke.User32.EnumDisplaySettingsExFlags dwFlags) -> bool
+static extern PInvoke.User32.GetLastInputInfo(PInvoke.User32.LASTINPUTINFO* plii) -> bool
 static extern PInvoke.User32.GetParent(System.IntPtr hWnd) -> System.IntPtr
+static extern PInvoke.User32.GetProp(System.IntPtr hWnd, int atom) -> System.IntPtr
+static extern PInvoke.User32.GetProp(System.IntPtr hWnd, string lpString) -> System.IntPtr
 static extern PInvoke.User32.LoadString(System.IntPtr hInstance, uint uID, char* lpBuffer, int cchBufferMax) -> int
+static extern PInvoke.User32.RemoveProp(System.IntPtr hWnd, int atom) -> System.IntPtr
+static extern PInvoke.User32.RemoveProp(System.IntPtr hWnd, string lpString) -> System.IntPtr
+static extern PInvoke.User32.SetProp(System.IntPtr hWnd, int atom, System.IntPtr hData) -> bool
+static extern PInvoke.User32.SetProp(System.IntPtr hWnd, string lpString, System.IntPtr hData) -> bool
 static extern PInvoke.User32.UnregisterClass(string lpClassName, System.IntPtr hInstance) -> bool
 static readonly PInvoke.User32.DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED -> System.IntPtr
-static PInvoke.User32.GetLastInputInfo(System.IntPtr plii) -> bool
-static PInvoke.User32.GetLastInputInfo(out PInvoke.User32.LASTINPUTINFO plii) -> bool
-static extern PInvoke.User32.GetLastInputInfo(PInvoke.User32.LASTINPUTINFO* plii) -> bool
-PInvoke.User32.LASTINPUTINFO
-PInvoke.User32.LASTINPUTINFO.LASTINPUTINFO() -> void
-PInvoke.User32.LASTINPUTINFO.cbSize -> int
-PInvoke.User32.LASTINPUTINFO.dwTime -> uint
-static PInvoke.User32.LASTINPUTINFO.Create() -> PInvoke.User32.LASTINPUTINFO

--- a/src/User32/User32+CWPRETSTRUCT.cs
+++ b/src/User32/User32+CWPRETSTRUCT.cs
@@ -39,7 +39,7 @@ namespace PInvoke
             /// <summary>
             /// A handle to the window that processed the message specified by the message value.
             /// </summary>
-            public IntPtr hWnd;
+            public IntPtr hwnd;
         }
     }
 }

--- a/src/User32/User32+CWPRETSTRUCT.cs
+++ b/src/User32/User32+CWPRETSTRUCT.cs
@@ -1,0 +1,45 @@
+﻿// Copyright © .NET Foundation and Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace PInvoke
+{
+    using System;
+    using System.Runtime.InteropServices;
+
+    /// <content>
+    /// Contains the <see cref="CWPRETSTRUCT"/> nested type.
+    /// </content>
+    public partial class User32
+    {
+        /// <summary>
+        /// Defines the message parameters passed to a WH_CALLWNDPROCRET hook procedure, CallWndRetProc.
+        /// </summary>
+        public struct CWPRETSTRUCT
+        {
+            /// <summary>
+            /// The return value of the window procedure that processed the message specified by the message value.
+            /// </summary>
+            public IntPtr lResult;
+
+            /// <summary>
+            /// Additional information about the message. The exact meaning depends on the message value.
+            /// </summary>
+            public IntPtr lParam;
+
+            /// <summary>
+            /// Additional information about the message. The exact meaning depends on the message value.
+            /// </summary>
+            public IntPtr wParam;
+
+            /// <summary>
+            /// The message.
+            /// </summary>
+            public WindowMessage message;
+
+            /// <summary>
+            /// A handle to the window that processed the message specified by the message value.
+            /// </summary>
+            public IntPtr hWnd;
+        }
+    }
+}

--- a/src/User32/User32+CWPSTRUCT.cs
+++ b/src/User32/User32+CWPSTRUCT.cs
@@ -1,0 +1,40 @@
+﻿// Copyright © .NET Foundation and Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace PInvoke
+{
+    using System;
+    using System.Runtime.InteropServices;
+
+    /// <content>
+    /// Contains the <see cref="CWPSTRUCT"/> nested type.
+    /// </content>
+    public partial class User32
+    {
+        /// <summary>
+        /// Defines the message parameters passed to a WH_CALLWNDPROC hook procedure, CallWndProc.
+        /// </summary>
+        public struct CWPSTRUCT
+        {
+            /// <summary>
+            /// Additional information about the message. The exact meaning depends on the message value.
+            /// </summary>
+            public IntPtr lParam;
+
+            /// <summary>
+            /// Additional information about the message. The exact meaning depends on the message value.
+            /// </summary>
+            public IntPtr wParam;
+
+            /// <summary>
+            /// The message.
+            /// </summary>
+            public WindowMessage message;
+
+            /// <summary>
+            /// A handle to the window to receive the message.
+            /// </summary>
+            public IntPtr hWnd;
+        }
+    }
+}

--- a/src/User32/User32+CWPSTRUCT.cs
+++ b/src/User32/User32+CWPSTRUCT.cs
@@ -34,7 +34,7 @@ namespace PInvoke
             /// <summary>
             /// A handle to the window to receive the message.
             /// </summary>
-            public IntPtr hWnd;
+            public IntPtr hwnd;
         }
     }
 }

--- a/src/User32/User32+WindowStyles+ButtonWindowStyles.cs
+++ b/src/User32/User32+WindowStyles+ButtonWindowStyles.cs
@@ -1,0 +1,178 @@
+﻿// Copyright © .NET Foundation and Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace PInvoke
+{
+    using System;
+
+    /// <content>
+    /// Contains the <see cref="ButtonWindowStyles"/> nested type.
+    /// </content>
+    public partial class User32
+    {
+        /// <summary>
+        /// Specifies a combination of button styles. If you create a button using the BUTTON class with the CreateWindow or CreateWindowEx function, you can specify any of the button styles listed below.
+        /// </summary>
+        [Flags]
+        public enum ButtonWindowStyles : uint
+        {
+            /// <summary>
+            /// Creates a push button that posts a WM_COMMAND message to the owner window when the user selects the button.
+            /// </summary>
+            BS_PUSHBUTTON = 0x00000000,
+
+            /// <summary>
+            /// Creates a push button that behaves like a BS_PUSHBUTTON style button, but has a distinct appearance. If the button is in a dialog box, the user can select the button by pressing the ENTER key, even when the button does not have the input focus. This style is useful for enabling the user to quickly select the most likely (default) option.
+            /// </summary>
+            BS_DEFPUSHBUTTON = 0x00000001,
+
+            /// <summary>
+            /// Creates a small, empty check box with text. By default, the text is displayed to the right of the check box. To display the text to the left of the check box, combine this flag with the BS_LEFTTEXT style (or with the equivalent BS_RIGHTBUTTON style).
+            /// </summary>
+            BS_CHECKBOX = 0x00000002,
+
+            /// <summary>
+            /// Creates a button that is the same as a check box, except that the check state automatically toggles between checked and cleared each time the user selects the check box.
+            /// </summary>
+            BS_AUTOCHECKBOX = 0x00000003,
+
+            /// <summary>
+            /// Creates a small circle with text. By default, the text is displayed to the right of the circle. To display the text to the left of the circle, combine this flag with the BS_LEFTTEXT style (or with the equivalent BS_RIGHTBUTTON style). Use radio buttons for groups of related, but mutually exclusive choices.
+            /// </summary>
+            BS_RADIOBUTTON = 0x00000004,
+
+            /// <summary>
+            /// Creates a button that is the same as a check box, except that the box can be grayed as well as checked or cleared. Use the grayed state to show that the state of the check box is not determined.
+            /// </summary>
+            BS_3STATE = 0x00000005,
+
+            /// <summary>
+            /// Creates a button that is the same as a three-state check box, except that the box changes its state when the user selects it. The state cycles through checked, indeterminate, and cleared.
+            /// </summary>
+            BS_AUTO3STATE = 0x00000006,
+
+            /// <summary>
+            /// Creates a rectangle in which other controls can be grouped. Any text associated with this style is displayed in the rectangle's upper left corner.
+            /// </summary>
+            BS_GROUPBOX = 0x00000007,
+
+            /// <summary>
+            /// Obsolete, but provided for compatibility with 16-bit versions of Windows. Applications should use BS_OWNERDRAW instead.
+            /// </summary>
+            BS_USERBUTTON = 0x00000008,
+
+            /// <summary>
+            /// Creates a button that is the same as a radio button, except that when the user selects it, the system automatically sets the button's check state to checked and automatically sets the check state for all other buttons in the same group to cleared.
+            /// </summary>
+            BS_AUTORADIOBUTTON = 0x00000009,
+
+            BS_PUSHBOX = 0x0000000A,
+
+            /// <summary>
+            /// Creates an owner-drawn button. The owner window receives a WM_DRAWITEM message when a visual aspect of the button has changed. Do not combine the BS_OWNERDRAW style with any other button styles.
+            /// </summary>
+            BS_OWNERDRAW = 0x0000000B,
+
+            /// <summary>
+            /// Do not use this style. A composite style bit that results from using the OR operator on BS_* style bits. It can be used to mask out valid BS_* bits from a given bitmask. Note that this is out of date and does not correctly include all valid styles. Thus, you should not use this style.
+            /// </summary>
+            BS_TYPEMASK = 0x0000000F,
+
+            /// <summary>
+            /// Places text on the left side of the radio button or check box when combined with a radio button or check box style. Same as the BS_RIGHTBUTTON style.
+            /// </summary>
+            BS_LEFTTEXT = 0x00000020,
+
+            /// <summary>
+            /// Specifies that the button displays text.
+            /// </summary>
+            BS_TEXT = 0x00000000,
+
+            /// <summary>
+            /// Specifies that the button displays an icon. See the Remarks section for its interaction with BS_BITMAP.
+            /// </summary>
+            BS_ICON = 0x00000040,
+
+            /// <summary>
+            /// Specifies that the button displays a bitmap. See the Remarks section for its interaction with BS_ICON.
+            /// </summary>
+            BS_BITMAP = 0x00000080,
+
+            /// <summary>
+            /// Left-justifies the text in the button rectangle. However, if the button is a check box or radio button that does not have the BS_RIGHTBUTTON style, the text is left justified on the right side of the check box or radio button.
+            /// </summary>
+            BS_LEFT = 0x00000100,
+
+            /// <summary>
+            /// Right-justifies text in the button rectangle. However, if the button is a check box or radio button that does not have the BS_RIGHTBUTTON style, the text is right justified on the right side of the check box or radio button.
+            /// </summary>
+            BS_RIGHT = 0x00000200,
+
+            /// <summary>
+            /// Centers text horizontally in the button rectangle.
+            /// </summary>
+            BS_CENTER = 0x00000300,
+
+            /// <summary>
+            /// Places text at the top of the button rectangle.
+            /// </summary>
+            BS_TOP = 0x00000400,
+
+            /// <summary>
+            /// Places text at the bottom of the button rectangle.
+            /// </summary>
+            BS_BOTTOM = 0x00000800,
+
+            /// <summary>
+            /// Places text in the middle (vertically) of the button rectangle.
+            /// </summary>
+            BS_VCENTER = 0x00000C00,
+
+            /// <summary>
+            /// Makes a button (such as a check box, three-state check box, or radio button) look and act like a push button. The button looks raised when it isn't pushed or checked, and sunken when it is pushed or checked.
+            /// </summary>
+            BS_PUSHLIKE = 0x00001000,
+
+            /// <summary>
+            /// Wraps the button text to multiple lines if the text string is too long to fit on a single line in the button rectangle.
+            /// </summary>
+            BS_MULTILINE = 0x00002000,
+
+            /// <summary>
+            /// Enables a button to send BN_KILLFOCUS and BN_SETFOCUS notification codes to its parent window.
+            /// Note that buttons send the BN_CLICKED notification code regardless of whether it has this style. To get BN_DBLCLK notification codes, the button must have the BS_RADIOBUTTON or BS_OWNERDRAW style.
+            /// </summary>
+            BS_NOTIFY = 0x00004000,
+
+            /// <summary>
+            /// Specifies that the button is two-dimensional; it does not use the default shading to create a 3-D image.
+            /// </summary>
+            BS_FLAT = 0x00008000,
+
+            /// <summary>
+            /// Positions a radio button's circle or a check box's square on the right side of the button rectangle. Same as the BS_LEFTTEXT style.
+            /// </summary>
+            BS_RIGHTBUTTON = BS_LEFTTEXT,
+
+            /// <summary>
+            /// Creates a command link button that behaves like a BS_PUSHBUTTON style button, but the command link button has a green arrow on the left pointing to the button text. A caption for the button text can be set by sending the BCM_SETNOTE message to the button.
+            /// </summary>
+            BS_COMMANDLINK = 0x0000000E,
+
+            /// <summary>
+            /// Creates a command link button that behaves like a BS_PUSHBUTTON style button. If the button is in a dialog box, the user can select the command link button by pressing the ENTER key, even when the command link button does not have the input focus. This style is useful for enabling the user to quickly select the most likely (default) option.
+            /// </summary>
+            BS_DEFCOMMANDLINK = 0x0000000F,
+
+            /// <summary>
+            /// Creates a split button that behaves like a BS_PUSHBUTTON style button, but also has a distinctive appearance. If the split button is in a dialog box, the user can select the split button by pressing the ENTER key, even when the split button does not have the input focus. This style is useful for enabling the user to quickly select the most likely (default) option.
+            /// </summary>
+            BS_DEFSPLITBUTTON = 0x0000000D,
+
+            /// <summary>
+            /// Creates a split button. A split button has a drop down arrow.
+            /// </summary>
+            BS_SPLITBUTTON = 0x0000000C,
+        }
+    }
+}

--- a/src/User32/User32+WindowStyles+ComboBoxWindowStyles.cs
+++ b/src/User32/User32+WindowStyles+ComboBoxWindowStyles.cs
@@ -1,0 +1,86 @@
+﻿// Copyright © .NET Foundation and Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace PInvoke
+{
+    using System;
+
+    /// <content>
+    /// Contains the <see cref="ButtonWindowStyles"/> nested type.
+    /// </content>
+    public partial class User32
+    {
+        /// <summary>
+        /// To create a combo box using the CreateWindow or CreateWindowEx function, specify the COMBOBOX class, appropriate window style constants, and a combination of the following combo box styles.
+        /// </summary>
+        [Flags]
+        public enum ComboBoxWindowStyles : uint
+        {
+            /// <summary>
+            /// Displays the list box at all times. The current selection in the list box is displayed in the edit control.
+            /// </summary>
+            CBS_SIMPLE = 0x0001,
+
+            /// <summary>
+            /// Similar to CBS_SIMPLE, except that the list box is not displayed unless the user selects an icon next to the edit control.
+            /// </summary>
+            CBS_DROPDOWN = 0x0002,
+
+            /// <summary>
+            /// Similar to CBS_DROPDOWN, except that the edit control is replaced by a static text item that displays the current selection in the list box.
+            /// </summary>
+            CBS_DROPDOWNLIST = 0x0003,
+
+            /// <summary>
+            /// Specifies that the owner of the list box is responsible for drawing its contents and that the items in the list box are all the same height. The owner window receives a WM_MEASUREITEM message when the combo box is created and a WM_DRAWITEM message when a visual aspect of the combo box has changed.
+            /// </summary>
+            CBS_OWNERDRAWFIXED = 0x0010,
+
+            /// <summary>
+            /// Specifies that the owner of the list box is responsible for drawing its contents and that the items in the list box are variable in height. The owner window receives a WM_MEASUREITEM message for each item in the combo box when you create the combo box and a WM_DRAWITEM message when a visual aspect of the combo box has changed.
+            /// </summary>
+            CBS_OWNERDRAWVARIABLE = 0x0020,
+
+            /// <summary>
+            /// Automatically scrolls the text in an edit control to the right when the user types a character at the end of the line. If this style is not set, only text that fits within the rectangular boundary is allowed.
+            /// </summary>
+            CBS_AUTOHSCROLL = 0x0040,
+
+            /// <summary>
+            /// Converts text entered in the combo box edit control from the Windows character set to the OEM character set and then back to the Windows character set. This ensures proper character conversion when the application calls the CharToOem function to convert a Windows string in the combo box to OEM characters. This style is most useful for combo boxes that contain file names and applies only to combo boxes created with the CBS_SIMPLE or CBS_DROPDOWN style.
+            /// </summary>
+            CBS_OEMCONVERT = 0x0080,
+
+            /// <summary>
+            /// Automatically sorts strings added to the list box.
+            /// </summary>
+            CBS_SORT = 0x0100,
+
+            /// <summary>
+            /// Specifies that an owner-drawn combo box contains items consisting of strings. The combo box maintains the memory and address for the strings so the application can use the CB_GETLBTEXT message to retrieve the text for a particular item.
+            /// For accessibility issues, see Exposing Owner-Drawn Combo Box Items
+            /// </summary>
+            CBS_HASSTRINGS = 0x0200,
+
+            /// <summary>
+            /// Specifies that the size of the combo box is exactly the size specified by the application when it created the combo box. Normally, the system sizes a combo box so that it does not display partial items.
+            /// </summary>
+            CBS_NOINTEGRALHEIGHT = 0x0400,
+
+            /// <summary>
+            /// Shows a disabled vertical scroll bar in the list box when the box does not contain enough items to scroll. Without this style, the scroll bar is hidden when the list box does not contain enough items.
+            /// </summary>
+            CBS_DISABLENOSCROLL = 0x0800,
+
+            /// <summary>
+            /// Converts to uppercase all text in both the selection field and the list.
+            /// </summary>
+            CBS_UPPERCASE = 0x2000,
+
+            /// <summary>
+            /// Converts to lowercase all text in both the selection field and the list.
+            /// </summary>
+            CBS_LOWERCASE = 0x4000,
+        }
+    }
+}

--- a/src/User32/User32+WindowStyles+ComboBoxWindowStyles.cs
+++ b/src/User32/User32+WindowStyles+ComboBoxWindowStyles.cs
@@ -6,7 +6,7 @@ namespace PInvoke
     using System;
 
     /// <content>
-    /// Contains the <see cref="ButtonWindowStyles"/> nested type.
+    /// Contains the <see cref="ComboBoxWindowStyles"/> nested type.
     /// </content>
     public partial class User32
     {

--- a/src/User32/User32+WindowStyles+DialogWindowStyles.cs
+++ b/src/User32/User32+WindowStyles+DialogWindowStyles.cs
@@ -1,0 +1,103 @@
+﻿// Copyright © .NET Foundation and Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace PInvoke
+{
+    using System;
+
+    /// <content>
+    /// Contains the <see cref="DialogWindowStyles"/> nested type.
+    /// </content>
+    public partial class User32
+    {
+        /// <summary>
+        /// The following table lists the dialog box styles that you can specify when you create a dialog box. You can use these styles in calls to the CreateWindow and CreateWindowEx functions, in the style member of the DLGTEMPLATE and DLGTEMPLATEEX structures, and in the statement of a dialog box definition in a resource file.
+        /// </summary>
+        [Flags]
+        public enum DialogWindowStyles : uint
+        {
+            /// <summary>
+            /// Indicates that the coordinates of the dialog box are screen coordinates. If this style is not specified, the coordinates are client coordinates.
+            /// </summary>
+            DS_ABSALIGN = 0x01,
+
+            /// <summary>
+            /// This style is obsolete and is included for compatibility with 16-bit versions of Windows. If you specify this style, the system creates the dialog box with the WS_EX_TOPMOST style. This style does not prevent the user from accessing other windows on the desktop.
+            /// Do not combine this style with the DS_CONTROL style.
+            /// </summary>
+            DS_SYSMODAL = 0x02,
+
+            /// <summary>
+            /// Applies to 16-bit applications only. This style directs edit controls in the dialog box to allocate memory from the application's data segment. Otherwise, edit controls allocate storage from a global memory object.
+            /// </summary>
+            DS_LOCALEDIT = 0x20,
+
+            /// <summary>
+            /// Indicates that the header of the dialog box template (either standard or extended) contains additional data specifying the font to use for text in the client area and controls of the dialog box. If possible, the system selects a font according to the specified font data. The system passes a handle to the font to the dialog box and to each control by sending them the WM_SETFONT message. For descriptions of the format of this font data, see DLGTEMPLATE and DLGTEMPLATEEX.
+            /// If neither DS_SETFONT nor DS_SHELLFONT is specified, the dialog box template does not include the font data.
+            /// </summary>
+            DS_SETFONT = 0x40,
+
+            /// <summary>
+            /// Creates a dialog box with a modal dialog-box frame that can be combined with a title bar and window menu by specifying the WS_CAPTION and WS_SYSMENU styles.
+            /// </summary>
+            DS_MODALFRAME = 0x80,
+
+            /// <summary>
+            /// Suppresses WM_ENTERIDLE messages that the system would otherwise send to the owner of the dialog box while the dialog box is displayed.
+            /// </summary>
+            DS_NOIDLEMSG = 0x100,
+
+            /// <summary>
+            /// Causes the system to use the SetForegroundWindow function to bring the dialog box to the foreground. This style is useful for modal dialog boxes that require immediate attention from the user regardless of whether the owner window is the foreground window.
+            /// The system restricts which processes can set the foreground window. For more information, see Foreground and Background Windows.
+            /// </summary>
+            DS_SETFOREGROUND = 0x200,
+
+            /// <summary>
+            /// Obsolete. The system automatically applies the three-dimensional look to dialog boxes created by applications.
+            /// </summary>
+            DS_3DLOOK = 0x0004,
+
+            /// <summary>
+            /// Causes the dialog box to use the SYSTEM_FIXED_FONT instead of the default SYSTEM_FONT. This is a monospace font compatible with the System font in 16-bit versions of Windows earlier than 3.0.
+            /// </summary>
+            DS_FIXEDSYS = 0x0008,
+
+            /// <summary>
+            /// Creates the dialog box even if errors occur for example, if a child window cannot be created or if the system cannot create a special data segment for an edit control.
+            /// </summary>
+            DS_NOFAILCREATE = 0x0010,
+
+            /// <summary>
+            /// Creates a dialog box that works well as a child window of another dialog box, much like a page in a property sheet. This style allows the user to tab among the control windows of a child dialog box, use its accelerator keys, and so on.
+            /// </summary>
+            DS_CONTROL = 0x0400,
+
+            /// <summary>
+            /// Centers the dialog box in the working area of the monitor that contains the owner window. If no owner window is specified, the dialog box is centered in the working area of a monitor determined by the system. The working area is the area not obscured by the taskbar or any appbars.
+            /// </summary>
+            DS_CENTER = 0x0800,
+
+            /// <summary>
+            /// Centers the dialog box on the mouse cursor.
+            /// </summary>
+            DS_CENTERMOUSE = 0x1000,
+
+            /// <summary>
+            /// Includes a question mark in the title bar of the dialog box. When the user clicks the question mark, the cursor changes to a question mark with a pointer. If the user then clicks a control in the dialog box, the control receives a WM_HELP message. The control should pass the message to the dialog box procedure, which should call the function using the HELP_WM_HELP command. The help application displays a pop-up window that typically contains help for the control.
+            /// Note that DS_CONTEXTHELP is only a placeholder. When the dialog box is created, the system checks for DS_CONTEXTHELP and, if it is there, adds WS_EX_CONTEXTHELP to the extended style of the dialog box. WS_EX_CONTEXTHELP cannot be used with the WS_MAXIMIZEBOX or WS_MINIMIZEBOX styles.
+            /// </summary>
+            DS_CONTEXTHELP = 0x2000,
+
+            /// <summary>
+            /// Indicates that the dialog box should use the system font. The typeface member of the extended dialog box template must be set to MS Shell Dlg. Otherwise, this style has no effect. It is also recommended that you use the DIALOGEX Resource, rather than the DIALOG Resource. For more information, see Dialog Box Fonts.
+            /// The system selects a font using the font data specified in the pointsize, weight, and italic members. The system passes a handle to the font to the dialog box and to each control by sending them the WM_SETFONT message. For descriptions of the format of this font data, see DLGTEMPLATEEX.
+            /// If neither DS_SHELLFONT nor DS_SETFONT is specified, the extended dialog box template does not include the font data.
+            /// </summary>
+            DS_SHELLFONT = DS_SETFONT | DS_FIXEDSYS,
+
+            DS_USEPIXELS = 0x8000,
+        }
+    }
+}

--- a/src/User32/User32+WindowStyles+EditControlWindowStyles.cs
+++ b/src/User32/User32+WindowStyles+EditControlWindowStyles.cs
@@ -1,0 +1,102 @@
+﻿// Copyright © .NET Foundation and Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace PInvoke
+{
+    using System;
+
+    /// <content>
+    /// Contains the <see cref="EditControlWindowStyles"/> nested type.
+    /// </content>
+    public partial class User32
+    {
+        /// <summary>
+        /// To create an edit control using the CreateWindow or CreateWindowEx function, specify the EDIT class, appropriate window style constants, and a combination of the following edit control styles. After the control has been created, these styles cannot be modified, except as noted.
+        /// </summary>
+        [Flags]
+        public enum EditControlWindowStyles : uint
+        {
+            /// <summary>
+            /// Aligns text with the left margin.
+            /// </summary>
+            ES_LEFT = 0x0000,
+
+            /// <summary>
+            /// Centers text in a single-line or multiline edit control.
+            /// </summary>
+            ES_CENTER = 0x0001,
+
+            /// <summary>
+            /// Right-aligns text in a single-line or multiline edit control.
+            /// </summary>
+            ES_RIGHT = 0x0002,
+
+            /// <summary>
+            /// Designates a multiline edit control. The default is single-line edit control.
+            /// When the multiline edit control is in a dialog box, the default response to pressing the ENTER key is to activate the default button. To use the ENTER key as a carriage return, use the ES_WANTRETURN style.
+            /// When the multiline edit control is not in a dialog box and the ES_AUTOVSCROLL style is specified, the edit control shows as many lines as possible and scrolls vertically when the user presses the ENTER key. If you do not specify ES_AUTOVSCROLL, the edit control shows as many lines as possible and beeps if the user presses the ENTER key when no more lines can be displayed.
+            /// If you specify the ES_AUTOHSCROLL style, the multiline edit control automatically scrolls horizontally when the caret goes past the right edge of the control. To start a new line, the user must press the ENTER key. If you do not specify ES_AUTOHSCROLL, the control automatically wraps words to the beginning of the next line when necessary. A new line is also started if the user presses the ENTER key. The window size determines the position of the Wordwrap. If the window size changes, the Wordwrapping position changes and the text is redisplayed.
+            /// Multiline edit controls can have scroll bars. An edit control with scroll bars processes its own scroll bar messages. Note that edit controls without scroll bars scroll as described in the previous paragraphs and process any scroll messages sent by the parent window.
+            /// </summary>
+            ES_MULTILINE = 0x0004,
+
+            /// <summary>
+            /// Converts all characters to uppercase as they are typed into the edit control.
+            /// To change this style after the control has been created, use SetWindowLong.
+            /// </summary>
+            ES_UPPERCASE = 0x0008,
+
+            /// <summary>
+            /// Converts all characters to lowercase as they are typed into the edit control.
+            /// To change this style after the control has been created, use SetWindowLong.
+            /// </summary>
+            ES_LOWERCASE = 0x0010,
+
+            /// <summary>
+            /// Displays an asterisk (*) for each character typed into the edit control. This style is valid only for single-line edit controls.
+            /// To change the characters that is displayed, or set or clear this style, use the EM_SETPASSWORDCHAR message.
+            /// </summary>
+            ES_PASSWORD = 0x0020,
+
+            /// <summary>
+            /// Automatically scrolls text up one page when the user presses the ENTER key on the last line.
+            /// </summary>
+            ES_AUTOVSCROLL = 0x0040,
+
+            /// <summary>
+            /// Automatically scrolls text to the right by 10 characters when the user types a character at the end of the line. When the user presses the ENTER key, the control scrolls all text back to position zero.
+            /// </summary>
+            ES_AUTOHSCROLL = 0x0080,
+
+            /// <summary>
+            /// Negates the default behavior for an edit control. The default behavior hides the selection when the control loses the input focus and inverts the selection when the control receives the input focus. If you specify ES_NOHIDESEL, the selected text is inverted, even if the control does not have the focus.
+            /// </summary>
+            ES_NOHIDESEL = 0x0100,
+
+            /// <summary>
+            /// Converts text entered in the edit control. The text is converted from the Windows character set to the OEM character set and then back to the Windows character set. This ensures proper character conversion when the application calls the CharToOem function to convert a Windows string in the edit control to OEM characters. This style is most useful for edit controls that contain file names that will be used on file systems that do not support Unicode.
+            /// To change this style after the control has been created, use SetWindowLong.
+            /// </summary>
+            ES_OEMCONVERT = 0x0400,
+
+            /// <summary>
+            /// Prevents the user from typing or editing text in the edit control.
+            /// To change this style after the control has been created, use the EM_SETREADONLY message.
+            /// </summary>
+            ES_READONLY = 0x0800,
+
+            /// <summary>
+            /// Specifies that a carriage return be inserted when the user presses the ENTER key while entering text into a multiline edit control in a dialog box. If you do not specify this style, pressing the ENTER key has the same effect as pressing the dialog box's default push button. This style has no effect on a single-line edit control.
+            /// To change this style after the control has been created, use SetWindowLong.
+            /// </summary>
+            ES_WANTRETURN = 0x1000,
+
+            /// <summary>
+            /// Allows only digits to be entered into the edit control. Note that, even with this set, it is still possible to paste non-digits into the edit control.
+            /// To change this style after the control has been created, use SetWindowLong.
+            /// To translate text that was entered into the edit control to an integer value, use the GetDlgItemInt function. To set the text of the edit control to the string representation of a specified integer, use the SetDlgItemInt function.
+            /// </summary>
+            ES_NUMBER = 0x2000,
+        }
+    }
+}

--- a/src/User32/User32+WindowStyles+ListBoxWindowStyles.cs
+++ b/src/User32/User32+WindowStyles+ListBoxWindowStyles.cs
@@ -1,0 +1,113 @@
+﻿// Copyright © .NET Foundation and Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace PInvoke
+{
+    using System;
+
+    /// <content>
+    /// Contains the <see cref="ListBoxWindowStyles"/> nested type.
+    /// </content>
+    public partial class User32
+    {
+        /// <summary>
+        /// To create a list box by using the CreateWindow or CreateWindowEx function, use the LISTBOX class, appropriate window style constants, and the following style constants to define the list box. After the control has been created, these styles cannot be modified, except as noted.
+        /// </summary>
+        [Flags]
+        public enum ListBoxWindowStyles : uint
+        {
+            /// <summary>
+            /// Causes the list box to send a notification code to the parent window whenever the user clicks a list box item (LBN_SELCHANGE), double-clicks an item (LBN_DBLCLK), or cancels the selection (LBN_SELCANCEL).
+            /// </summary>
+            LBS_NOTIFY = 0x0001,
+
+            /// <summary>
+            /// Sorts strings in the list box alphabetically.
+            /// </summary>
+            LBS_SORT = 0x0002,
+
+            /// <summary>
+            /// Specifies that the list box's appearance is not updated when changes are made.
+            /// To change the redraw state of the control, use the WM_SETREDRAW message.
+            /// </summary>
+            LBS_NOREDRAW = 0x0004,
+
+            /// <summary>
+            /// Turns string selection on or off each time the user clicks or double-clicks a string in the list box. The user can select any number of strings.
+            /// </summary>
+            LBS_MULTIPLESEL = 0x0008,
+
+            /// <summary>
+            /// Specifies that the owner of the list box is responsible for drawing its contents and that the items in the list box are the same height. The owner window receives a WM_MEASUREITEM message when the list box is created and a WM_DRAWITEM message when a visual aspect of the list box has changed.
+            /// </summary>
+            LBS_OWNERDRAWFIXED = 0x0010,
+
+            /// <summary>
+            /// Specifies that the owner of the list box is responsible for drawing its contents and that the items in the list box are variable in height. The owner window receives a WM_MEASUREITEM message for each item in the box when the list box is created and a WM_DRAWITEM message when a visual aspect of the list box has changed.
+            /// This style causes the LBS_NOINTEGRALHEIGHT style to be enabled.
+            /// This style is ignored if the LBS_MULTICOLUMN style is specified.
+            /// </summary>
+            LBS_OWNERDRAWVARIABLE = 0x0020,
+
+            /// <summary>
+            /// Specifies that a list box contains items consisting of strings. The list box maintains the memory and addresses for the strings so that the application can use the LB_GETTEXT message to retrieve the text for a particular item. By default, all list boxes except owner-drawn list boxes have this style. You can create an owner-drawn list box either with or without this style.
+            /// For owner-drawn list boxes without this style, the LB_GETTEXT message retrieves the value associated with an item (the item data).
+            /// </summary>
+            LBS_HASSTRINGS = 0x0040,
+
+            /// <summary>
+            /// Enables a list box to recognize and expand tab characters when drawing its strings. You can use the LB_SETTABSTOPS message to specify tab stop positions. The default tab positions are 32 dialog template units apart. Dialog template units are the device-independent units used in dialog box templates. To convert measurements from dialog template units to screen units (pixels), use the MapDialogRect function.
+            /// </summary>
+            LBS_USETABSTOPS = 0x0080,
+
+            /// <summary>
+            /// Specifies that the size of the list box is exactly the size specified by the application when it created the list box. Normally, the system sizes a list box so that the list box does not display partial items.
+            /// For list boxes with the LBS_OWNERDRAWVARIABLE style, the LBS_NOINTEGRALHEIGHT style is always enforced.
+            /// </summary>
+            LBS_NOINTEGRALHEIGHT = 0x0100,
+
+            /// <summary>
+            /// Specifies a multi-column list box that is scrolled horizontally. The list box automatically calculates the width of the columns, or an application can set the width by using the LB_SETCOLUMNWIDTH message. If a list box has the LBS_OWNERDRAWFIXED style, an application can set the width when the list box sends the WM_MEASUREITEM message.
+            /// A list box with the LBS_MULTICOLUMN style cannot scroll vertically it ignores any WM_VSCROLL messages it receives.
+            /// The LBS_MULTICOLUMN and LBS_OWNERDRAWVARIABLE styles cannot be combined. If both are specified, LBS_OWNERDRAWVARIABLE is ignored.
+            /// </summary>
+            LBS_MULTICOLUMN = 0x0200,
+
+            /// <summary>
+            /// Specifies that the owner of the list box receives WM_VKEYTOITEM messages whenever the user presses a key and the list box has the input focus. This enables an application to perform special processing on the keyboard input.
+            /// </summary>
+            LBS_WANTKEYBOARDINPUT = 0x0400,
+
+            /// <summary>
+            /// Allows multiple items to be selected by using the SHIFT key and the mouse or special key combinations.
+            /// </summary>
+            LBS_EXTENDEDSEL = 0x0800,
+
+            /// <summary>
+            /// Shows a disabled horizontal or vertical scroll bar when the list box does not contain enough items to scroll. If you do not specify this style, the scroll bar is hidden when the list box does not contain enough items. This style must be used with the WS_VSCROLL or WS_HSCROLL style.
+            /// </summary>
+            LBS_DISABLENOSCROLL = 0x1000,
+
+            /// <summary>
+            /// Specifies a no-data list box. Specify this style when the count of items in the list box will exceed one thousand. A no-data list box must also have the LBS_OWNERDRAWFIXED style, but must not have the LBS_SORT or LBS_HASSTRINGS style.
+            /// A no-data list box resembles an owner-drawn list box except that it contains no string or bitmap data for an item. Commands to add, insert, or delete an item always ignore any specified item data; requests to find a string within the list box always fail. The system sends the WM_DRAWITEM message to the owner window when an item must be drawn. The itemID member of the DRAWITEMSTRUCT structure passed with the WM_DRAWITEM message specifies the line number of the item to be drawn. A no-data list box does not send a WM_DELETEITEM message.
+            /// </summary>
+            LBS_NODATA = 0x2000,
+
+            /// <summary>
+            /// Specifies that the list box contains items that can be viewed but not selected.
+            /// </summary>
+            LBS_NOSEL = 0x4000,
+
+            /// <summary>
+            /// Notifies a list box that it is part of a combo box. This allows coordination between the two controls so that they present a unified UI. The combo box itself must set this style. If the style is set by anything but the combo box, the list box will regard itself incorrectly as a child of a combo box and a failure will result.
+            /// </summary>
+            LBS_COMBOBOX = 0x8000,
+
+            /// <summary>
+            /// Sorts strings in the list box alphabetically. The parent window receives a notification code whenever the user clicks a list box item, double-clicks an item, or or cancels the selection. The list box has a vertical scroll bar, and it has borders on all sides. This style combines the LBS_NOTIFY, LBS_SORT, WS_VSCROLL, and WS_BORDER styles.
+            /// </summary>
+            LBS_STANDARD = LBS_NOTIFY | LBS_SORT | WindowStyles.WS_VSCROLL | WindowStyles.WS_BORDER,
+        }
+    }
+}

--- a/src/User32/User32+WindowStyles+ProgressBarWindowStyles.cs
+++ b/src/User32/User32+WindowStyles+ProgressBarWindowStyles.cs
@@ -1,0 +1,40 @@
+﻿// Copyright © .NET Foundation and Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace PInvoke
+{
+    using System;
+
+    /// <content>
+    /// Contains the <see cref="ProgressBarWindowStyles"/> nested type.
+    /// </content>
+    public partial class User32
+    {
+        /// <summary>
+        /// Specifies a combination of button styles. If you create a button using the BUTTON class with the CreateWindow or CreateWindowEx function, you can specify any of the button styles listed below.
+        /// </summary>
+        [Flags]
+        public enum ProgressBarWindowStyles : uint
+        {
+            /// <summary>
+            /// Version 4.70 or later. The progress bar displays progress status vertically, from bottom to top.
+            /// </summary>
+            PBS_VERTICAL = 0x04,
+
+            /// <summary>
+            /// Version 6.0 or later. The progress indicator does not grow in size but instead moves repeatedly along the length of the bar, indicating activity without specifying what proportion of the progress is complete.
+            /// </summary>
+            PBS_MARQUEE = 0x08,
+
+            /// <summary>
+            /// Version 4.70 or later. The progress bar displays progress status in a smooth scrolling bar instead of the default segmented bar.
+            /// </summary>
+            PBS_SMOOTH = 0x01,
+
+            /// <summary>
+            /// Version 6.0 or later and Windows Vista. Determines the animation behavior that the progress bar should use when moving backward (from a higher value to a lower value). If this is set, then a "smooth" transition will occur, otherwise the control will "jump" to the lower value.
+            /// </summary>
+            PBS_SMOOTHREVERSE = 0x10,
+        }
+    }
+}

--- a/src/User32/User32+WindowStyles+ScrollBarWindowStyles.cs
+++ b/src/User32/User32+WindowStyles+ScrollBarWindowStyles.cs
@@ -37,7 +37,7 @@ namespace PInvoke
             SBS_LEFTALIGN = 0x0002,
 
             /// <summary>
-            /// 	Aligns the bottom edge of the scroll bar with the bottom edge of the rectangle defined by the x, y, nWidth, and nHeight parameters of CreateWindowEx function. The scroll bar has the default height for system scroll bars. Use this style with the SBS_HORZ style.
+            /// Aligns the bottom edge of the scroll bar with the bottom edge of the rectangle defined by the x, y, nWidth, and nHeight parameters of CreateWindowEx function. The scroll bar has the default height for system scroll bars. Use this style with the SBS_HORZ style.
             /// </summary>
             SBS_BOTTOMALIGN = 0x0004,
 
@@ -47,7 +47,7 @@ namespace PInvoke
             SBS_RIGHTALIGN = 0x0004,
 
             /// <summary>
-            /// 	Aligns the upper left corner of the size box with the upper left corner of the rectangle specified by the x, y, nWidth, and nHeight parameters of CreateWindowEx. The size box has the default size for system size boxes. Use this style with the SBS_SIZEBOX or SBS_SIZEGRIP styles.
+            /// Aligns the upper left corner of the size box with the upper left corner of the rectangle specified by the x, y, nWidth, and nHeight parameters of CreateWindowEx. The size box has the default size for system size boxes. Use this style with the SBS_SIZEBOX or SBS_SIZEGRIP styles.
             /// </summary>
             SBS_SIZEBOXTOPLEFTALIGN = 0x0002,
 

--- a/src/User32/User32+WindowStyles+ScrollBarWindowStyles.cs
+++ b/src/User32/User32+WindowStyles+ScrollBarWindowStyles.cs
@@ -1,0 +1,70 @@
+﻿// Copyright © .NET Foundation and Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace PInvoke
+{
+    using System;
+
+    /// <content>
+    /// Contains the <see cref="ScrollBarWindowStyles"/> nested type.
+    /// </content>
+    public partial class User32
+    {
+        /// <summary>
+        /// To create a scroll bar control using the CreateWindow or CreateWindowEx function specify the SCROLLBAR class, appropriate window style constants, and a combination of the following scroll bar control styles. Some of the styles create a scroll bar control that uses a default width or height. However, you must always specify the x- and y-coordinates and the other dimensions of the scroll bar when you call CreateWindow or CreateWindowEx.
+        /// </summary>
+        [Flags]
+        public enum ScrollBarWindowStyles : uint
+        {
+            /// <summary>
+            /// Designates a horizontal scroll bar. If neither the SBS_BOTTOMALIGN nor SBS_TOPALIGN style is specified, the scroll bar has the height, width, and position specified by the x, y, nWidth, and nHeight parameters of CreateWindowEx.
+            /// </summary>
+            SBS_HORZ = 0x0000,
+
+            /// <summary>
+            /// Designates a vertical scroll bar. If you specify neither the SBS_RIGHTALIGN nor the SBS_LEFTALIGN style, the scroll bar has the height, width, and position specified by the x, y, nWidth, and nHeight parameters of CreateWindowEx.
+            /// </summary>
+            SBS_VERT = 0x0001,
+
+            /// <summary>
+            /// Aligns the top edge of the scroll bar with the top edge of the rectangle defined by the x, y, nWidth, and nHeight parameters of CreateWindowEx. The scroll bar has the default height for system scroll bars. Use this style with the SBS_HORZ style.
+            /// </summary>
+            SBS_TOPALIGN = 0x0002,
+
+            /// <summary>
+            /// Aligns the left edge of the scroll bar with the left edge of the rectangle defined by the x, y, nWidth, and nHeight parameters of CreateWindowEx. The scroll bar has the default width for system scroll bars. Use this style with the SBS_VERT style.
+            /// </summary>
+            SBS_LEFTALIGN = 0x0002,
+
+            /// <summary>
+            /// 	Aligns the bottom edge of the scroll bar with the bottom edge of the rectangle defined by the x, y, nWidth, and nHeight parameters of CreateWindowEx function. The scroll bar has the default height for system scroll bars. Use this style with the SBS_HORZ style.
+            /// </summary>
+            SBS_BOTTOMALIGN = 0x0004,
+
+            /// <summary>
+            /// Aligns the right edge of the scroll bar with the right edge of the rectangle defined by the x, y, nWidth, and nHeight parameters of CreateWindowEx. The scroll bar has the default width for system scroll bars. Use this style with the SBS_VERT style.
+            /// </summary>
+            SBS_RIGHTALIGN = 0x0004,
+
+            /// <summary>
+            /// 	Aligns the upper left corner of the size box with the upper left corner of the rectangle specified by the x, y, nWidth, and nHeight parameters of CreateWindowEx. The size box has the default size for system size boxes. Use this style with the SBS_SIZEBOX or SBS_SIZEGRIP styles.
+            /// </summary>
+            SBS_SIZEBOXTOPLEFTALIGN = 0x0002,
+
+            /// <summary>
+            /// Aligns the lower right corner of the size box with the lower right corner of the rectangle specified by the x, y, nWidth, and nHeight parameters of CreateWindowEx. The size box has the default size for system size boxes. Use this style with the SBS_SIZEBOX or SBS_SIZEGRIP styles.
+            /// </summary>
+            SBS_SIZEBOXBOTTOMRIGHTALIGN = 0x0004,
+
+            /// <summary>
+            /// Designates a size box. If you specify neither the SBS_SIZEBOXBOTTOMRIGHTALIGN nor the SBS_SIZEBOXTOPLEFTALIGN style, the size box has the height, width, and position specified by the x, y, nWidth, and nHeight parameters of CreateWindowEx.
+            /// </summary>
+            SBS_SIZEBOX = 0x0008,
+
+            /// <summary>
+            /// Same as SBS_SIZEBOX, but with a raised edge.
+            /// </summary>
+            SBS_SIZEGRIP = 0x0010,
+        }
+    }
+}

--- a/src/User32/User32+WindowStyles+StaticControlWindowStyles.cs
+++ b/src/User32/User32+WindowStyles+StaticControlWindowStyles.cs
@@ -1,0 +1,187 @@
+﻿// Copyright © .NET Foundation and Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace PInvoke
+{
+    using System;
+
+    /// <content>
+    /// Contains the <see cref="StaticControlWindowStyles"/> nested type.
+    /// </content>
+    public partial class User32
+    {
+        /// <summary>
+        /// To create a static control using the CreateWindow or CreateWindowEx function, specify the STATIC class, appropriate window style constants, and a combination of the following static control styles.
+        /// </summary>
+        [Flags]
+        public enum StaticControlWindowStyles : uint
+        {
+            /// <summary>
+            /// 	A simple rectangle and left-aligns the text in the rectangle. The text is formatted before it is displayed. Words that extend past the end of a line are automatically wrapped to the beginning of the next left-aligned line. Words that are longer than the width of the control are truncated.
+            /// </summary>
+            SS_LEFT = 0x00000000,
+
+            /// <summary>
+            /// A simple rectangle and centers the text in the rectangle. The text is formatted before it is displayed. Words that extend past the end of a line are automatically wrapped to the beginning of the next centered line. Words that are longer than the width of the control are truncated.
+            /// </summary>
+            SS_CENTER = 0x00000001,
+
+            /// <summary>
+            /// 	A simple rectangle and right-aligns the text in the rectangle. The text is formatted before it is displayed. Words that extend past the end of a line are automatically wrapped to the beginning of the next right-aligned line. Words that are longer than the width of the control are truncated.
+            /// </summary>
+            SS_RIGHT = 0x00000002,
+
+            /// <summary>
+            /// An icon to be displayed in the dialog box. If the control is created as part of a dialog box, the text is the name of an icon (not a filename) defined elsewhere in the resource file. If the control is created via CreateWindow or a related function, the text is the name of an icon (not a filename) defined in the resource file associated with the module specified by the hInstance parameter to CreateWindow.
+            /// The icon can be an animated cursor.
+            /// The style ignores the CreateWindow parameters nWidth and nHeight; the control automatically sizes itself to accommodate the icon. As it uses the LoadIcon function, the SS_ICON style can load only icons of dimensions SM_CXICON and SM_CYICON. This restriction can be bypassed by using the SS_REALSIZEIMAGE style in addition to SS_ICON.
+            /// If an icon cannot be loaded through LoadIcon, an attempt is made to load the specified resource as a cursor using LoadCursor. If that too fails, an attempt is made to load from the device driver using LoadImage.
+            /// </summary>
+            SS_ICON = 0x00000003,
+
+            /// <summary>
+            /// A rectangle filled with the current window frame color. This color is black in the default color scheme.
+            /// </summary>
+            SS_BLACKRECT = 0x00000004,
+
+            /// <summary>
+            /// A rectangle filled with the current screen background color. This color is gray in the default color scheme.
+            /// </summary>
+            SS_GRAYRECT = 0x00000005,
+
+            /// <summary>
+            /// A rectangle filled with the current window background color. This color is white in the default color scheme.
+            /// </summary>
+            SS_WHITERECT = 0x00000006,
+
+            /// <summary>
+            /// A box with a frame drawn in the same color as the window frames. This color is black in the default color scheme.
+            /// </summary>
+            SS_BLACKFRAME = 0x00000007,
+
+            /// <summary>
+            /// A box with a frame drawn with the same color as the screen background (desktop). This color is gray in the default color scheme.
+            /// </summary>
+            SS_GRAYFRAME = 0x00000008,
+
+            /// <summary>
+            /// A box with a frame drawn with the same color as the window background. This color is white in the default color scheme.
+            /// </summary>
+            SS_WHITEFRAME = 0x00000009,
+
+            SS_USERITEM = 0x0000000A,
+
+            /// <summary>
+            /// A simple rectangle and displays a single line of left-aligned text in the rectangle. The text line cannot be shortened or altered in any way. Also, if the control is disabled, the control does not gray its text.
+            /// </summary>
+            SS_SIMPLE = 0x0000000B,
+
+            /// <summary>
+            /// 	A simple rectangle and left-aligns the text in the rectangle. Tabs are expanded, but words are not wrapped. Text that extends past the end of a line is clipped.
+            /// </summary>
+            SS_LEFTNOWORDWRAP = 0x0000000C,
+
+            /// <summary>
+            /// 	The owner of the static control is responsible for drawing the control. The owner window receives a WM_DRAWITEM message whenever the control needs to be drawn.
+            /// </summary>
+            SS_OWNERDRAW = 0x0000000D,
+
+            /// <summary>
+            /// A bitmap is to be displayed in the static control. The text is the name of a bitmap (not a filename) defined elsewhere in the resource file. The style ignores the nWidth and nHeight parameters; the control automatically sizes itself to accommodate the bitmap.
+            /// </summary>
+            SS_BITMAP = 0x0000000E,
+
+            /// <summary>
+            /// 	An enhanced metafile is to be displayed in the static control. The text is the name of a metafile. An enhanced metafile static control has a fixed size; the metafile is scaled to fit the static control's client area.
+            /// </summary>
+            SS_ENHMETAFILE = 0x0000000F,
+
+            /// <summary>
+            /// Draws the top and bottom edges of the static control using the EDGE_ETCHED edge style. For more information, see the DrawEdge function.
+            /// </summary>
+            SS_ETCHEDHORZ = 0x00000010,
+
+            /// <summary>
+            /// Draws the left and right edges of the static control using the EDGE_ETCHED edge style. For more information, see the DrawEdge function.
+            /// </summary>
+            SS_ETCHEDVERT = 0x00000011,
+
+            /// <summary>
+            /// Draws the frame of the static control using the EDGE_ETCHED edge style. For more information, see the DrawEdge function.
+            /// </summary>
+            SS_ETCHEDFRAME = 0x00000012,
+
+            /// <summary>
+            /// A composite style bit that results from using the OR operator on SS_* style bits. Can be used to mask out valid SS_* bits from a given bitmask. Note that this is out of date and does not correctly include all valid styles. Thus, you should not use this style.
+            /// </summary>
+            SS_TYPEMASK = 0x0000001F,
+
+            /// <summary>
+            /// Adjusts the bitmap to fit the size of the static control. For example, changing the locale can change the system font, and thus controls might be resized. If a static control had a bitmap, the bitmap would no longer fit the control. This style bit dictates automatic redimensioning of bitmaps to fit their controls.
+            /// If SS_CENTERIMAGE is specified, the bitmap or icon is centered (and clipped if needed). If SS_CENTERIMAGE is not specified, the bitmap or icon is stretched or shrunk.
+            /// Note that the redimensioning in the two axes are independent, and the result may have a changed aspect ratio.
+            /// Compare with SS_REALSIZEIMAGE.
+            /// </summary>
+            SS_REALSIZECONTROL = 0x00000040,
+
+            /// <summary>
+            /// Prevents interpretation of any ampersand (&) characters in the control's text as accelerator prefix characters. These are displayed with the ampersand removed and the next character in the string underlined. This static control style may be included with any of the defined static controls. You can combine SS_NOPREFIX with other styles. This can be useful when filenames or other strings that may contain an ampersand (&) must be displayed in a static control in a dialog box.
+            /// </summary>
+            SS_NOPREFIX = 0x00000080,
+
+            /// <summary>
+            /// Sends the parent window STN_CLICKED, STN_DBLCLK, STN_DISABLE, and STN_ENABLE notification codes when the user clicks or double-clicks the control.
+            /// </summary>
+            SS_NOTIFY = 0x00000100,
+
+            /// <summary>
+            /// A bitmap is centered in the static control that contains it. The control is not resized, so that a bitmap too large for the control will be clipped. If the static control contains a single line of text, the text is centered vertically in the client area of the control.
+            /// </summary>
+            SS_CENTERIMAGE = 0x00000200,
+
+            /// <summary>
+            /// 	The lower right corner of a static control with the SS_BITMAP or SS_ICON style is to remain fixed when the control is resized. Only the top and left sides are adjusted to accommodate a new bitmap or icon.
+            /// </summary>
+            SS_RIGHTJUST = 0x00000400,
+
+            /// <summary>
+            /// Specifies that the actual resource width is used and the icon is loaded using LoadImage. SS_REALSIZEIMAGE is always used in conjunction with SS_ICON.
+            /// SS_REALSIZEIMAGE uses LoadImage, overriding the process normally followed under SS_ICON. It does not load cursors; if LoadImage fails, no further attempts to load are made. It uses the actual resource width. The static control is resized accordingly, but the icon remains aligned to the originally specified left and top edges of the control.
+            /// Note that if SS_CENTERIMAGE is also specified, the icon is centered within the control's space, which was specified using the CreateWindow parameters nWidth and nHeight.
+            /// Compare with SS_REALSIZECONTROL.
+            /// </summary>
+            SS_REALSIZEIMAGE = 0x00000800,
+
+            /// <summary>
+            /// Draws a half-sunken border around a static control.
+            /// </summary>
+            SS_SUNKEN = 0x00001000,
+
+            /// <summary>
+            /// The static control duplicates the text-displaying characteristics of a multiline edit control. Specifically, the average character width is calculated in the same manner as with an edit control, and the function does not display a partially visible last line.
+            /// </summary>
+            SS_EDITCONTROL = 0x00002000,
+
+            /// <summary>
+            /// 	If the end of a string does not fit in the rectangle, it is truncated and ellipses are added. If a word that is not at the end of the string goes beyond the limits of the rectangle, it is truncated without ellipses. Using this style will force the control s text to be on one line with no word wrap. Compare with SS_PATHELLIPSIS and SS_WORDELLIPSIS.
+            /// </summary>
+            SS_ENDELLIPSIS = 0x00004000,
+
+            /// <summary>
+            /// Replaces characters in the middle of the string with ellipses so that the result fits in the specified rectangle. If the string contains backslash () characters, SS_PATHELLIPSIS preserves as much as possible of the text after the last backslash. Using this style will force the control s text to be on one line with no word wrap. Compare with SS_ENDELLIPSIS and SS_WORDELLIPSIS.
+            /// </summary>
+            SS_PATHELLIPSIS = 0x00008000,
+
+            /// <summary>
+            /// Truncates any word that does not fit in the rectangle and adds ellipses. Using this style will force the control s text to be on one line with no word wrap.
+            /// Compare with SS_ENDELLIPSIS and SS_PATHELLIPSIS.
+            /// </summary>
+            SS_WORDELLIPSIS = 0x0000C000,
+
+            /// <summary>
+            /// Same as <see cref="SS_WORDELLIPSIS"/>
+            /// </summary>
+            SS_ELLIPSISMASK = 0x0000C000,
+        }
+    }
+}

--- a/src/User32/User32+WindowStyles+StaticControlWindowStyles.cs
+++ b/src/User32/User32+WindowStyles+StaticControlWindowStyles.cs
@@ -17,7 +17,7 @@ namespace PInvoke
         public enum StaticControlWindowStyles : uint
         {
             /// <summary>
-            /// 	A simple rectangle and left-aligns the text in the rectangle. The text is formatted before it is displayed. Words that extend past the end of a line are automatically wrapped to the beginning of the next left-aligned line. Words that are longer than the width of the control are truncated.
+            /// A simple rectangle and left-aligns the text in the rectangle. The text is formatted before it is displayed. Words that extend past the end of a line are automatically wrapped to the beginning of the next left-aligned line. Words that are longer than the width of the control are truncated.
             /// </summary>
             SS_LEFT = 0x00000000,
 
@@ -27,7 +27,7 @@ namespace PInvoke
             SS_CENTER = 0x00000001,
 
             /// <summary>
-            /// 	A simple rectangle and right-aligns the text in the rectangle. The text is formatted before it is displayed. Words that extend past the end of a line are automatically wrapped to the beginning of the next right-aligned line. Words that are longer than the width of the control are truncated.
+            /// A simple rectangle and right-aligns the text in the rectangle. The text is formatted before it is displayed. Words that extend past the end of a line are automatically wrapped to the beginning of the next right-aligned line. Words that are longer than the width of the control are truncated.
             /// </summary>
             SS_RIGHT = 0x00000002,
 
@@ -77,12 +77,12 @@ namespace PInvoke
             SS_SIMPLE = 0x0000000B,
 
             /// <summary>
-            /// 	A simple rectangle and left-aligns the text in the rectangle. Tabs are expanded, but words are not wrapped. Text that extends past the end of a line is clipped.
+            /// A simple rectangle and left-aligns the text in the rectangle. Tabs are expanded, but words are not wrapped. Text that extends past the end of a line is clipped.
             /// </summary>
             SS_LEFTNOWORDWRAP = 0x0000000C,
 
             /// <summary>
-            /// 	The owner of the static control is responsible for drawing the control. The owner window receives a WM_DRAWITEM message whenever the control needs to be drawn.
+            /// The owner of the static control is responsible for drawing the control. The owner window receives a WM_DRAWITEM message whenever the control needs to be drawn.
             /// </summary>
             SS_OWNERDRAW = 0x0000000D,
 
@@ -92,7 +92,7 @@ namespace PInvoke
             SS_BITMAP = 0x0000000E,
 
             /// <summary>
-            /// 	An enhanced metafile is to be displayed in the static control. The text is the name of a metafile. An enhanced metafile static control has a fixed size; the metafile is scaled to fit the static control's client area.
+            /// An enhanced metafile is to be displayed in the static control. The text is the name of a metafile. An enhanced metafile static control has a fixed size; the metafile is scaled to fit the static control's client area.
             /// </summary>
             SS_ENHMETAFILE = 0x0000000F,
 
@@ -125,7 +125,7 @@ namespace PInvoke
             SS_REALSIZECONTROL = 0x00000040,
 
             /// <summary>
-            /// Prevents interpretation of any ampersand (&) characters in the control's text as accelerator prefix characters. These are displayed with the ampersand removed and the next character in the string underlined. This static control style may be included with any of the defined static controls. You can combine SS_NOPREFIX with other styles. This can be useful when filenames or other strings that may contain an ampersand (&) must be displayed in a static control in a dialog box.
+            /// Prevents interpretation of any ampersand (&amp;) characters in the control's text as accelerator prefix characters. These are displayed with the ampersand removed and the next character in the string underlined. This static control style may be included with any of the defined static controls. You can combine SS_NOPREFIX with other styles. This can be useful when filenames or other strings that may contain an ampersand (&amp;) must be displayed in a static control in a dialog box.
             /// </summary>
             SS_NOPREFIX = 0x00000080,
 
@@ -140,7 +140,7 @@ namespace PInvoke
             SS_CENTERIMAGE = 0x00000200,
 
             /// <summary>
-            /// 	The lower right corner of a static control with the SS_BITMAP or SS_ICON style is to remain fixed when the control is resized. Only the top and left sides are adjusted to accommodate a new bitmap or icon.
+            /// The lower right corner of a static control with the SS_BITMAP or SS_ICON style is to remain fixed when the control is resized. Only the top and left sides are adjusted to accommodate a new bitmap or icon.
             /// </summary>
             SS_RIGHTJUST = 0x00000400,
 
@@ -163,7 +163,7 @@ namespace PInvoke
             SS_EDITCONTROL = 0x00002000,
 
             /// <summary>
-            /// 	If the end of a string does not fit in the rectangle, it is truncated and ellipses are added. If a word that is not at the end of the string goes beyond the limits of the rectangle, it is truncated without ellipses. Using this style will force the control s text to be on one line with no word wrap. Compare with SS_PATHELLIPSIS and SS_WORDELLIPSIS.
+            /// If the end of a string does not fit in the rectangle, it is truncated and ellipses are added. If a word that is not at the end of the string goes beyond the limits of the rectangle, it is truncated without ellipses. Using this style will force the control s text to be on one line with no word wrap. Compare with SS_PATHELLIPSIS and SS_WORDELLIPSIS.
             /// </summary>
             SS_ENDELLIPSIS = 0x00004000,
 

--- a/src/User32/User32.cs
+++ b/src/User32/User32.cs
@@ -4042,6 +4042,88 @@ namespace PInvoke
             [Friendly(FriendlyFlags.Out)] LASTINPUTINFO* plii);
 
         /// <summary>
+        /// Retrieves a data handle from the property list of the specified window. The character string identifies the handle to be retrieved. The string and handle must have been added to the property list by a previous call to the <see cref="SetProp(IntPtr, string, IntPtr)" /> function.
+        /// </summary>
+        /// <param name="hWnd">A handle to the window whose property list is to be searched.</param>
+        /// <param name="lpString">An atom that identifies a string. If this parameter is an atom, it must have been created by using the GlobalAddAtom function. The atom, a 16-bit value, must be placed in the low-order word of the <paramref name="lpString"/> parameter; the high-order word must be zero.</param>
+        /// <returns>If the property list contains the string, the return value is the associated data handle. Otherwise, the return value is NULL.</returns>
+        [DllImport(nameof(User32), SetLastError = true)]
+        public static extern IntPtr GetProp(IntPtr hWnd, string lpString);
+
+        /// <summary>
+        /// Retrieves a data handle from the property list of the specified window. The character string identifies the handle to be retrieved. The string and handle must have been added to the property list by a previous call to the <see cref="SetProp(IntPtr, string, IntPtr)" /> function.
+        /// </summary>
+        /// <param name="hWnd">A handle to the window whose property list is to be searched.</param>
+        /// <param name="atom">An atom that identifies a string. If this parameter is an atom, it must have been created by using the GlobalAddAtom function.</param>
+        /// <returns>If the property list contains the string, the return value is the associated data handle. Otherwise, the return value is NULL.</returns>
+        [DllImport(nameof(User32), SetLastError = true)]
+        public static extern IntPtr GetProp(IntPtr hWnd, int atom);
+
+        /// <summary>
+        /// Adds a new entry or changes an existing entry in the property list of the specified window. The function adds a new entry to the list if the specified character string does not exist already in the list. The new entry contains the string and the handle. Otherwise, the function replaces the string's current handle with the specified handle.
+        /// </summary>
+        /// <param name="hWnd">A handle to the window whose property list receives the new entry.</param>
+        /// <param name="lpString">A null-terminated string or an atom that identifies a string. If this parameter is an atom, it must be a global atom created by a previous call to the GlobalAddAtom function. The atom must be placed in the low-order word of <paramref name="lpString" />; the high-order word must be zero.</param>
+        /// <param name="hData">A handle to the data to be copied to the property list. The data handle can identify any value useful to the application.</param>
+        /// <returns>
+        /// If the data handle and string are added to the property list, the return value is nonzero.
+        /// If the function fails, the return value is zero. To get extended error information, call <see cref="GetLastError" />.
+        /// </returns>
+        /// <remarks>
+        /// Before a window is destroyed (that is, before it returns from processing the <see cref="WindowMessage.WM_NCDESTROY" /> message), an application must remove all entries it has added to the property list. The application must use the RemoveProp function to remove the entries.
+        /// SetProp is subject to the restrictions of User Interface Privilege Isolation (UIPI). A process can only call this function on a window belonging to a process of lesser or equal integrity level. When UIPI blocks property changes, <see cref="GetLastError" /> will return 5.
+        /// </remarks>
+        [DllImport(nameof(User32), SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool SetProp(IntPtr hWnd, string lpString, IntPtr hData);
+
+        /// <summary>
+        /// Adds a new entry or changes an existing entry in the property list of the specified window. The function adds a new entry to the list if the specified character string does not exist already in the list. The new entry contains the string and the handle. Otherwise, the function replaces the string's current handle with the specified handle.
+        /// </summary>
+        /// <param name="hWnd">A handle to the window whose property list receives the new entry.</param>
+        /// <param name="atom">An atom that identifies a string. It must be a global atom created by a previous call to the GlobalAddAtom function.</param>
+        /// <param name="hData">A handle to the data to be copied to the property list. The data handle can identify any value useful to the application.</param>
+        /// <returns>
+        /// If the data handle and string are added to the property list, the return value is nonzero.
+        /// If the function fails, the return value is zero. To get extended error information, call <see cref="GetLastError" />.
+        /// </returns>
+        /// <remarks>
+        /// Before a window is destroyed (that is, before it returns from processing the <see cref="WindowMessage.WM_NCDESTROY" /> message), an application must remove all entries it has added to the property list. The application must use the RemoveProp function to remove the entries.
+        /// SetProp is subject to the restrictions of User Interface Privilege Isolation (UIPI). A process can only call this function on a window belonging to a process of lesser or equal integrity level. When UIPI blocks property changes, <see cref="GetLastError" /> will return 5.
+        /// </remarks>
+        [DllImport(nameof(User32), SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool SetProp(IntPtr hWnd, int atom, IntPtr hData);
+
+        /// <summary>
+        /// Removes an entry from the property list of the specified window. The specified character string identifies the entry to be removed.
+        /// </summary>
+        /// <param name="hWnd">A handle to the window whose property list is to be changed.</param>
+        /// <param name="lpString">A null-terminated character string or an atom that identifies a string. If this parameter is an atom, it must have been created using the GlobalAddAtom function. The atom, a 16-bit value, must be placed in the low-order word of <paramref name="lpString" />; the high-order word must be zero.</param>
+        /// <returns>The return value identifies the specified data. If the data cannot be found in the specified property list, the return value is NULL.</returns>
+        /// <remarks>
+        /// The return value is the hData value that was passed to <see cref="SetProp(IntPtr, string, IntPtr)" />; it is an application-defined value. Note, this function only destroys the association between the data and the window. If appropriate, the application must free the data handles associated with entries removed from a property list. The application can remove only those properties it has added. It must not remove properties added by other applications or by the system itself.
+        /// The RemoveProp function returns the data handle associated with the string so that the application can free the data associated with the handle.
+        /// Starting with Windows Vista, RemoveProp is subject to the restrictions of User Interface Privilege Isolation (UIPI). A process can only call this function on a window belonging to a process of lesser or equal integrity level. When UIPI blocks property changes, <see cref="GetLastError" /> will return 5.
+        /// </remarks>
+        [DllImport(nameof(User32), SetLastError = true)]
+        public static extern IntPtr RemoveProp(IntPtr hWnd, string lpString);
+
+        /// <summary>
+        /// Removes an entry from the property list of the specified window. The specified character string identifies the entry to be removed.
+        /// </summary>
+        /// <param name="hWnd">A handle to the window whose property list is to be changed.</param>
+        /// <param name="atom">An atom that identifies a string. If this parameter is an atom, it must have been created using the GlobalAddAtom function.</param>
+        /// <returns>The return value identifies the specified data. If the data cannot be found in the specified property list, the return value is NULL.</returns>
+        /// <remarks>
+        /// The return value is the hData value that was passed to <see cref="SetProp(IntPtr, string, IntPtr)" />; it is an application-defined value. Note, this function only destroys the association between the data and the window. If appropriate, the application must free the data handles associated with entries removed from a property list. The application can remove only those properties it has added. It must not remove properties added by other applications or by the system itself.
+        /// The RemoveProp function returns the data handle associated with the string so that the application can free the data associated with the handle.
+        /// Starting with Windows Vista, RemoveProp is subject to the restrictions of User Interface Privilege Isolation (UIPI). A process can only call this function on a window belonging to a process of lesser or equal integrity level. When UIPI blocks property changes, <see cref="GetLastError" /> will return 5.
+        /// </remarks>
+        [DllImport(nameof(User32), SetLastError = true)]
+        public static extern IntPtr RemoveProp(IntPtr hWnd, int atom);
+
+        /// <summary>
         /// The BeginPaint function prepares the specified window for painting and fills a <see cref="PAINTSTRUCT"/> structure with information about the painting.
         /// </summary>
         /// <param name="hwnd">Handle to the window to be repainted.</param>


### PR DESCRIPTION
Adding the following new structs, functions and enums:

CWPSTRUCT: https://docs.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-cwpstruct
CWPRETSTRUCT: https://docs.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-cwpretstruct

Prop functions:
https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setpropa
https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getpropa
https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-removepropa

Control Style enums:
https://docs.microsoft.com/en-us/windows/win32/controls/button-styles
https://docs.microsoft.com/en-us/windows/win32/controls/combo-box-styles
https://docs.microsoft.com/en-us/windows/win32/dlgbox/dialog-box-styles
https://docs.microsoft.com/en-us/windows/win32/controls/edit-control-styles
https://docs.microsoft.com/en-us/windows/win32/controls/list-box-styles
https://docs.microsoft.com/en-us/windows/win32/controls/progress-bar-control-styles
https://docs.microsoft.com/en-us/windows/win32/controls/scroll-bar-control-styles
https://docs.microsoft.com/en-us/windows/win32/controls/static-control-styles

