### PR TITLE
Fix `GetCursorInfo` to use `ref` instead of `out`

### DIFF
--- a/src/User32/PublicAPI.Shipped.txt
+++ b/src/User32/PublicAPI.Shipped.txt
@@ -2181,7 +2181,7 @@ static PInvoke.User32.CreateCursor(System.IntPtr hInst, int xHotspot, int yHotSp
 static PInvoke.User32.CreateWindowEx(PInvoke.User32.WindowStylesEx dwExStyle, short lpClassName, string lpWindowName, PInvoke.User32.WindowStyles dwStyle, int x, int y, int nWidth, int nHeight, System.IntPtr hWndParent, System.IntPtr hMenu, System.IntPtr hInstance, System.IntPtr lpParam) -> System.IntPtr
 static PInvoke.User32.CreateWindowEx(PInvoke.User32.WindowStylesEx dwExStyle, short lpClassName, string lpWindowName, PInvoke.User32.WindowStyles dwStyle, int x, int y, int nWidth, int nHeight, System.IntPtr hWndParent, System.IntPtr hMenu, System.IntPtr hInstance, void* lpParam) -> System.IntPtr
 static PInvoke.User32.GetCursorInfo(System.IntPtr pci) -> bool
-static PInvoke.User32.GetCursorInfo(out PInvoke.User32.CURSORINFO pci) -> bool
+static PInvoke.User32.GetCursorInfo(ref PInvoke.User32.CURSORINFO pci) -> bool
 static PInvoke.User32.GetMenuBarInfo(System.IntPtr hwnd, PInvoke.User32.MenuObject idObject, int idItem, System.IntPtr pmbi) -> bool
 static PInvoke.User32.GetMenuInfo(System.IntPtr hMenu, System.IntPtr lpMenuInfo) -> bool
 static PInvoke.User32.GetMenuItemInfo(System.IntPtr hMenu, uint uItem, bool fByPosition, System.IntPtr lpmii) -> bool

--- a/src/User32/User32.cs
+++ b/src/User32/User32.cs
@@ -1100,7 +1100,7 @@ namespace PInvoke
         [DllImport(nameof(User32))]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern unsafe bool GetCursorInfo(
-            [Friendly(FriendlyFlags.Out)] CURSORINFO* pci);
+            [Friendly(FriendlyFlags.Bidirectional)] CURSORINFO* pci);
 
         /// <summary>
         /// Displays or hides the cursor.


### PR DESCRIPTION
This is required because the input parameter must have its size field initialized by the caller.

As identified by #558