### PR TITLE
WinUsb_WritePipeAsync: Use ReadOnlyMemory<byte> instead of Memory<byte>

### DIFF
--- a/src/WinUsb/PublicAPI.Unshipped.txt
+++ b/src/WinUsb/PublicAPI.Unshipped.txt
@@ -23,7 +23,7 @@ static PInvoke.WinUsb.WinUsb_ReadPipeAsync(PInvoke.WinUsb.SafeUsbHandle interfac
 static PInvoke.WinUsb.WinUsb_WritePipe(PInvoke.WinUsb.SafeUsbHandle interfaceHandle, byte pipeID, System.IntPtr buffer, int bufferLength, out int lengthTransferred, System.IntPtr overlapped) -> bool
 static PInvoke.WinUsb.WinUsb_WritePipe(PInvoke.WinUsb.SafeUsbHandle interfaceHandle, byte pipeID, System.ReadOnlySpan<byte> buffer, int bufferLength, out int lengthTransferred, System.Threading.NativeOverlapped? overlapped) -> bool
 static PInvoke.WinUsb.WinUsb_WritePipe(PInvoke.WinUsb.SafeUsbHandle interfaceHandle, byte pipeID, byte[] buffer, int bufferLength, out int lengthTransferred, System.Threading.NativeOverlapped? overlapped) -> bool
-static PInvoke.WinUsb.WinUsb_WritePipeAsync(PInvoke.WinUsb.SafeUsbHandle interfaceHandle, byte pipeID, System.Memory<byte> buffer, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<int>
+static PInvoke.WinUsb.WinUsb_WritePipeAsync(PInvoke.WinUsb.SafeUsbHandle interfaceHandle, byte pipeID, System.ReadOnlyMemory<byte> buffer, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<int>
 static extern PInvoke.WinUsb.WinUsb_AbortPipe(PInvoke.WinUsb.SafeUsbHandle handle, byte pipeID) -> bool
 static extern PInvoke.WinUsb.WinUsb_Initialize(PInvoke.Kernel32.SafeObjectHandle deviceHandle, out PInvoke.WinUsb.SafeUsbHandle interfaceHandle) -> bool
 static extern PInvoke.WinUsb.WinUsb_QueryPipe(PInvoke.WinUsb.SafeUsbHandle interfaceHandle, byte alternateInterfaceNumber, byte pipeIndex, PInvoke.WinUsb.WINUSB_PIPE_INFORMATION* pipeInformation) -> bool

--- a/src/WinUsb/WinUsb+WinUsbOverlapped.cs
+++ b/src/WinUsb/WinUsb+WinUsbOverlapped.cs
@@ -19,7 +19,6 @@ namespace PInvoke
         /// </summary>
         private class WinUsbOverlapped : Overlapped
         {
-            private readonly Memory<byte> buffer;
             private readonly SafeUsbHandle handle;
             private readonly byte pipeID;
             private readonly CancellationToken cancellationToken;
@@ -41,18 +40,18 @@ namespace PInvoke
             /// <param name="pipeID">
             /// The ID of the pipe on which the I/O is being performed.
             /// </param>
-            /// <param name="buffer">
-            /// The buffer which is used by the I/O operation. This buffer will be pinned for the duration of
+            /// <param name="bufferHandle">
+            /// A handle to the buffer which is used by the I/O operation. This buffer will be pinned for the duration of
             /// the operation.
             /// </param>
             /// <param name="cancellationToken">
             /// A <see cref="CancellationToken"/> which can be used to cancel the overlapped I/O.
             /// </param>
-            public WinUsbOverlapped(SafeUsbHandle handle, byte pipeID, Memory<byte> buffer, CancellationToken cancellationToken)
+            public WinUsbOverlapped(SafeUsbHandle handle, byte pipeID, MemoryHandle bufferHandle, CancellationToken cancellationToken)
             {
                 this.handle = handle ?? throw new ArgumentNullException(nameof(handle));
                 this.pipeID = pipeID;
-                this.buffer = buffer;
+                this.BufferHandle = bufferHandle;
                 this.cancellationToken = cancellationToken;
             }
 
@@ -84,8 +83,6 @@ namespace PInvoke
             /// </returns>
             internal unsafe NativeOverlapped* Pack()
             {
-                this.BufferHandle = this.buffer.Pin();
-
                 this.native = this.Pack(
                     this.DeviceIOControlCompletionCallback,
                     null);

--- a/src/WinUsb/WinUsb.Helpers.cs
+++ b/src/WinUsb/WinUsb.Helpers.cs
@@ -34,7 +34,7 @@ namespace PInvoke
         /// </returns>
         public static unsafe ValueTask<int> WinUsb_ReadPipeAsync(SafeUsbHandle interfaceHandle, byte pipeID, Memory<byte> buffer, CancellationToken cancellationToken)
         {
-            var overlapped = new WinUsbOverlapped(interfaceHandle, pipeID, buffer, cancellationToken);
+            var overlapped = new WinUsbOverlapped(interfaceHandle, pipeID, buffer.Pin(), cancellationToken);
             var nativeOverlapped = overlapped.Pack();
 
             if (WinUsb_ReadPipe(
@@ -87,9 +87,9 @@ namespace PInvoke
         /// <returns>
         /// A <see cref="ValueTask"/> which represents the asynchronous operation, and returns the number of bytes transferred.
         /// </returns>
-        public static unsafe ValueTask<int> WinUsb_WritePipeAsync(SafeUsbHandle interfaceHandle, byte pipeID, Memory<byte> buffer, CancellationToken cancellationToken)
+        public static unsafe ValueTask<int> WinUsb_WritePipeAsync(SafeUsbHandle interfaceHandle, byte pipeID, ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
         {
-            var overlapped = new WinUsbOverlapped(interfaceHandle, pipeID, buffer, cancellationToken);
+            var overlapped = new WinUsbOverlapped(interfaceHandle, pipeID, buffer.Pin(), cancellationToken);
             var nativeOverlapped = overlapped.Pack();
 
             if (WinUsb_WritePipe(


### PR DESCRIPTION
WinUsb_WritePipe sends the data to the USB device, and does not change the contents of the buffer. Changing the API signature makes it implement WriteAsync in a Stream subclass which wraps around the WinUsb API.