### PR TITLE
Make Kernel32::ReadConsoleOutput can read more than one CHAR_INFO.

### DIFF
--- a/src/Kernel32/PublicAPI.Shipped.txt
+++ b/src/Kernel32/PublicAPI.Shipped.txt
@@ -1373,6 +1373,7 @@ static extern PInvoke.Kernel32.QueryFullProcessImageName(PInvoke.Kernel32.SafeOb
 static extern PInvoke.Kernel32.QueryFullProcessImageName(PInvoke.Kernel32.SafeObjectHandle hProcess, PInvoke.Kernel32.QueryFullProcessImageNameFlags dwFlags, char* lpExeName, ref int lpdwSize) -> bool
 static extern PInvoke.Kernel32.ReadConsoleInput(System.IntPtr hConsoleInput, out PInvoke.Kernel32.INPUT_RECORD lpBuffer, int nLength, out int lpNumberOfEventsRead) -> bool
 static extern PInvoke.Kernel32.ReadConsoleOutput(System.IntPtr hConsoleOutput, out PInvoke.Kernel32.CHAR_INFO lpBuffer, PInvoke.COORD dwBufferSize, PInvoke.COORD dwBufferCoord, ref PInvoke.SMALL_RECT lpReadRegion) -> bool
+static extern PInvoke.Kernel32.ReadConsoleOutput(System.IntPtr hConsoleOutput, out System.IntPtr lpBuffer, PInvoke.COORD dwBufferSize, PInvoke.COORD dwBufferCoord, ref PInvoke.SMALL_RECT lpReadRegion) -> bool
 static extern PInvoke.Kernel32.ReadFile(PInvoke.Kernel32.SafeObjectHandle hFile, void* lpBuffer, int nNumberOfBytesToRead, int* lpNumberOfBytesRead, PInvoke.Kernel32.OVERLAPPED* lpOverlapped) -> bool
 static extern PInvoke.Kernel32.ResumeThread(PInvoke.Kernel32.SafeObjectHandle hThread) -> int
 static extern PInvoke.Kernel32.ScrollConsoleScreenBuffer(System.IntPtr hConsoleOutput, PInvoke.SMALL_RECT* lpScrollRectangle, PInvoke.SMALL_RECT* lpClipRectangle, PInvoke.COORD dwDestinationOrigin, PInvoke.Kernel32.CHAR_INFO* lpFill) -> bool

--- a/src/Kernel32/storebanned/Kernel32.cs
+++ b/src/Kernel32/storebanned/Kernel32.cs
@@ -2675,6 +2675,10 @@ namespace PInvoke
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool ReadConsoleOutput(IntPtr hConsoleOutput, out CHAR_INFO lpBuffer, COORD dwBufferSize, COORD dwBufferCoord, ref SMALL_RECT lpReadRegion);
 
+        [DllImport(nameof(Kernel32), CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool ReadConsoleOutput(IntPtr hConsoleOutput, IntPtr lpBuffer, COORD dwBufferSize, COORD dwBufferCoord, ref SMALL_RECT lpReadRegion);
+
         /// <summary>
         /// Reads character input from the console input buffer and removes it from the buffer.
         /// </summary>


### PR DESCRIPTION
Kernel32::ReadConsoleOutput's second parameter[out PInvoke.Kernel32.CHAR_INFO lpBuffer] can only get one PInvoke.Kernel32.CHAR_INFO。So I add a method change second parameter to System.IntPtr.Now we can read more than one CHAR_INFO at a time.

Read Console Output Sample:
```C#
using PInvoke;
using System.Diagnostics;
using System.Runtime.InteropServices;
using System.Text;
using static PInvoke.Kernel32;

short MAX_READ_LINES = 10;
var hOut = GetStdHandle(StdHandle.STD_OUTPUT_HANDLE);
CONSOLE_SCREEN_BUFFER_INFO csbi;
if (!GetConsoleScreenBufferInfo(hOut, out csbi))
{
    Console.WriteLine("GetConsoleScreenBufferInfo Failed!");
    return;
}
IntPtr hBuffer = Marshal.AllocHGlobal(Marshal.SizeOf<CHAR_INFO>() * csbi.dwSize.X * MAX_READ_LINES);
SMALL_RECT smallRect = new SMALL_RECT() { Right = csbi.dwSize.X, Bottom = MAX_READ_LINES };
if (!PInvoke.Kernel32.ReadConsoleOutput(
    hOut, hBuffer,
    new COORD() { X = csbi.dwSize.X, Y = MAX_READ_LINES },
    new COORD() { X = 0, Y = 0 }, ref smallRect))
{
    Console.WriteLine($"ReadConsoleOutput Failed!csbi.dwSize.X:{csbi.dwSize.X},csbi.dwSize.Y:{csbi.dwSize.Y}");
    return;
}
StringBuilder sb = new StringBuilder();
for (var i = 0; i < csbi.dwSize.X * MAX_READ_LINES; i++)
{
    var charInfo = Marshal.PtrToStructure<CHAR_INFO>(hBuffer);
    sb.Append(charInfo.Char.UnicodeChar);
    hBuffer += Marshal.SizeOf<CHAR_INFO>();
}
Console.WriteLine("Console Content：" + sb.ToString());
```