### PR TITLE
fix558

### DIFF
--- a/src/Kernel32/storebanned/Kernel32.cs
+++ b/src/Kernel32/storebanned/Kernel32.cs
@@ -1352,7 +1352,7 @@ namespace PInvoke
         /// Therefore, do not pass a handle returned by this function to the <see cref="FreeLibrary"/> function. Doing so can cause a DLL module to be unmapped prematurely.
         /// </remarks>
         [DllImport(nameof(Kernel32), SetLastError = true, CharSet = CharSet.Unicode)]
-        public static extern SafeLibraryHandle GetModuleHandle(string lpModuleName);
+        public static extern IntPtr GetModuleHandle(string lpModuleName);
 
         /// <summary>
         /// Retrieves a module handle for the specified module and increments the module's reference count unless <see cref="GetModuleHandleExFlags.GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT"/> is specified.


### PR DESCRIPTION
- Fix `GetMonitorInfo` signature
- Fix `GetCursorInfo` to use `ref` instead of `out`
- Fix `GetModuleHandle` so its use doesn't prematurely unload a module
