### PR TITLE
Fix ReadConsoleOutput

### DIFF
--- a/src/Kernel32/PublicAPI.Shipped.txt
+++ b/src/Kernel32/PublicAPI.Shipped.txt
@@ -1372,7 +1372,6 @@ static extern PInvoke.Kernel32.Process32Next(PInvoke.Kernel32.SafeObjectHandle h
 static extern PInvoke.Kernel32.QueryFullProcessImageName(PInvoke.Kernel32.SafeObjectHandle hProcess, PInvoke.Kernel32.QueryFullProcessImageNameFlags dwFlags, System.Text.StringBuilder lpExeName, ref int lpdwSize) -> bool
 static extern PInvoke.Kernel32.QueryFullProcessImageName(PInvoke.Kernel32.SafeObjectHandle hProcess, PInvoke.Kernel32.QueryFullProcessImageNameFlags dwFlags, char* lpExeName, ref int lpdwSize) -> bool
 static extern PInvoke.Kernel32.ReadConsoleInput(System.IntPtr hConsoleInput, out PInvoke.Kernel32.INPUT_RECORD lpBuffer, int nLength, out int lpNumberOfEventsRead) -> bool
-static extern PInvoke.Kernel32.ReadConsoleOutput(System.IntPtr hConsoleOutput, out PInvoke.Kernel32.CHAR_INFO lpBuffer, PInvoke.COORD dwBufferSize, PInvoke.COORD dwBufferCoord, ref PInvoke.SMALL_RECT lpReadRegion) -> bool
 static extern PInvoke.Kernel32.ReadFile(PInvoke.Kernel32.SafeObjectHandle hFile, void* lpBuffer, int nNumberOfBytesToRead, int* lpNumberOfBytesRead, PInvoke.Kernel32.OVERLAPPED* lpOverlapped) -> bool
 static extern PInvoke.Kernel32.ResumeThread(PInvoke.Kernel32.SafeObjectHandle hThread) -> int
 static extern PInvoke.Kernel32.ScrollConsoleScreenBuffer(System.IntPtr hConsoleOutput, PInvoke.SMALL_RECT* lpScrollRectangle, PInvoke.SMALL_RECT* lpClipRectangle, PInvoke.COORD dwDestinationOrigin, PInvoke.Kernel32.CHAR_INFO* lpFill) -> bool

--- a/src/Kernel32/PublicAPI.Unshipped.txt
+++ b/src/Kernel32/PublicAPI.Unshipped.txt
@@ -263,6 +263,9 @@ static PInvoke.Kernel32.QueryFullProcessImageName(PInvoke.Kernel32.SafeObjectHan
 static PInvoke.Kernel32.ReadConsole(System.IntPtr hConsoleInput, System.IntPtr lpBuffer, int nNumberOfCharsToRead, out int lpNumberOfCharsRead, System.IntPtr pInputControl) -> bool
 static PInvoke.Kernel32.ReadConsole(System.IntPtr hConsoleInput, System.Span<char> lpBuffer, out int lpNumberOfCharsRead, PInvoke.Kernel32.CONSOLE_READCONSOLE_CONTROL? pInputControl) -> bool
 static PInvoke.Kernel32.ReadConsole(System.IntPtr hConsoleInput, char[] lpBuffer, int nNumberOfCharsToRead, out int lpNumberOfCharsRead, PInvoke.Kernel32.CONSOLE_READCONSOLE_CONTROL? pInputControl) -> bool
+static PInvoke.Kernel32.ReadConsoleOutput(System.IntPtr hConsoleOutput, PInvoke.Kernel32.CHAR_INFO[] lpBuffer, PInvoke.COORD dwBufferSize, PInvoke.COORD dwBufferCoord, ref PInvoke.SMALL_RECT lpReadRegion) -> bool
+static PInvoke.Kernel32.ReadConsoleOutput(System.IntPtr hConsoleOutput, System.IntPtr lpBuffer, PInvoke.COORD dwBufferSize, PInvoke.COORD dwBufferCoord, ref PInvoke.SMALL_RECT lpReadRegion) -> bool
+static PInvoke.Kernel32.ReadConsoleOutput(System.IntPtr hConsoleOutput, System.Span<PInvoke.Kernel32.CHAR_INFO> lpBuffer, PInvoke.COORD dwBufferSize, PInvoke.COORD dwBufferCoord, ref PInvoke.SMALL_RECT lpReadRegion) -> bool
 static PInvoke.Kernel32.ReadFile(PInvoke.Kernel32.SafeObjectHandle hFile, void* lpBuffer, int nNumberOfBytesToRead, int* lpNumberOfBytesRead, System.Threading.NativeOverlapped* lpOverlapped) -> bool
 static PInvoke.Kernel32.ReadProcessMemory(PInvoke.Kernel32.SafeObjectHandle hProcess, System.IntPtr lpBaseAddress, System.IntPtr lpBuffer, System.UIntPtr nSize, out System.UIntPtr lpNumberOfBytesRead) -> bool
 static PInvoke.Kernel32.SetFilePointer(PInvoke.Kernel32.SafeObjectHandle hFile, int lDistanceToMove, System.IntPtr lpDistanceToMoveHigh, System.IO.SeekOrigin dwMoveMethod) -> int
@@ -288,6 +291,7 @@ static extern PInvoke.Kernel32.GetProcessIdOfThread(PInvoke.Kernel32.SafeObjectH
 static extern PInvoke.Kernel32.GetProcessInformation(PInvoke.Kernel32.SafeObjectHandle hProcess, PInvoke.Kernel32.PROCESS_INFORMATION_CLASS ProcessInformationClass, void* ProcessInformation, uint ProcessInformationSize) -> bool
 static extern PInvoke.Kernel32.GetVolumeInformation(string lpRootPathName, char* lpVolumeNameBuffer, int nVolumeNameSize, out uint lpVolumeSerialNumber, out int lpMaximumComponentLength, out PInvoke.Kernel32.FileSystemFlags lpFileSystemFlags, char* lpFileSystemNameBuffer, int nFileSystemNameSize) -> bool
 static extern PInvoke.Kernel32.ReadConsole(System.IntPtr hConsoleInput, char* lpBuffer, int nNumberOfCharsToRead, out int lpNumberOfCharsRead, PInvoke.Kernel32.CONSOLE_READCONSOLE_CONTROL* pInputControl) -> bool
+static extern PInvoke.Kernel32.ReadConsoleOutput(System.IntPtr hConsoleOutput, PInvoke.Kernel32.CHAR_INFO* lpBuffer, PInvoke.COORD dwBufferSize, PInvoke.COORD dwBufferCoord, ref PInvoke.SMALL_RECT lpReadRegion) -> bool
 static extern PInvoke.Kernel32.ReadProcessMemory(PInvoke.Kernel32.SafeObjectHandle hProcess, void* lpBaseAddress, void* lpBuffer, System.UIntPtr nSize, out System.UIntPtr lpNumberOfBytesRead) -> bool
 static extern PInvoke.Kernel32.ResizePseudoConsole(PInvoke.Kernel32.SafePseudoConsoleHandle hPC, PInvoke.COORD size) -> PInvoke.HResult
 static extern PInvoke.Kernel32.SetFilePointer(PInvoke.Kernel32.SafeObjectHandle hFile, int lDistanceToMove, int* lpDistanceToMoveHigh, System.IO.SeekOrigin dwMoveMethod) -> int

--- a/src/Kernel32/storebanned/Kernel32.cs
+++ b/src/Kernel32/storebanned/Kernel32.cs
@@ -2673,7 +2673,12 @@ namespace PInvoke
 
         [DllImport(nameof(Kernel32), CharSet = CharSet.Unicode, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool ReadConsoleOutput(IntPtr hConsoleOutput, out CHAR_INFO lpBuffer, COORD dwBufferSize, COORD dwBufferCoord, ref SMALL_RECT lpReadRegion);
+        public static extern unsafe bool ReadConsoleOutput(
+            IntPtr hConsoleOutput,
+            [Friendly(FriendlyFlags.Out | FriendlyFlags.Array)] CHAR_INFO* lpBuffer,
+            COORD dwBufferSize,
+            COORD dwBufferCoord,
+            ref SMALL_RECT lpReadRegion);
 
         /// <summary>
         /// Reads character input from the console input buffer and removes it from the buffer.


### PR DESCRIPTION
This supersedes #589 by using `[FriendlyFlags]` in the existing signature to correct the problem.