### PR TITLE
Fix `GetModuleHandle` so its use doesn't prematurely unload a module

### DIFF
--- a/src/Kernel32/PublicAPI.Shipped.txt
+++ b/src/Kernel32/PublicAPI.Shipped.txt
@@ -1320,7 +1320,7 @@ static extern PInvoke.Kernel32.GetDllDirectory(int nBufferLength, char* lpBuffer
 static extern PInvoke.Kernel32.GetExitCodeProcess(System.IntPtr hProcess, out int lpExitCode) -> bool
 static extern PInvoke.Kernel32.GetExitCodeThread(System.IntPtr hThread, out int lpExitCode) -> bool
 static extern PInvoke.Kernel32.GetLargestConsoleWindowSize(System.IntPtr hConsoleOutput) -> PInvoke.COORD
-static extern PInvoke.Kernel32.GetModuleHandle(string lpModuleName) -> PInvoke.Kernel32.SafeLibraryHandle
+static extern PInvoke.Kernel32.GetModuleHandle(string lpModuleName) -> System.IntPtr
 static extern PInvoke.Kernel32.GetModuleHandleEx(PInvoke.Kernel32.GetModuleHandleExFlags dwFlags, string lpModuleName, out PInvoke.Kernel32.SafeLibraryHandle phModule) -> bool
 static extern PInvoke.Kernel32.GetNamedPipeClientComputerName(PInvoke.Kernel32.SafeObjectHandle Pipe, System.Text.StringBuilder ClientComputerName, int ClientComputerNameLength) -> bool
 static extern PInvoke.Kernel32.GetNamedPipeClientComputerName(PInvoke.Kernel32.SafeObjectHandle Pipe, char* ClientComputerName, int ClientComputerNameLength) -> bool

--- a/src/Kernel32/storebanned/Kernel32.cs
+++ b/src/Kernel32/storebanned/Kernel32.cs
@@ -1352,7 +1352,7 @@ namespace PInvoke
         /// Therefore, do not pass a handle returned by this function to the <see cref="FreeLibrary"/> function. Doing so can cause a DLL module to be unmapped prematurely.
         /// </remarks>
         [DllImport(nameof(Kernel32), SetLastError = true, CharSet = CharSet.Unicode)]
-        public static extern SafeLibraryHandle GetModuleHandle(string lpModuleName);
+        public static extern IntPtr GetModuleHandle(string lpModuleName);
 
         /// <summary>
         /// Retrieves a module handle for the specified module and increments the module's reference count unless <see cref="GetModuleHandleExFlags.GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT"/> is specified.


### PR DESCRIPTION
Fixes #563