### PR TITLE
Fix `GetMonitorInfo` signature

### DIFF
--- a/src/User32.Tests/User32Facts.cs
+++ b/src/User32.Tests/User32Facts.cs
@@ -157,4 +157,19 @@ public partial class User32Facts
         Assert.Equal(expectedSize, Marshal.SizeOf(info));
         Assert.Equal(expectedSize, MENUBARINFO.Create().cbSize);
     }
+
+    [Fact]
+    public unsafe void EnumDisplayMonitors_GetMonitorInfo_Test()
+    {
+        Assert.True(EnumDisplayMonitors(IntPtr.Zero, IntPtr.Zero, Callback, IntPtr.Zero));
+
+        bool Callback(IntPtr hMonitor, IntPtr hdcMonitor, RECT* lprcMonitor, void* dwData)
+        {
+            MONITORINFO info = default;
+            info.cbSize = sizeof(MONITORINFO);
+            Assert.True(GetMonitorInfo(hMonitor, ref info));
+            Assert.True(info.rcMonitor.bottom > 0);
+            return true;
+        }
+    }
 }

--- a/src/User32/PublicAPI.Shipped.txt
+++ b/src/User32/PublicAPI.Shipped.txt
@@ -1806,9 +1806,9 @@ static PInvoke.User32.GetDC(System.IntPtr hWnd) -> PInvoke.User32.SafeDCHandle
 static PInvoke.User32.GetDCEx(System.IntPtr hWnd, System.IntPtr hrgnClip, PInvoke.User32.DeviceContextValues flags) -> PInvoke.User32.SafeDCHandle
 static PInvoke.User32.GetMessage(System.IntPtr lpMsg, System.IntPtr hWnd, PInvoke.User32.WindowMessage wMsgFilterMin, PInvoke.User32.WindowMessage wMsgFilterMax) -> int
 static PInvoke.User32.GetMonitorInfo(System.IntPtr hMonitor, System.IntPtr lpmi) -> bool
-static PInvoke.User32.GetMonitorInfo(System.IntPtr hMonitor, out PInvoke.User32.MONITORINFO lpmi) -> bool
+static PInvoke.User32.GetMonitorInfo(System.IntPtr hMonitor, ref PInvoke.User32.MONITORINFO lpmi) -> bool
 static PInvoke.User32.GetMonitorInfoEx(System.IntPtr hMonitor, System.IntPtr lpmi) -> bool
-static PInvoke.User32.GetMonitorInfoEx(System.IntPtr hMonitor, out PInvoke.User32.MONITORINFOEX lpmi) -> bool
+static PInvoke.User32.GetMonitorInfoEx(System.IntPtr hMonitor, ref PInvoke.User32.MONITORINFOEX lpmi) -> bool
 static PInvoke.User32.GetUserObjectInformation(System.IntPtr hObj, PInvoke.User32.ObjectInformationType nIndex, System.IntPtr pvInfo, uint nLength, System.IntPtr lpnLengthNeeded) -> bool
 static PInvoke.User32.GetWindowDC(System.IntPtr hWnd) -> PInvoke.User32.SafeDCHandle
 static PInvoke.User32.GetWindowPlacement(System.IntPtr hWnd) -> PInvoke.User32.WINDOWPLACEMENT

--- a/src/User32/User32.Helpers.cs
+++ b/src/User32/User32.Helpers.cs
@@ -464,7 +464,7 @@ namespace PInvoke
         [NoFriendlyOverloads]
         public static unsafe bool GetMonitorInfo(
             IntPtr hMonitor,
-            [Friendly(FriendlyFlags.Out)] MONITORINFOEX* lpmi)
+            [Friendly(FriendlyFlags.Bidirectional)] MONITORINFOEX* lpmi)
         {
             return GetMonitorInfo(hMonitor, (MONITORINFO*)lpmi);
         }
@@ -475,6 +475,7 @@ namespace PInvoke
             IntPtr hMonitor,
             out MONITORINFOEX lpmi)
         {
+            lpmi = MONITORINFOEX.Create();
             fixed (MONITORINFOEX* lpmiLocal = &lpmi)
             {
                 return GetMonitorInfo(hMonitor, lpmiLocal);

--- a/src/User32/User32.cs
+++ b/src/User32/User32.cs
@@ -1813,11 +1813,11 @@ namespace PInvoke
         [DllImport(nameof(User32))]
         public static extern unsafe bool GetMonitorInfo(
             IntPtr hMonitor,
-            [Friendly(FriendlyFlags.Out)] MONITORINFO* lpmi);
+            [Friendly(FriendlyFlags.Bidirectional)] MONITORINFO* lpmi);
 
         /// <inheritdoc cref="GetMonitorInfo(IntPtr, MONITORINFOEX*)"/>
         [Obsolete("Use " + nameof(GetMonitorInfo) + " instead.")]
-        public static unsafe bool GetMonitorInfoEx(IntPtr hMonitor, [Friendly(FriendlyFlags.Out)] MONITORINFOEX* lpmi) => GetMonitorInfo(hMonitor, lpmi);
+        public static unsafe bool GetMonitorInfoEx(IntPtr hMonitor, [Friendly(FriendlyFlags.Bidirectional)] MONITORINFOEX* lpmi) => GetMonitorInfo(hMonitor, lpmi);
 
         [DllImport(nameof(User32), SetLastError = true)]
         public static extern int GetSystemMetrics(SystemMetric smIndex);


### PR DESCRIPTION
This allows callers of the friendly overloads to initialize the `cbSize` field as required.

Fixes #558
