### PR TITLE
Refactor usage of NTSTATUS.SeverityShift

### DIFF
--- a/src/Windows.Core.Tests/HResultFacts.cs
+++ b/src/Windows.Core.Tests/HResultFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © .NET Foundation and Contributors. All rights reserved.
+// Copyright © .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -157,7 +157,7 @@ public class HResultFacts
     [Fact]
     public void Severity()
     {
-        Assert.Equal((HResult.SeverityCode)0x80000000u, new HResult(0xffffffff).Severity);
+        Assert.Equal((HResult.SeverityCode)0x1u, new HResult(0xffffffff).Severity);
     }
 
     [Fact]

--- a/src/Windows.Core.Tests/NTStatusFacts.cs
+++ b/src/Windows.Core.Tests/NTStatusFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © .NET Foundation and Contributors. All rights reserved.
+// Copyright © .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -139,7 +139,7 @@ public class NTStatusFacts
     [Fact]
     public void Severity()
     {
-        Assert.Equal((NTSTATUS.SeverityCode)0xc0000000, new NTSTATUS(0xffffffff).Severity);
+        Assert.Equal((NTSTATUS.SeverityCode)0xc, new NTSTATUS(0xffffffff).Severity);
     }
 
     [Fact]

--- a/src/Windows.Core.Tests/NTStatusFacts.cs
+++ b/src/Windows.Core.Tests/NTStatusFacts.cs
@@ -139,7 +139,7 @@ public class NTStatusFacts
     [Fact]
     public void Severity()
     {
-        Assert.Equal((NTSTATUS.SeverityCode)0xc, new NTSTATUS(0xffffffff).Severity);
+        Assert.Equal((NTSTATUS.SeverityCode)0x3, new NTSTATUS(0xffffffff).Severity);
     }
 
     [Fact]

--- a/src/Windows.Core/HResult+SeverityCode.cs
+++ b/src/Windows.Core/HResult+SeverityCode.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © .NET Foundation and Contributors. All rights reserved.
+// Copyright © .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace PInvoke
@@ -14,7 +14,7 @@ namespace PInvoke
         public enum SeverityCode : uint
         {
             Success = 0,
-            Fail = 0x80000000,
+            Fail = 1,
         }
     }
 }

--- a/src/Windows.Core/HResult.cs
+++ b/src/Windows.Core/HResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © .NET Foundation and Contributors. All rights reserved.
+// Copyright © .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace PInvoke
@@ -143,7 +143,7 @@ namespace PInvoke
         /// <summary>
         /// Gets the severity of the HRESULT.
         /// </summary>
-        public SeverityCode Severity => (SeverityCode)(this.AsUInt32 & SeverityMask);
+        public SeverityCode Severity => (SeverityCode)((this.AsUInt32 & SeverityMask) >> SeverityShift);
 
         /// <summary>
         /// Gets the facility's status code bits from the HRESULT.

--- a/src/Windows.Core/NTStatus+SeverityCode.cs
+++ b/src/Windows.Core/NTStatus+SeverityCode.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © .NET Foundation and Contributors. All rights reserved.
+// Copyright © .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace PInvoke
@@ -13,10 +13,10 @@ namespace PInvoke
         /// </summary>
         public enum SeverityCode : uint
         {
-            STATUS_SEVERITY_SUCCESS = 0x0 << SeverityShift,
-            STATUS_SEVERITY_INFORMATIONAL = 0x1 << SeverityShift,
-            STATUS_SEVERITY_WARNING = 0x2u << SeverityShift,
-            STATUS_SEVERITY_ERROR = 0x3u << SeverityShift,
+            STATUS_SEVERITY_SUCCESS = 0x0,
+            STATUS_SEVERITY_INFORMATIONAL = 0x1u,
+            STATUS_SEVERITY_WARNING = 0x2u,
+            STATUS_SEVERITY_ERROR = 0x3u,
         }
     }
 }

--- a/src/Windows.Core/NTStatus.cs
+++ b/src/Windows.Core/NTStatus.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © .NET Foundation and Contributors. All rights reserved.
+// Copyright © .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace PInvoke
@@ -130,7 +130,7 @@ namespace PInvoke
         /// <summary>
         /// Gets the severity code of this value.
         /// </summary>
-        public SeverityCode Severity => (SeverityCode)(this.AsUInt32 & SeverityMask);
+        public SeverityCode Severity => (SeverityCode)((this.AsUInt32 & SeverityMask) >> SeverityShift);
 
         /// <summary>
         /// Gets the customer code portion of this value.

--- a/src/Windows.Core/PublicAPI.Shipped.txt
+++ b/src/Windows.Core/PublicAPI.Shipped.txt
@@ -2731,10 +2731,10 @@ PInvoke.NTSTATUS.NTSTATUS(int status) -> void
 PInvoke.NTSTATUS.NTSTATUS(uint status) -> void
 PInvoke.NTSTATUS.Severity.get -> PInvoke.NTSTATUS.SeverityCode
 PInvoke.NTSTATUS.SeverityCode
-PInvoke.NTSTATUS.SeverityCode.STATUS_SEVERITY_ERROR = 3221225472 -> PInvoke.NTSTATUS.SeverityCode
-PInvoke.NTSTATUS.SeverityCode.STATUS_SEVERITY_INFORMATIONAL = 1073741824 -> PInvoke.NTSTATUS.SeverityCode
+PInvoke.NTSTATUS.SeverityCode.STATUS_SEVERITY_ERROR = 3 -> PInvoke.NTSTATUS.SeverityCode
+PInvoke.NTSTATUS.SeverityCode.STATUS_SEVERITY_INFORMATIONAL = 1 -> PInvoke.NTSTATUS.SeverityCode
 PInvoke.NTSTATUS.SeverityCode.STATUS_SEVERITY_SUCCESS = 0 -> PInvoke.NTSTATUS.SeverityCode
-PInvoke.NTSTATUS.SeverityCode.STATUS_SEVERITY_WARNING = 2147483648 -> PInvoke.NTSTATUS.SeverityCode
+PInvoke.NTSTATUS.SeverityCode.STATUS_SEVERITY_WARNING = 2 -> PInvoke.NTSTATUS.SeverityCode
 PInvoke.NTSTATUS.ToString(string format, System.IFormatProvider formatProvider) -> string
 PInvoke.NTSTATUS.Value.get -> PInvoke.NTSTATUS.Code
 PInvoke.PInvokeExtensions

--- a/src/Windows.Core/PublicAPI.Shipped.txt
+++ b/src/Windows.Core/PublicAPI.Shipped.txt
@@ -162,7 +162,7 @@ PInvoke.HResult.HResult(int value) -> void
 PInvoke.HResult.HResult(uint value) -> void
 PInvoke.HResult.Severity.get -> PInvoke.HResult.SeverityCode
 PInvoke.HResult.SeverityCode
-PInvoke.HResult.SeverityCode.Fail = 2147483648 -> PInvoke.HResult.SeverityCode
+PInvoke.HResult.SeverityCode.Fail = 1 -> PInvoke.HResult.SeverityCode
 PInvoke.HResult.SeverityCode.Success = 0 -> PInvoke.HResult.SeverityCode
 PInvoke.HResult.Succeeded.get -> bool
 PInvoke.HResult.ThrowOnFailure() -> void


### PR DESCRIPTION
Closes dotnet/pinvoke#600

* refactor bit shift of enum NTSTATUS.SeverityCode to property NTSTATUS.Severity
* refactor NTStatusFacts.Severity() to acknowledge new bit equation.

BREAKING CHANGE
* All values of enum NTSTATUS.SeverityCode have changed!